### PR TITLE
feat: centralize scene transition handling

### DIFF
--- a/Assets/Scripts/World/SceneTransitionManager.cs
+++ b/Assets/Scripts/World/SceneTransitionManager.cs
@@ -1,0 +1,138 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.EventSystems;
+
+namespace World
+{
+    /// <summary>
+    /// Manages moving key objects between scenes and handling fade transitions.
+    /// </summary>
+    public class SceneTransitionManager : MonoBehaviour
+    {
+        public static SceneTransitionManager Instance;
+
+        private Transform _playerToMove;
+        private GameObject _cameraToMove;
+        private GameObject _inventoryUIToMove;
+        private GameObject _eventSystemToMove;
+        private string _nextSpawnPoint;
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+
+        public IEnumerator Transition(string sceneToLoad, string spawnPointName, string requiredItemId, bool removeItemOnUse)
+        {
+            if (string.IsNullOrEmpty(sceneToLoad))
+                yield break;
+
+            if (ScreenFader.Instance == null)
+                new GameObject("ScreenFader").AddComponent<ScreenFader>();
+
+            if (ScreenFader.Instance != null)
+                yield return ScreenFader.Instance.FadeOut();
+
+            _nextSpawnPoint = spawnPointName;
+
+            var player = GameObject.FindGameObjectWithTag("Player");
+            if (player != null)
+            {
+                _playerToMove = player.transform;
+                var inv = player.GetComponent<Inventory.Inventory>();
+                if (removeItemOnUse && inv != null && !string.IsNullOrEmpty(requiredItemId))
+                    inv.RemoveItem(requiredItemId);
+                DontDestroyOnLoad(player);
+            }
+
+            var cam = Camera.main;
+            _cameraToMove = cam ? cam.gameObject : null;
+            if (_cameraToMove) DontDestroyOnLoad(_cameraToMove);
+
+            _inventoryUIToMove = GameObject.Find("InventoryUI");
+            if (_inventoryUIToMove) DontDestroyOnLoad(_inventoryUIToMove);
+
+            var ev = EventSystem.current;
+            _eventSystemToMove = ev ? ev.gameObject : null;
+            if (_eventSystemToMove) DontDestroyOnLoad(_eventSystemToMove);
+
+            SceneManager.sceneLoaded += OnSceneLoaded;
+            SceneManager.LoadScene(sceneToLoad);
+        }
+
+        private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+        {
+            if (_playerToMove != null && !string.IsNullOrEmpty(_nextSpawnPoint))
+            {
+                var points = GameObject.FindObjectsOfType<SpawnPoint>();
+                foreach (var p in points)
+                {
+                    if (p.id == _nextSpawnPoint)
+                    {
+                        _playerToMove.position = p.transform.position;
+                        break;
+                    }
+                }
+
+                SceneManager.MoveGameObjectToScene(_playerToMove.gameObject, scene);
+                var players = GameObject.FindGameObjectsWithTag("Player");
+                foreach (var p in players)
+                {
+                    if (p != _playerToMove.gameObject)
+                        Destroy(p);
+                }
+            }
+
+            if (_cameraToMove != null)
+            {
+                SceneManager.MoveGameObjectToScene(_cameraToMove, scene);
+                var cameras = GameObject.FindObjectsOfType<Camera>();
+                foreach (var c in cameras)
+                {
+                    if (c.gameObject != _cameraToMove)
+                        Destroy(c.gameObject);
+                }
+            }
+
+            if (_inventoryUIToMove != null)
+            {
+                SceneManager.MoveGameObjectToScene(_inventoryUIToMove, scene);
+                var canvases = GameObject.FindObjectsOfType<Canvas>();
+                foreach (var cv in canvases)
+                {
+                    if (cv.gameObject != _inventoryUIToMove && cv.gameObject.name == _inventoryUIToMove.name)
+                        Destroy(cv.gameObject);
+                }
+            }
+
+            if (_eventSystemToMove != null)
+            {
+                SceneManager.MoveGameObjectToScene(_eventSystemToMove, scene);
+                var systems = GameObject.FindObjectsOfType<EventSystem>();
+                foreach (var es in systems)
+                {
+                    if (es.gameObject != _eventSystemToMove)
+                        Destroy(es.gameObject);
+                }
+            }
+
+            SceneManager.sceneLoaded -= OnSceneLoaded;
+            _playerToMove = null;
+            _nextSpawnPoint = null;
+            _cameraToMove = null;
+            _inventoryUIToMove = null;
+            _eventSystemToMove = null;
+
+            if (ScreenFader.Instance != null)
+                ScreenFader.Instance.StartCoroutine(ScreenFader.Instance.FadeIn());
+        }
+    }
+}

--- a/Assets/Scripts/World/SceneTransitionManager.cs.meta
+++ b/Assets/Scripts/World/SceneTransitionManager.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e3d69c5fb9e6485a9cdfcba7e5b45aa0
+timeCreated: 1735689600


### PR DESCRIPTION
## Summary
- add SceneTransitionManager singleton to handle scene fades and move player, camera, UI, and EventSystem between scenes
- refactor Door to use SceneTransitionManager for transitions

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a059a10d98832eb7e3439df369eb5d