### PR TITLE
Pause NPC movement when shop is open

### DIFF
--- a/Assets/Scripts/NPC/NPCInteractable.cs
+++ b/Assets/Scripts/NPC/NPCInteractable.cs
@@ -43,7 +43,7 @@ namespace NPC
             var ui = FindObjectOfType<ShopSystem.ShopUI>();
             if (ui != null)
             {
-                ui.Open(shop);
+                ui.Open(shop, GetComponent<NpcRandomMovement>());
             }
         }
 

--- a/Assets/Scripts/Shop/ShopUI.cs
+++ b/Assets/Scripts/Shop/ShopUI.cs
@@ -3,6 +3,7 @@ using UnityEngine.UI;
 using UnityEngine.EventSystems;
 using Inventory;
 using Player;
+using NPC;
 
 namespace ShopSystem
 {
@@ -37,6 +38,7 @@ namespace ShopSystem
         private Text[] slotPriceTexts;
         private Shop currentShop;
         private PlayerMover playerMover;
+        private NpcRandomMovement npcMover;
 
         private void Awake()
         {
@@ -46,9 +48,9 @@ namespace ShopSystem
         }
 
         /// <summary>
-        /// Opens the UI for the given shop.
+        /// Opens the UI for the given shop and optionally pauses an NPC's movement.
         /// </summary>
-        public void Open(Shop shop)
+        public void Open(Shop shop, NpcRandomMovement npcMovement = null)
         {
             if (shop == null) return;
             currentShop = shop;
@@ -58,6 +60,9 @@ namespace ShopSystem
                 playerMover = FindObjectOfType<PlayerMover>();
             if (playerMover != null)
                 playerMover.enabled = false;
+            npcMover = npcMovement;
+            if (npcMover != null)
+                npcMover.enabled = false;
         }
 
         /// <summary>
@@ -69,6 +74,11 @@ namespace ShopSystem
             currentShop = null;
             if (playerMover != null)
                 playerMover.enabled = true;
+            if (npcMover != null)
+            {
+                npcMover.enabled = true;
+                npcMover = null;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- allow ShopUI to disable and re-enable an NPC's `NpcRandomMovement` while a shop window is open
- pass the NPC movement component from `NpcInteractable` when opening the shop

## Testing
- `dotnet build` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689fb4a6a9cc832ea84e300c2408391f