### PR TITLE
Display item name in inventory tooltip

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -142,8 +142,7 @@ namespace Inventory
             tooltipText.font = tooltipFont != null
                 ? tooltipFont
                 : Resources.GetBuiltinResource<Font>("Arial.ttf");
-            tooltipText.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
-            tooltipText.alignment = TextAnchor.MiddleLeft;
+            tooltipText.alignment = TextAnchor.UpperLeft;
             tooltipText.color = Color.white;
 
             var tooltipRect = tooltip.GetComponent<RectTransform>();
@@ -233,7 +232,8 @@ namespace Inventory
             var item = items[slotIndex];
             if (item == null || tooltip == null || tooltipText == null) return;
 
-            tooltipText.text = item.description;
+            string name = !string.IsNullOrEmpty(item.itemName) ? item.itemName : item.name;
+            tooltipText.text = $"{name}\n{item.description}";
             tooltip.SetActive(true);
             tooltip.transform.position = slotRect.position + new Vector3(slotSize.x, 0f, 0f);
         }

--- a/Assets/Scripts/Inventory/ItemData.cs
+++ b/Assets/Scripts/Inventory/ItemData.cs
@@ -12,6 +12,7 @@ public class ItemData : ScriptableObject
     public string id;
 
     [Header("Display")]
+    public string itemName;
     public Sprite icon;
 
     [Header("Description")]


### PR DESCRIPTION
## Summary
- show an item's name along with its description when hovering over inventory slots
- allow tooltip font to be customized via the Inventory component

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*


------
https://chatgpt.com/codex/tasks/task_e_689f547850dc832eaeb95591e0f12592