### PR TITLE
Ensure door clicks work through overlapping objects

### DIFF
--- a/Assets/Scripts/World/Door.cs
+++ b/Assets/Scripts/World/Door.cs
@@ -31,7 +31,24 @@ namespace World
         private static GameObject inventoryUIToMove;
         private static GameObject eventSystemToMove;
 
-        private void OnMouseDown() => StartCoroutine(UseDoor());
+        private void Update()
+        {
+            if (!Input.GetMouseButtonDown(0))
+                return;
+
+            if (EventSystem.current != null && EventSystem.current.IsPointerOverGameObject())
+                return;
+
+            var worldPoint = (Vector2)Camera.main.ScreenToWorldPoint(Input.mousePosition);
+            foreach (var col in Physics2D.OverlapPointAll(worldPoint))
+            {
+                if (col.gameObject == gameObject)
+                {
+                    StartCoroutine(UseDoor());
+                    break;
+                }
+            }
+        }
 
         private IEnumerator UseDoor()
         {


### PR DESCRIPTION
## Summary
- Detect door clicks via manual OverlapPoint check so overlapping colliders no longer block interaction

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689f1b6a0964832e9e1d36784727395a