### PR TITLE
Prevent ShopUI duplication across scene loads

### DIFF
--- a/Assets/Scripts/Shop/ShopUI.cs
+++ b/Assets/Scripts/Shop/ShopUI.cs
@@ -34,6 +34,7 @@ namespace ShopSystem
         public Inventory.Inventory playerInventory;
 
         private GameObject uiRoot;
+        private static GameObject sharedUIRoot;
         private Image[] slotImages;
         private Text[] slotPriceTexts;
         private Text tooltipText;
@@ -54,9 +55,24 @@ namespace ShopSystem
             }
 
             instance = this;
-            CreateUI();
+
+            if (sharedUIRoot != null)
+            {
+                uiRoot = sharedUIRoot;
+            }
+            else
+            {
+                CreateUI();
+                sharedUIRoot = uiRoot;
+            }
             if (uiRoot != null)
                 uiRoot.SetActive(false);
+        }
+
+        private void OnDestroy()
+        {
+            if (instance == this)
+                instance = null;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- avoid recreating Shop UI canvas when scenes reload
- reset ShopUI singleton on destroy

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a05f9801c0832ebc8d486b484ace9d