### PR TITLE
Assign default font for inventory tooltip text

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -135,6 +135,7 @@ namespace Inventory
             var textGO = new GameObject("Text", typeof(Text));
             textGO.transform.SetParent(tooltip.transform, false);
             tooltipText = textGO.GetComponent<Text>();
+            tooltipText.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
             tooltipText.alignment = TextAnchor.MiddleLeft;
             tooltipText.color = Color.white;
 


### PR DESCRIPTION
## Summary
- set tooltip text font to built-in Arial to ensure UI displays descriptions

## Testing
- `unity -version` *(command not found)*
- `dotnet build` *(no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689f502074c8832eb792f87a76b6816d