### PR TITLE
Show item descriptions in tooltips

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -149,6 +149,8 @@ namespace Inventory
             tooltipText.alignment = TextAnchor.UpperLeft;
             tooltipText.color = Color.white;
             tooltipText.raycastTarget = false;
+            tooltipText.horizontalOverflow = HorizontalWrapMode.Wrap;
+            tooltipText.verticalOverflow = VerticalWrapMode.Overflow;
 
             var tooltipRect = tooltip.GetComponent<RectTransform>();
             tooltipRect.pivot = new Vector2(0f, 1f);


### PR DESCRIPTION
## Summary
- render tooltip descriptions by allowing text overflow instead of truncating after one line

## Testing
- `dotnet test` (fails: Specify a project or solution file)


------
https://chatgpt.com/codex/tasks/task_e_689f58884324832e9511385bce7911b0