### PR TITLE
Fix inventory UI font loading for newer Unity versions

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -73,7 +73,30 @@ namespace Inventory
         {
             // Ensure at least one slot and cache the builtin font once
             size = Mathf.Max(1, size);
-            defaultFont = Resources.GetBuiltinResource<Font>("Arial.ttf");
+
+            // Unity 2022+ renamed the builtin Arial font. Attempt to load the new
+            // name first and fall back for older Unity versions to avoid
+            // runtime exceptions that would prevent the UI from being created.
+            try
+            {
+                defaultFont = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            }
+            catch (System.ArgumentException)
+            {
+                // ignored: will fall back below
+            }
+
+            if (defaultFont == null)
+            {
+                try
+                {
+                    defaultFont = Resources.GetBuiltinResource<Font>("Arial.ttf");
+                }
+                catch (System.ArgumentException)
+                {
+                    defaultFont = null;
+                }
+            }
 
             items = new InventoryEntry[size];
             EnsureLegacyEventSystem();


### PR DESCRIPTION
## Summary
- prevent inventory UI creation from failing by loading LegacyRuntime.ttf with an Arial fallback

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689f781acd04832ea22a6da62dc3b80c