### PR TITLE
Add optional item consumption and missing item popup to doors

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -160,6 +160,33 @@ namespace Inventory
             return false;
         }
 
+        /// <summary>
+        /// Removes the first occurrence of an item with the given ID.
+        /// Returns true if an item was removed.
+        /// </summary>
+        public bool RemoveItem(string id)
+        {
+            for (int i = 0; i < items.Length; i++)
+            {
+                if (items[i] != null && items[i].id == id)
+                {
+                    items[i] = null;
+
+                    if (slotImages != null && i < slotImages.Length && slotImages[i] != null)
+                    {
+                        slotImages[i].sprite = slotFrameSprite;
+                        slotImages[i].type = (slotFrameSprite != null) ? Image.Type.Sliced : Image.Type.Simple;
+                        slotImages[i].color = emptySlotColor;
+                        slotImages[i].enabled = true;
+                    }
+
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         private void Update()
         {
             // OLD INPUT MANAGER

--- a/Assets/Scripts/World/Door.cs
+++ b/Assets/Scripts/World/Door.cs
@@ -19,6 +19,12 @@ namespace World
         [Tooltip("Optional item ID required to use this door.  Leave empty for no requirement.")]
         public string requiredItemId;
 
+        [Tooltip("If true, the required item will be removed from the player's inventory when used.")]
+        public bool removeItemOnUse;
+
+        [Tooltip("Text to display if the player lacks the required item.")]
+        public string missingItemMessage;
+
         [Tooltip("Name of the spawn point in the target scene where the player should appear.")]
         public string spawnPointName;
 
@@ -63,9 +69,13 @@ namespace World
             {
                 if (inv == null || !inv.HasItem(requiredItemId))
                 {
-                    // Player doesn't have the required item
+                    if (!string.IsNullOrEmpty(missingItemMessage))
+                        PopupText.Show(missingItemMessage, player.transform);
                     yield break;
                 }
+
+                if (removeItemOnUse && inv != null)
+                    inv.RemoveItem(requiredItemId);
             }
 
             if (!string.IsNullOrEmpty(sceneToLoad))

--- a/Assets/Scripts/World/PopupText.cs
+++ b/Assets/Scripts/World/PopupText.cs
@@ -1,0 +1,44 @@
+using TMPro;
+using UnityEngine;
+
+namespace World
+{
+    /// <summary>
+    /// Displays a temporary text popup above a target transform.
+    /// </summary>
+    public class PopupText : MonoBehaviour
+    {
+        private float _life;
+        private Vector3 _offset;
+
+        /// <summary>
+        /// Creates a popup text above the target.
+        /// </summary>
+        public static void Show(string message, Transform target, float duration = 2f)
+        {
+            if (target == null || string.IsNullOrEmpty(message)) return;
+
+            var go = new GameObject("PopupText");
+            go.transform.SetParent(target, false);
+
+            var popup = go.AddComponent<PopupText>();
+            popup._life = duration;
+            popup._offset = new Vector3(0f, 1f, 0f);
+
+            var tmp = go.AddComponent<TextMeshPro>();
+            tmp.text = message;
+            tmp.alignment = TextAlignmentOptions.Center;
+            tmp.fontSize = 2f;
+        }
+
+        private void Update()
+        {
+            if (Camera.main) transform.rotation = Camera.main.transform.rotation;
+            transform.localPosition = _offset;
+
+            _life -= Time.deltaTime;
+            if (_life <= 0f)
+                Destroy(gameObject);
+        }
+    }
+}

--- a/Assets/Scripts/World/PopupText.cs.meta
+++ b/Assets/Scripts/World/PopupText.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ebbaf5fcb4174218a304d8e0a3743c92
+timeCreated: 1735689600


### PR DESCRIPTION
## Summary
- allow doors to optionally consume the required item on use
- display configurable popup text above the player when the required item is missing
- add inventory support for removing items and a PopupText helper

## Testing
- `mcs Assets/Scripts/World/Door.cs` *(fails: `UnityEngine` assemblies not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f2169e1b4832ebe666450ae7b126d