### PR TITLE
Allow per-item control over inventory stack splitting

### DIFF
--- a/Assets/Item/Gold Coins.asset
+++ b/Assets/Item/Gold Coins.asset
@@ -22,3 +22,4 @@ MonoBehaviour:
     gods'
   stackable: 1
   maxStack: 2147483647
+  splittable: 0

--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -511,7 +511,7 @@ namespace Inventory
         {
             if (slotIndex < 0 || slotIndex >= items.Length) return;
             var entry = items[slotIndex];
-            if (entry.item == null) return;
+            if (entry.item == null || !entry.item.splittable) return;
 
             int amount = Mathf.Clamp(quantity, 1, entry.count - 1);
             if (amount <= 0) return;
@@ -547,6 +547,7 @@ namespace Inventory
             if (slotIndex < 0 || slotIndex >= items.Length) return;
             var entry = items[slotIndex];
             if (entry.item == null || entry.count <= 1) return;
+            if (!entry.item.splittable) return;
             if (type == StackSplitType.Drop && !CanDropItems) return;
 
             StackSplitDialog.Show(uiRoot.transform, entry.count, amount =>

--- a/Assets/Scripts/Inventory/ItemData.cs
+++ b/Assets/Scripts/Inventory/ItemData.cs
@@ -25,4 +25,7 @@ public class ItemData : ScriptableObject
 
     [Tooltip("Maximum number of items per stack when stackable.")]
     public int maxStack = 1;
+
+    [Tooltip("If true, stacks of this item can be split in the inventory.")]
+    public bool splittable = true;
 }


### PR DESCRIPTION
## Summary
- allow items to specify if their stacks can be split
- prevent splitting for items marked as unsplittable
- mark gold coins as unsplittable by default

## Testing
- `dotnet build` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68a0570d406c832e853a6f4e15b7d5a1