### PR TITLE
Fix player movement velocity property

### DIFF
--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -142,7 +142,7 @@ namespace Player
 
         void FixedUpdate()
         {
-            rb.linearVelocity = moveDir * moveSpeed;
+            rb.velocity = moveDir * moveSpeed;
         }
     }
 }


### PR DESCRIPTION
## Summary
- use `Rigidbody2D.velocity` instead of `linearVelocity` to apply movement

## Testing
- `dotnet test` (command not found)

------
https://chatgpt.com/codex/tasks/task_e_689e526ea754832eb02eefb55eab9cdb