### PR TITLE
Keep camera and UI across scene loads

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -59,6 +59,7 @@ namespace Inventory
             uiRoot = new GameObject("InventoryUI", typeof(Canvas), typeof(CanvasScaler), typeof(GraphicRaycaster));
             // Put UI at the SCENE ROOT so it never behaves like a world object
             uiRoot.transform.SetParent(null, false);
+            DontDestroyOnLoad(uiRoot);
 
             // Optional: assign UI layer if it exists (no error if it doesn't)
             int uiLayer = LayerMask.NameToLayer("UI");
@@ -175,10 +176,15 @@ namespace Inventory
         private static void EnsureLegacyEventSystem()
         {
             var existing = Object.FindObjectOfType<EventSystem>();
-            if (existing != null) return;
+            if (existing != null)
+            {
+                DontDestroyOnLoad(existing.gameObject);
+                return;
+            }
 
             var go = new GameObject("EventSystem", typeof(EventSystem), typeof(StandaloneInputModule));
             go.transform.SetParent(null, false);
+            DontDestroyOnLoad(go);
         }
     }
 }

--- a/Assets/Scripts/Player/CameraFollow2D.cs
+++ b/Assets/Scripts/Player/CameraFollow2D.cs
@@ -23,7 +23,11 @@ namespace Player
         private Vector3 velocity;
         private Camera cam;
 
-        void Awake() { cam = GetComponent<Camera>(); }
+        void Awake()
+        {
+            cam = GetComponent<Camera>();
+            DontDestroyOnLoad(gameObject);
+        }
 
         void LateUpdate()
         {


### PR DESCRIPTION
## Summary
- Ensure the main camera isn't destroyed when loading new scenes so it follows the player everywhere.
- Persist the inventory UI and event system so they survive scene transitions.

## Testing
- `dotnet test` *(fails: dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f0f8cbfac832e89c2322dfa21fa5e