### PR TITLE
Display quantity only in shop slots

### DIFF
--- a/Assets/Scripts/Shop/ShopUI.cs
+++ b/Assets/Scripts/Shop/ShopUI.cs
@@ -269,7 +269,8 @@ namespace ShopSystem
                         img.sprite = entry.item.icon != null ? entry.item.icon : slotFrameSprite;
                         img.color = Color.white;
                         img.enabled = true;
-                        price.text = $"{entry.price} ({entry.quantity})";
+                        // Display only the quantity in the slot, not the price
+                        price.text = $"({entry.quantity})";
                         continue;
                     }
                 }


### PR DESCRIPTION
## Summary
- show only the available quantity in each shop slot, removing price display

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a04d8a5da4832eb7da5a70b9135e05