### PR TITLE
Add popup text pooling

### DIFF
--- a/Assets/Scripts/World/PopupText.cs
+++ b/Assets/Scripts/World/PopupText.cs
@@ -18,14 +18,30 @@ namespace World
         {
             if (target == null || string.IsNullOrEmpty(message)) return;
 
-            var go = new GameObject("PopupText");
-            go.transform.SetParent(target, false);
+            PopupText popup;
+            TextMeshPro tmp;
 
-            var popup = go.AddComponent<PopupText>();
+            if (PopupTextPool.Instance != null)
+            {
+                popup = PopupTextPool.Instance.Get();
+                tmp = popup.GetComponent<TextMeshPro>();
+            }
+            else
+            {
+                var goNew = new GameObject("PopupText");
+                popup = goNew.AddComponent<PopupText>();
+                tmp = goNew.AddComponent<TextMeshPro>();
+                tmp.alignment = TextAlignmentOptions.Center;
+                tmp.fontSize = 2f;
+            }
+
+            var go = popup.gameObject;
+            go.transform.SetParent(target, false);
+            go.SetActive(true);
+
             popup._life = duration;
             popup._offset = new Vector3(0f, 1f, 0f);
 
-            var tmp = go.AddComponent<TextMeshPro>();
             tmp.text = message;
             tmp.alignment = TextAlignmentOptions.Center;
             tmp.fontSize = 2f;
@@ -38,7 +54,12 @@ namespace World
 
             _life -= Time.deltaTime;
             if (_life <= 0f)
-                Destroy(gameObject);
+            {
+                if (PopupTextPool.Instance != null)
+                    PopupTextPool.Instance.Return(this);
+                else
+                    Destroy(gameObject);
+            }
         }
     }
 }

--- a/Assets/Scripts/World/PopupTextPool.cs
+++ b/Assets/Scripts/World/PopupTextPool.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+
+namespace World
+{
+    /// <summary>
+    /// Pool for <see cref="PopupText"/> instances to reduce allocations.
+    /// </summary>
+    public class PopupTextPool : MonoBehaviour
+    {
+        public static PopupTextPool Instance { get; private set; }
+
+        [SerializeField]
+        private int _maxPoolSize = 20;
+
+        [SerializeField]
+        private int _warmUpCount = 0;
+
+        private readonly Queue<PopupText> _pool = new Queue<PopupText>();
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            Instance = this;
+
+            for (int i = 0; i < _warmUpCount; i++)
+            {
+                _pool.Enqueue(CreatePopup());
+            }
+        }
+
+        private PopupText CreatePopup()
+        {
+            var go = new GameObject("PopupText");
+            go.transform.SetParent(transform, false);
+            var popup = go.AddComponent<PopupText>();
+            var tmp = go.AddComponent<TextMeshPro>();
+            tmp.alignment = TextAlignmentOptions.Center;
+            tmp.fontSize = 2f;
+            go.SetActive(false);
+            return popup;
+        }
+
+        /// <summary>
+        /// Retrieves a popup from the pool or creates a new one if none are available.
+        /// </summary>
+        public PopupText Get()
+        {
+            return _pool.Count > 0 ? _pool.Dequeue() : CreatePopup();
+        }
+
+        /// <summary>
+        /// Returns a popup to the pool. If the pool is full the popup is destroyed.
+        /// </summary>
+        public void Return(PopupText popup)
+        {
+            if (_pool.Count >= _maxPoolSize)
+            {
+                Destroy(popup.gameObject);
+                return;
+            }
+
+            popup.gameObject.SetActive(false);
+            popup.transform.SetParent(transform, false);
+            _pool.Enqueue(popup);
+        }
+    }
+}

--- a/Assets/Scripts/World/PopupTextPool.cs.meta
+++ b/Assets/Scripts/World/PopupTextPool.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 69397fa71efa81c436f4af39b8e8ab8d
+timeCreated: 1735689600


### PR DESCRIPTION
## Summary
- add `PopupTextPool` singleton to reuse popup text objects with configurable pool size and warm-up amount
- refactor `PopupText.Show` to pull from the pool and to return expired popups

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689f7b798bcc832e90276abc67d0f464