### PR TITLE
Allow custom font for inventory tooltip

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -32,6 +32,10 @@ namespace Inventory
         [Tooltip("Color/tint for empty slots if no frame sprite, or tint over the frame.")]
         public Color emptySlotColor = new Color(1f, 1f, 1f, 0.25f); // light translucent
 
+        [Header("Tooltip")]
+        [Tooltip("Optional: custom font for tooltip text. Uses Arial if null.")]
+        public Font tooltipFont;
+
         private Image[] slotImages;
         private ItemData[] items;
 
@@ -135,6 +139,9 @@ namespace Inventory
             var textGO = new GameObject("Text", typeof(Text));
             textGO.transform.SetParent(tooltip.transform, false);
             tooltipText = textGO.GetComponent<Text>();
+            tooltipText.font = tooltipFont != null
+                ? tooltipFont
+                : Resources.GetBuiltinResource<Font>("Arial.ttf");
             tooltipText.alignment = TextAnchor.MiddleLeft;
             tooltipText.color = Color.white;
 


### PR DESCRIPTION
## Summary
- expose optional tooltip font field in Inventory
- fall back to built-in Arial if no custom font provided

## Testing
- `unity -version` *(command not found)*
- `dotnet build` *(no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689f502074c8832eb792f87a76b6816d