### PR TITLE
feat: add dark grey shop window

### DIFF
--- a/Assets/Scripts/Shop/ShopUI.cs
+++ b/Assets/Scripts/Shop/ShopUI.cs
@@ -18,6 +18,10 @@ namespace ShopSystem
         public Sprite slotFrameSprite;
         public Color emptySlotColor = new Color(1f, 1f, 1f, 0.25f);
 
+        [Header("Window")]
+        public Color windowColor = new Color(0.15f, 0.15f, 0.15f, 0.95f);
+        public Vector2 windowPadding = new Vector2(8f, 8f);
+
         [Header("Price Display")]
         public Font priceFont;
         public Color priceColor = Color.white;
@@ -84,8 +88,20 @@ namespace ShopSystem
             scaler.referenceResolution = referenceResolution;
             scaler.matchWidthOrHeight = 0f;
 
+            GameObject window = new GameObject("Window", typeof(RectTransform), typeof(Image));
+            window.transform.SetParent(uiRoot.transform, false);
+
+            var windowRect = window.GetComponent<RectTransform>();
+            windowRect.anchorMin = new Vector2(0.5f, 0.5f);
+            windowRect.anchorMax = new Vector2(0.5f, 0.5f);
+            windowRect.pivot = new Vector2(0.5f, 0.5f);
+            windowRect.anchoredPosition = Vector2.zero;
+
+            var windowImg = window.GetComponent<Image>();
+            windowImg.color = windowColor;
+
             GameObject panel = new GameObject("Slots", typeof(RectTransform), typeof(GridLayoutGroup));
-            panel.transform.SetParent(uiRoot.transform, false);
+            panel.transform.SetParent(window.transform, false);
 
             var rect = panel.GetComponent<RectTransform>();
             rect.anchorMin = new Vector2(0.5f, 0.5f);
@@ -98,6 +114,8 @@ namespace ShopSystem
             grid.spacing = slotSpacing;
             grid.childAlignment = TextAnchor.UpperLeft;
             grid.startCorner = GridLayoutGroup.Corner.UpperLeft;
+            grid.constraint = GridLayoutGroup.Constraint.FixedColumns;
+            grid.constraintCount = 6;
 
             slotImages = new Image[Shop.MaxSlots];
             slotPriceTexts = new Text[Shop.MaxSlots];
@@ -140,6 +158,12 @@ namespace ShopSystem
                 slotComponent.shopUI = this;
                 slotComponent.index = i;
             }
+
+            int rows = Mathf.CeilToInt((float)Shop.MaxSlots / grid.constraintCount);
+            float width = grid.constraintCount * slotSize.x + (grid.constraintCount - 1) * slotSpacing.x + windowPadding.x * 2f;
+            float height = rows * slotSize.y + (rows - 1) * slotSpacing.y + windowPadding.y * 2f;
+            windowRect.sizeDelta = new Vector2(width, height);
+            rect.sizeDelta = new Vector2(width - windowPadding.x * 2f, height - windowPadding.y * 2f);
         }
 
         private void Refresh()


### PR DESCRIPTION
## Summary
- style shop items in centered dark grey window reminiscent of OldSchool RuneScape
- constrain slots to six columns and pad window for consistent layout

## Testing
- `dotnet test` *(fails: project or solution file not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fad19ffa0832e90f9fa3bfc4739b2