### PR TITLE
Prevent dropping items while shop UI is open

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -6,6 +6,7 @@ using UnityEngine.EventSystems;
 using UnityEngine.InputSystem;
 #endif
 using ShopSystem;
+using Player;
 
 namespace Inventory
 {
@@ -74,6 +75,8 @@ namespace Inventory
         private Shop currentShop;
         private ShopUI currentShopUI;
 
+        private PlayerMover playerMover;
+
         // UI
         private GameObject uiRoot; // Canvas root
 
@@ -83,6 +86,8 @@ namespace Inventory
 
         // Cached default font to avoid repeated builtin lookups that may throw
         private Font defaultFont;
+
+        private bool CanDropItems => playerMover == null || playerMover.CanDrop;
 
         private void Awake()
         {
@@ -116,6 +121,8 @@ namespace Inventory
             items = new InventoryEntry[size];
             EnsureLegacyEventSystem();
             CreateUI();
+
+            playerMover = GetComponent<PlayerMover>();
 
             // Start completely hidden (inactive object so it’s clear in Hierarchy)
             if (uiRoot != null)
@@ -472,6 +479,7 @@ namespace Inventory
         /// </summary>
         public void DropItem(int slotIndex, int quantity = 1)
         {
+            if (!CanDropItems) return;
             if (slotIndex < 0 || slotIndex >= items.Length) return;
             var entry = items[slotIndex];
             if (entry.item == null) return;
@@ -528,6 +536,7 @@ namespace Inventory
             if (slotIndex < 0 || slotIndex >= items.Length) return;
             var entry = items[slotIndex];
             if (entry.item == null || entry.count <= 1) return;
+            if (type == StackSplitType.Drop && !CanDropItems) return;
 
             StackSplitDialog.Show(uiRoot.transform, entry.count, amount =>
             {

--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -15,6 +15,9 @@ namespace Player
         [Tooltip("Deadzone used when reading analog sticks to snap to -1/0/1.")]
         public float gamepadDeadzone = 0.3f;
 
+        [HideInInspector]
+        public bool CanDrop = true;
+
         [Header("(Optional) Direct Sprite Override")]
         [Tooltip("If assigned, these sprites will be applied directly each frame based on Dir/IsMoving. Leave null to rely on Animator clips.")]
         public Sprite idleDown, idleLeft, idleRight, idleUp;

--- a/Assets/Scripts/Shop/ShopUI.cs
+++ b/Assets/Scripts/Shop/ShopUI.cs
@@ -63,7 +63,10 @@ namespace ShopSystem
             if (playerMover == null)
                 playerMover = FindObjectOfType<PlayerMover>();
             if (playerMover != null)
+            {
                 playerMover.enabled = false;
+                playerMover.CanDrop = false;
+            }
             npcMover = npcMovement;
             if (npcMover != null)
                 npcMover.enabled = false;
@@ -81,7 +84,10 @@ namespace ShopSystem
             if (playerInventory != null)
                 playerInventory.SetShopContext(null, null);
             if (playerMover != null)
+            {
                 playerMover.enabled = true;
+                playerMover.CanDrop = true;
+            }
             if (npcMover != null)
             {
                 npcMover.enabled = true;


### PR DESCRIPTION
## Summary
- add `CanDrop` flag to `PlayerMover`
- toggle `CanDrop` in `ShopUI` when opening and closing
- guard inventory drop actions using the `CanDrop` flag

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a04f7d5898832ea4da7626217cf668