### PR TITLE
Add drag-and-drop item swapping to inventory UI

### DIFF
--- a/Assets/Scripts/Inventory/InventorySlot.cs
+++ b/Assets/Scripts/Inventory/InventorySlot.cs
@@ -6,7 +6,13 @@ namespace Inventory
     /// <summary>
     /// Handles pointer hover events for an inventory slot to display tooltips.
     /// </summary>
-    public class InventorySlot : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler
+    public class InventorySlot : MonoBehaviour,
+        IPointerEnterHandler,
+        IPointerExitHandler,
+        IBeginDragHandler,
+        IDragHandler,
+        IEndDragHandler,
+        IDropHandler
     {
         [HideInInspector]
         public Inventory inventory;
@@ -21,6 +27,26 @@ namespace Inventory
         public void OnPointerExit(PointerEventData eventData)
         {
             inventory?.HideTooltip();
+        }
+
+        public void OnBeginDrag(PointerEventData eventData)
+        {
+            inventory?.BeginDrag(index);
+        }
+
+        public void OnDrag(PointerEventData eventData)
+        {
+            inventory?.Drag(eventData);
+        }
+
+        public void OnEndDrag(PointerEventData eventData)
+        {
+            inventory?.EndDrag();
+        }
+
+        public void OnDrop(PointerEventData eventData)
+        {
+            inventory?.Drop(index);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add per-slot drag handlers to inventory slots to allow moving items
- introduce drag state and icon management in inventory with swap support between slots

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689f66906f6c832e80d97cba6d79f893