### PR TITLE
Fix player missing after scene transition

### DIFF
--- a/Assets/Scripts/World/Door.cs
+++ b/Assets/Scripts/World/Door.cs
@@ -49,7 +49,7 @@ namespace World
             }
         }
 
-        private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+        private static void OnSceneLoaded(Scene scene, LoadSceneMode mode)
         {
             if (playerToMove != null && !string.IsNullOrEmpty(nextSpawnPoint))
             {


### PR DESCRIPTION
## Summary
- handle scene load with static callback so player persists through door transitions

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689f0a58b7c0832eb0d58b8b26a171ef