### PR TITLE
Fix stack splitting in inventory and ensure dialog overlays shop UI

### DIFF
--- a/Assets/Scripts/Inventory/InventorySlot.cs
+++ b/Assets/Scripts/Inventory/InventorySlot.cs
@@ -53,23 +53,23 @@ namespace Inventory
         public void OnPointerClick(PointerEventData eventData)
         {
             bool shift = Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);
-            if (eventData.button == PointerEventData.InputButton.Left)
-            {
-                if (!eventData.dragging)
-                {
-                    if (shift)
-                        inventory?.PromptStackSplit(index, true);
-                    else
-                        inventory?.SellItem(index, 1);
-                }
-            }
-            else if (eventData.button == PointerEventData.InputButton.Right)
-            {
-                if (shift)
-                    inventory?.PromptStackSplit(index, false);
-                else
-                    inventory?.DropItem(index, 1);
-            }
+              if (eventData.button == PointerEventData.InputButton.Left)
+              {
+                  if (!eventData.dragging)
+                  {
+                      if (shift)
+                          inventory?.PromptStackSplit(index, StackSplitType.Sell);
+                      else
+                          inventory?.SellItem(index, 1);
+                  }
+              }
+              else if (eventData.button == PointerEventData.InputButton.Right)
+              {
+                  if (shift)
+                      inventory?.PromptStackSplit(index, StackSplitType.Drop);
+                  else
+                      inventory?.DropItem(index, 1);
+              }
         }
     }
 }

--- a/Assets/Scripts/Inventory/StackSplitDialog.cs
+++ b/Assets/Scripts/Inventory/StackSplitDialog.cs
@@ -26,8 +26,19 @@ namespace Inventory
             if (instance != null)
                 Destroy(instance.gameObject);
 
-            var go = new GameObject("StackSplitDialog", typeof(Image), typeof(StackSplitDialog));
+            var go = new GameObject(
+                "StackSplitDialog",
+                typeof(Image),
+                typeof(Canvas),
+                typeof(GraphicRaycaster),
+                typeof(StackSplitDialog));
             go.transform.SetParent(parent, false);
+            go.transform.SetAsLastSibling();
+
+            var canvas = go.GetComponent<Canvas>();
+            canvas.overrideSorting = true;
+            canvas.sortingOrder = 1000;
+
             instance = go.GetComponent<StackSplitDialog>();
             instance.onConfirm = onConfirm;
             instance.maxAmount = Mathf.Max(1, max);


### PR DESCRIPTION
## Summary
- Add `StackSplitType` enum and support splitting stacks within inventory
- Route stack split actions through new `SplitStack` method and update slot click handling
- Create stack split dialog with its own high-sorting Canvas so it draws above shop UI

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689fd887b55c832ea22bb5dda22b4abd