### PR TITLE
fix: ensure inventory grid positions before hiding UI

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -168,6 +168,9 @@ namespace Inventory
                 slotCountTexts[i] = countText;
             }
 
+            // Force a layout rebuild so slots are positioned before the UI is hidden
+            LayoutRebuilder.ForceRebuildLayoutImmediate(rect);
+
             // Tooltip setup
             tooltip = new GameObject("Tooltip", typeof(Image), typeof(VerticalLayoutGroup), typeof(ContentSizeFitter));
             tooltip.transform.SetParent(uiRoot.transform, false);


### PR DESCRIPTION
## Summary
- rebuild inventory grid layout before hiding UI so slots don't overlap

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689f71b0fb60832ebf9419244e500988