### PR TITLE
Ensure inventory toggle and door scene spawn persistence

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.InputSystem;
 
 namespace Inventory
 {
@@ -33,6 +34,8 @@ namespace Inventory
         private void CreateUI()
         {
             uiRoot = new GameObject("InventoryUI", typeof(Canvas), typeof(CanvasScaler), typeof(GraphicRaycaster));
+            uiRoot.transform.SetParent(transform);
+
             var canvas = uiRoot.GetComponent<Canvas>();
             canvas.renderMode = RenderMode.ScreenSpaceOverlay;
 
@@ -102,10 +105,15 @@ namespace Inventory
 
         void Update()
         {
-            if (uiRoot != null && Input.GetKeyDown(KeyCode.I))
-            {
+            if (uiRoot == null)
+                return;
+
+            bool toggle = Input.GetKeyDown(KeyCode.I);
+            if (Keyboard.current != null && Keyboard.current.iKey.wasPressedThisFrame)
+                toggle = true;
+
+            if (toggle)
                 uiRoot.SetActive(!uiRoot.activeSelf);
-            }
         }
     }
 }

--- a/Assets/Scripts/World/Door.cs
+++ b/Assets/Scripts/World/Door.cs
@@ -17,6 +17,12 @@ namespace World
         [Tooltip("Optional item ID required to use this door.  Leave empty for no requirement.")]
         public string requiredItemId;
 
+        [Tooltip("Name of the spawn point in the target scene where the player should appear.")]
+        public string spawnPointName;
+
+        private static string nextSpawnPoint;
+        private static Transform playerToMove;
+
         private void OnMouseDown()
         {
             GameObject player = GameObject.FindGameObjectWithTag("Player");
@@ -34,8 +40,35 @@ namespace World
 
             if (!string.IsNullOrEmpty(sceneToLoad))
             {
+                nextSpawnPoint = spawnPointName;
+                playerToMove = player.transform;
+                DontDestroyOnLoad(player);
+
+                SceneManager.sceneLoaded += OnSceneLoaded;
                 SceneManager.LoadScene(sceneToLoad);
             }
+        }
+
+        private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+        {
+            if (playerToMove != null && !string.IsNullOrEmpty(nextSpawnPoint))
+            {
+                var points = GameObject.FindObjectsOfType<SpawnPoint>();
+                foreach (var p in points)
+                {
+                    if (p.id == nextSpawnPoint)
+                    {
+                        playerToMove.position = p.transform.position;
+                        break;
+                    }
+                }
+
+                SceneManager.MoveGameObjectToScene(playerToMove.gameObject, scene);
+            }
+
+            SceneManager.sceneLoaded -= OnSceneLoaded;
+            playerToMove = null;
+            nextSpawnPoint = null;
         }
     }
 }

--- a/Assets/Scripts/World/SpawnPoint.cs
+++ b/Assets/Scripts/World/SpawnPoint.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+namespace World
+{
+    /// <summary>
+    /// Simple marker component used to designate spawn locations that doors can
+    /// send the player to when loading a new scene.
+    /// </summary>
+    public class SpawnPoint : MonoBehaviour
+    {
+        [Tooltip("Identifier used by doors to look up this spawn point in the target scene.")]
+        public string id;
+    }
+}


### PR DESCRIPTION
## Summary
- Toggle inventory UI using both old and new input systems and parent it to player for persistence
- Add spawn point support to doors and keep player/inventory across scene loads
- Introduce SpawnPoint component to mark named spawn locations

## Testing
- `mcs Assets/Scripts/World/Door.cs Assets/Scripts/World/SpawnPoint.cs 2>&1 | tail -n 20` *(fails: UnityEngine references missing)*

------
https://chatgpt.com/codex/tasks/task_e_689e6736e5f8832ea69d6a988364f90e