### PR TITLE
Fix ambiguous Object reference in Inventory

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -727,7 +727,7 @@ namespace Inventory
         /// </summary>
         private static void EnsureLegacyEventSystem()
         {
-            var existing = Object.FindObjectOfType<EventSystem>();
+            var existing = UnityEngine.Object.FindObjectOfType<EventSystem>();
             if (existing != null)
             {
                 DontDestroyOnLoad(existing.gameObject);


### PR DESCRIPTION
## Summary
- Qualify Object usage to UnityEngine.Object to resolve ambiguous reference error

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a054848c90832ebbee1128b6d97205