### PR TITLE
Add basic shop system with NPC interaction

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -334,6 +334,71 @@ namespace Inventory
         }
 
         /// <summary>
+        /// Returns the total number of a given item currently in the inventory.
+        /// </summary>
+        public int GetItemCount(ItemData item)
+        {
+            int count = 0;
+            if (item == null) return count;
+            for (int i = 0; i < items.Length; i++)
+            {
+                if (items[i].item == item)
+                    count += items[i].count;
+            }
+            return count;
+        }
+
+        /// <summary>
+        /// Returns true if there is room to add at least one of the given item.
+        /// </summary>
+        public bool CanAddItem(ItemData item)
+        {
+            if (item == null)
+                return false;
+
+            if (item.stackable)
+            {
+                for (int i = 0; i < items.Length; i++)
+                {
+                    if (items[i].item == item && items[i].count < item.maxStack)
+                        return true;
+                }
+            }
+
+            for (int i = 0; i < items.Length; i++)
+            {
+                if (items[i].item == null)
+                    return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Removes up to 'count' of the specified item from the inventory.
+        /// Returns true if the requested amount was removed.
+        /// </summary>
+        public bool RemoveItem(ItemData item, int count)
+        {
+            if (item == null || count <= 0)
+                return false;
+
+            for (int i = 0; i < items.Length && count > 0; i++)
+            {
+                if (items[i].item == item)
+                {
+                    int remove = Mathf.Min(count, items[i].count);
+                    items[i].count -= remove;
+                    count -= remove;
+                    if (items[i].count <= 0)
+                        items[i].item = null;
+                    UpdateSlotVisual(i);
+                }
+            }
+
+            return count <= 0;
+        }
+
+        /// <summary>
         /// Checks whether the inventory contains an item by ID.
         /// </summary>
         public bool HasItem(string id)

--- a/Assets/Scripts/NPC/NPCInteractable.cs
+++ b/Assets/Scripts/NPC/NPCInteractable.cs
@@ -1,0 +1,55 @@
+using UnityEngine;
+using ShopSystem;
+
+namespace NPC
+{
+    /// <summary>
+    /// Allows the player to interact with an NPC via right-click context menu.
+    /// </summary>
+    [RequireComponent(typeof(Collider2D))]
+    public class NPCInteractable : MonoBehaviour
+    {
+        [Tooltip("Optional shop component for this NPC.")]
+        public Shop shop;
+        [Tooltip("Context menu prefab that provides Talk / Open Shop / Examine.")]
+        public RightClickMenu menuPrefab;
+
+        private RightClickMenu menuInstance;
+
+        private void OnMouseOver()
+        {
+            if (Input.GetMouseButtonDown(1))
+            {
+                if (menuInstance == null)
+                {
+                    var canvas = FindObjectOfType<Canvas>();
+                    if (canvas != null)
+                        menuInstance = Instantiate(menuPrefab, canvas.transform);
+                    else
+                        menuInstance = Instantiate(menuPrefab);
+                }
+                menuInstance.Show(this, Input.mousePosition);
+            }
+        }
+
+        public void Talk()
+        {
+            Debug.Log($"{name} has nothing to say yet.");
+        }
+
+        public void OpenShop()
+        {
+            if (shop == null) return;
+            var ui = FindObjectOfType<ShopSystem.ShopUI>();
+            if (ui != null)
+            {
+                ui.Open(shop);
+            }
+        }
+
+        public void Examine()
+        {
+            Debug.Log($"You examine {name}.");
+        }
+    }
+}

--- a/Assets/Scripts/NPC/NPCInteractable.cs.meta
+++ b/Assets/Scripts/NPC/NPCInteractable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 175847b768e444f5ad8badc3cf9eab03
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/NPC/RightClickMenu.cs
+++ b/Assets/Scripts/NPC/RightClickMenu.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace NPC
+{
+    /// <summary>
+    /// Simple right-click context menu used by NPCs.
+    /// </summary>
+    public class RightClickMenu : MonoBehaviour
+    {
+        public Button talkButton;
+        public Button shopButton;
+        public Button examineButton;
+
+        private NPCInteractable current;
+
+        private void Awake()
+        {
+            gameObject.SetActive(false);
+            if (talkButton != null)
+                talkButton.onClick.AddListener(() => { current?.Talk(); Hide(); });
+            if (shopButton != null)
+                shopButton.onClick.AddListener(() => { current?.OpenShop(); Hide(); });
+            if (examineButton != null)
+                examineButton.onClick.AddListener(() => { current?.Examine(); Hide(); });
+        }
+
+        public void Show(NPCInteractable npc, Vector2 position)
+        {
+            current = npc;
+            transform.position = position;
+            gameObject.SetActive(true);
+        }
+
+        public void Hide()
+        {
+            gameObject.SetActive(false);
+            current = null;
+        }
+    }
+}

--- a/Assets/Scripts/NPC/RightClickMenu.cs.meta
+++ b/Assets/Scripts/NPC/RightClickMenu.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 14905cb5a6ab44c795ff41f769ea3326
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Shop.meta
+++ b/Assets/Scripts/Shop.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1d74e805b33441f1913779ba7408a68d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Shop/Shop.cs
+++ b/Assets/Scripts/Shop/Shop.cs
@@ -1,0 +1,66 @@
+using UnityEngine;
+using Inventory;
+
+namespace ShopSystem
+{
+    /// <summary>
+    /// Describes an item the shop sells and its price.
+    /// </summary>
+    [System.Serializable]
+    public struct ShopItem
+    {
+        public ItemData item;
+        public int price;
+    }
+
+    /// <summary>
+    /// Basic shop component that can hold up to 30 items and a currency type.
+    /// </summary>
+    public class Shop : MonoBehaviour
+    {
+        public const int MaxSlots = 30;
+
+        [Header("Currency")]
+        public ItemData currency;
+
+        [Header("Stock")]
+        [Tooltip("Items available for purchase (max 30).")]
+        public ShopItem[] stock = new ShopItem[MaxSlots];
+
+        /// <summary>
+        /// Attempts to buy the item at the given slot index using the provided
+        /// player inventory.  Returns true if the purchase succeeds.
+        /// </summary>
+        public bool Buy(int slotIndex, Inventory.Inventory playerInventory)
+        {
+            if (playerInventory == null)
+                return false;
+            if (slotIndex < 0 || slotIndex >= stock.Length)
+                return false;
+
+            ShopItem entry = stock[slotIndex];
+            if (entry.item == null)
+                return false;
+
+            // Ensure player has enough currency and room for the item.
+            if (playerInventory.GetItemCount(currency) < entry.price)
+                return false;
+            if (!playerInventory.CanAddItem(entry.item))
+                return false;
+
+            if (!playerInventory.RemoveItem(currency, entry.price))
+                return false;
+
+            if (!playerInventory.AddItem(entry.item))
+            {
+                // Should not happen because we checked CanAddItem, but just in case
+                // refund the currency.
+                for (int i = 0; i < entry.price; i++)
+                    playerInventory.AddItem(currency);
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/Assets/Scripts/Shop/Shop.cs.meta
+++ b/Assets/Scripts/Shop/Shop.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ed670e9c99b84d68a669076f05aeb8fc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Shop/ShopSlot.cs
+++ b/Assets/Scripts/Shop/ShopSlot.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace ShopSystem
+{
+    /// <summary>
+    /// Handles click events for a shop slot.  Left click attempts to buy the item.
+    /// </summary>
+    public class ShopSlot : MonoBehaviour, IPointerClickHandler
+    {
+        [HideInInspector] public ShopUI shopUI;
+        [HideInInspector] public int index;
+
+        public void OnPointerClick(PointerEventData eventData)
+        {
+            if (eventData.button == PointerEventData.InputButton.Left)
+            {
+                shopUI?.Buy(index);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Shop/ShopSlot.cs.meta
+++ b/Assets/Scripts/Shop/ShopSlot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a0b246136e954369bf9c9c1b2954e043
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Shop/ShopUI.cs
+++ b/Assets/Scripts/Shop/ShopUI.cs
@@ -1,0 +1,169 @@
+using UnityEngine;
+using UnityEngine.UI;
+using UnityEngine.EventSystems;
+using Inventory;
+
+namespace ShopSystem
+{
+    /// <summary>
+    /// Runtime generated shop UI used to display items for sale.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class ShopUI : MonoBehaviour
+    {
+        [Header("Layout")]
+        public Vector2 slotSize = new Vector2(32, 32);
+        public Vector2 slotSpacing = new Vector2(4, 4);
+        public Vector2 referenceResolution = new Vector2(640, 360);
+        public Sprite slotFrameSprite;
+        public Color emptySlotColor = new Color(1f, 1f, 1f, 0.25f);
+
+        [Header("Price Display")]
+        public Font priceFont;
+        public Color priceColor = Color.white;
+
+        [Header("Inventory")]
+        public Inventory.Inventory playerInventory;
+
+        private GameObject uiRoot;
+        private Image[] slotImages;
+        private Text[] slotPriceTexts;
+        private Shop currentShop;
+
+        private void Awake()
+        {
+            CreateUI();
+            if (uiRoot != null)
+                uiRoot.SetActive(false);
+        }
+
+        /// <summary>
+        /// Opens the UI for the given shop.
+        /// </summary>
+        public void Open(Shop shop)
+        {
+            if (shop == null) return;
+            currentShop = shop;
+            Refresh();
+            uiRoot.SetActive(true);
+        }
+
+        /// <summary>
+        /// Closes the shop UI.
+        /// </summary>
+        public void Close()
+        {
+            uiRoot?.SetActive(false);
+            currentShop = null;
+        }
+
+        /// <summary>
+        /// Attempt to buy item at slot index.
+        /// </summary>
+        public void Buy(int index)
+        {
+            if (currentShop == null || playerInventory == null) return;
+            if (currentShop.Buy(index, playerInventory))
+            {
+                Refresh();
+            }
+        }
+
+        private void CreateUI()
+        {
+            uiRoot = new GameObject("ShopUI", typeof(Canvas), typeof(CanvasScaler), typeof(GraphicRaycaster));
+            uiRoot.transform.SetParent(null, false);
+            DontDestroyOnLoad(uiRoot);
+
+            var canvas = uiRoot.GetComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            canvas.pixelPerfect = true;
+
+            var scaler = uiRoot.GetComponent<CanvasScaler>();
+            scaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+            scaler.referenceResolution = referenceResolution;
+            scaler.matchWidthOrHeight = 0f;
+
+            GameObject panel = new GameObject("Slots", typeof(RectTransform), typeof(GridLayoutGroup));
+            panel.transform.SetParent(uiRoot.transform, false);
+
+            var rect = panel.GetComponent<RectTransform>();
+            rect.anchorMin = new Vector2(0.5f, 0.5f);
+            rect.anchorMax = new Vector2(0.5f, 0.5f);
+            rect.pivot = new Vector2(0.5f, 0.5f);
+            rect.anchoredPosition = Vector2.zero;
+
+            var grid = panel.GetComponent<GridLayoutGroup>();
+            grid.cellSize = slotSize;
+            grid.spacing = slotSpacing;
+            grid.childAlignment = TextAnchor.UpperLeft;
+            grid.startCorner = GridLayoutGroup.Corner.UpperLeft;
+
+            slotImages = new Image[Shop.MaxSlots];
+            slotPriceTexts = new Text[Shop.MaxSlots];
+
+            for (int i = 0; i < Shop.MaxSlots; i++)
+            {
+                GameObject slot = new GameObject($"Slot{i}", typeof(Image));
+                slot.transform.SetParent(panel.transform, false);
+
+                var img = slot.GetComponent<Image>();
+                if (slotFrameSprite != null)
+                {
+                    img.sprite = slotFrameSprite;
+                    img.type = Image.Type.Sliced;
+                    img.color = emptySlotColor;
+                }
+                else
+                {
+                    img.sprite = null;
+                    img.color = emptySlotColor;
+                }
+                img.enabled = true;
+                slotImages[i] = img;
+
+                GameObject priceGO = new GameObject("Price", typeof(Text));
+                priceGO.transform.SetParent(slot.transform, false);
+                var priceText = priceGO.GetComponent<Text>();
+                priceText.font = priceFont != null ? priceFont : Resources.GetBuiltinResource<Font>("Arial.ttf");
+                priceText.alignment = TextAnchor.LowerLeft;
+                priceText.color = priceColor;
+                priceText.raycastTarget = false;
+                var priceRect = priceGO.GetComponent<RectTransform>();
+                priceRect.anchorMin = Vector2.zero;
+                priceRect.anchorMax = Vector2.one;
+                priceRect.offsetMin = Vector2.zero;
+                priceRect.offsetMax = Vector2.zero;
+                slotPriceTexts[i] = priceText;
+
+                var slotComponent = slot.AddComponent<ShopSlot>();
+                slotComponent.shopUI = this;
+                slotComponent.index = i;
+            }
+        }
+
+        private void Refresh()
+        {
+            for (int i = 0; i < slotImages.Length; i++)
+            {
+                var img = slotImages[i];
+                var price = slotPriceTexts[i];
+                if (currentShop != null && i < currentShop.stock.Length)
+                {
+                    var entry = currentShop.stock[i];
+                    if (entry.item != null)
+                    {
+                        img.sprite = entry.item.icon != null ? entry.item.icon : slotFrameSprite;
+                        img.color = Color.white;
+                        img.enabled = true;
+                        price.text = entry.price.ToString();
+                        continue;
+                    }
+                }
+                img.sprite = slotFrameSprite;
+                img.color = emptySlotColor;
+                price.text = string.Empty;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Shop/ShopUI.cs.meta
+++ b/Assets/Scripts/Shop/ShopUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 771a3fc4c6bc41e79214eb125c3c0e44
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Implement a shop component with configurable currency and 30-item stock
- Add runtime shop UI and slot behaviour for purchases
- Expose inventory helpers for counting, removing, and capacity checks
- Introduce NPC interaction scripts with right-click menu (Talk, Open Shop, Examine)

## Testing
- `dotnet build` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689f9b0e05f8832e9c57057d751fe7fe