### PR TITLE
Retarget camera after scene changes

### DIFF
--- a/Assets/Scripts/Player/CameraFollow2D.cs
+++ b/Assets/Scripts/Player/CameraFollow2D.cs
@@ -27,7 +27,12 @@ namespace Player
 
         void LateUpdate()
         {
-            if (!target) return;
+            if (!target)
+            {
+                var playerObj = GameObject.FindGameObjectWithTag("Player");
+                if (playerObj) target = playerObj.transform;
+                else return;
+            }
 
             // desired position (keep current Z)
             Vector3 desired = new Vector3(


### PR DESCRIPTION
## Summary
- Rework CameraFollow2D to look up Player tagged object when target is missing

## Testing
- `dotnet test` (fails: command not found)

------
https://chatgpt.com/codex/tasks/task_e_689f0d467038832ea5d8da287e0e323a