### PR TITLE
Add item quantity tracking and shop restocking

### DIFF
--- a/Assets/Scripts/Shop/ShopUI.cs
+++ b/Assets/Scripts/Shop/ShopUI.cs
@@ -260,12 +260,12 @@ namespace ShopSystem
                 if (currentShop != null && i < currentShop.stock.Length)
                 {
                     var entry = currentShop.stock[i];
-                    if (entry.item != null)
+                    if (entry.item != null && entry.quantity > 0)
                     {
                         img.sprite = entry.item.icon != null ? entry.item.icon : slotFrameSprite;
                         img.color = Color.white;
                         img.enabled = true;
-                        price.text = entry.price.ToString();
+                        price.text = $"{entry.price} ({entry.quantity})";
                         continue;
                     }
                 }


### PR DESCRIPTION
## Summary
- Add quantity field to ShopItem and track stock depletion
- Introduce optional restocking with configurable delay
- Display remaining quantity in Shop UI and hide sold-out slots

## Testing
- `dotnet build` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689fc816dc3c832e9e65630a179dad30