### PR TITLE
Remove duplicate Player objects when switching scenes

### DIFF
--- a/Assets/Scripts/World/Door.cs
+++ b/Assets/Scripts/World/Door.cs
@@ -64,6 +64,15 @@ namespace World
                 }
 
                 SceneManager.MoveGameObjectToScene(playerToMove.gameObject, scene);
+
+                var players = GameObject.FindGameObjectsWithTag("Player");
+                foreach (var p in players)
+                {
+                    if (p != playerToMove.gameObject)
+                    {
+                        Destroy(p);
+                    }
+                }
             }
 
             SceneManager.sceneLoaded -= OnSceneLoaded;


### PR DESCRIPTION
## Summary
- destroy any extra Player-tagged GameObjects after moving player to new scene

## Testing
- `mcs -out:/tmp/test.exe Assets/Scripts/World/Door.cs`


------
https://chatgpt.com/codex/tasks/task_e_689f08820590832eaacb2b4c4d0d0a23