### PR TITLE
Prevent duplicate UI when returning to scenes

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -79,6 +79,7 @@ namespace Inventory
 
         // UI
         private GameObject uiRoot; // Canvas root
+        private static GameObject sharedUIRoot;
 
         // Drag & drop
         private int draggingIndex = -1;
@@ -122,7 +123,16 @@ namespace Inventory
 
             items = new InventoryEntry[size];
             EnsureLegacyEventSystem();
-            CreateUI();
+
+            if (sharedUIRoot != null)
+            {
+                uiRoot = sharedUIRoot;
+            }
+            else
+            {
+                CreateUI();
+                sharedUIRoot = uiRoot;
+            }
 
             playerMover = GetComponent<PlayerMover>();
 

--- a/Assets/Scripts/Shop/ShopUI.cs
+++ b/Assets/Scripts/Shop/ShopUI.cs
@@ -42,8 +42,18 @@ namespace ShopSystem
         private PlayerMover playerMover;
         private NpcRandomMovement npcMover;
 
+        private static ShopUI instance;
+        public static ShopUI Instance => instance;
+
         private void Awake()
         {
+            if (instance != null && instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            instance = this;
             CreateUI();
             if (uiRoot != null)
                 uiRoot.SetActive(false);


### PR DESCRIPTION
## Summary
- avoid recreating InventoryUI if one already exists
- enforce a singleton for ShopUI so only one instance persists across scenes

## Testing
- `dotnet test` *(fails: MSB1003 - no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a05c8f6678832e84142ec4cdf7ca85