### PR TITLE
Shrink tooltip background to match text height

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -150,7 +150,7 @@ namespace Inventory
             var layout = tooltip.GetComponent<VerticalLayoutGroup>();
             layout.childAlignment = TextAnchor.UpperLeft;
             layout.childControlWidth = false;
-            layout.childControlHeight = false;
+            layout.childControlHeight = true;
             layout.childForceExpandWidth = false;
             layout.childForceExpandHeight = false;
             layout.padding = new RectOffset(4, 4, 4, 4);


### PR DESCRIPTION
## Summary
- Prevent tooltip text elements from using default heights by enabling layout height control

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689f63d65980832e80526393517af547