### PR TITLE
Fix tooltip layout width control

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -149,9 +149,9 @@ namespace Inventory
 
             var layout = tooltip.GetComponent<VerticalLayoutGroup>();
             layout.childAlignment = TextAnchor.UpperLeft;
-            layout.childControlWidth = true;
+            layout.childControlWidth = false;
             layout.childControlHeight = false;
-            layout.childForceExpandWidth = true;
+            layout.childForceExpandWidth = false;
             layout.childForceExpandHeight = false;
             layout.padding = new RectOffset(4, 4, 4, 4);
             layout.spacing = 2f;


### PR DESCRIPTION
## Summary
- allow tooltip width to depend on content size by disabling child width control/expansion

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689f61c03d34832e91f10a8aa92e9c14