### PR TITLE
feat: persist debug menu across scenes

### DIFF
--- a/Assets/Scripts/Inventory/InventoryDebugMenu.cs
+++ b/Assets/Scripts/Inventory/InventoryDebugMenu.cs
@@ -18,6 +18,8 @@ namespace Inventory
     [DisallowMultipleComponent]
     public class InventoryDebugMenu : MonoBehaviour
     {
+        public static InventoryDebugMenu Instance;
+
         [Tooltip("Inventory to add items to. If not set the component tries to find one in the scene.")]
         public Inventory inventory;
 
@@ -27,6 +29,15 @@ namespace Inventory
 
         private void Awake()
         {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+
             if (inventory == null)
             {
                 inventory = FindObjectOfType<Inventory>();


### PR DESCRIPTION
## Summary
- keep InventoryDebugMenu object across scene loads using DontDestroyOnLoad
- add singleton check to avoid duplicate debug menus

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f49a0729c832e9e59d6992cb2f32d