### PR TITLE
Enable selling items back to shops

### DIFF
--- a/Assets/Scripts/Inventory/InventorySlot.cs
+++ b/Assets/Scripts/Inventory/InventorySlot.cs
@@ -52,7 +52,12 @@ namespace Inventory
 
         public void OnPointerClick(PointerEventData eventData)
         {
-            if (eventData.button == PointerEventData.InputButton.Right)
+            if (eventData.button == PointerEventData.InputButton.Left)
+            {
+                if (!eventData.dragging)
+                    inventory?.SellItem(index);
+            }
+            else if (eventData.button == PointerEventData.InputButton.Right)
             {
                 inventory?.DropItem(index);
             }

--- a/Assets/Scripts/Shop/ShopUI.cs
+++ b/Assets/Scripts/Shop/ShopUI.cs
@@ -58,6 +58,8 @@ namespace ShopSystem
             currentShop = shop;
             Refresh();
             uiRoot.SetActive(true);
+            if (playerInventory != null)
+                playerInventory.SetShopContext(shop, this);
             if (playerMover == null)
                 playerMover = FindObjectOfType<PlayerMover>();
             if (playerMover != null)
@@ -76,6 +78,8 @@ namespace ShopSystem
             currentShop = null;
             if (shopNameText != null)
                 shopNameText.text = string.Empty;
+            if (playerInventory != null)
+                playerInventory.SetShopContext(null, null);
             if (playerMover != null)
                 playerMover.enabled = true;
             if (npcMover != null)
@@ -248,7 +252,7 @@ namespace ShopSystem
             tooltipRect.offsetMax = new Vector2(-windowPadding.x, windowPadding.y + tooltipHeight);
         }
 
-        private void Refresh()
+        public void Refresh()
         {
             HideTooltip();
             if (shopNameText != null)


### PR DESCRIPTION
## Summary
- allow shop items to define player sell prices
- add `Shop.Sell` and helper to determine sell price
- wire inventory and shop UI to support selling with tooltips

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_689fcb65ae70832e9d8a3d5c3d39c269