### PR TITLE
Persist right-click menu across scenes

### DIFF
--- a/Assets/Scripts/NPC/NPCInteractable.cs
+++ b/Assets/Scripts/NPC/NPCInteractable.cs
@@ -16,7 +16,9 @@ namespace NPC
         [Tooltip("Context menu prefab that provides Talk / Open Shop / Examine.")]
         public RightClickMenu menuPrefab;
 
-        private RightClickMenu menuInstance;
+        // Shared instance so the menu persists across scene loads
+        private static RightClickMenu menuInstance;
+        private static Canvas menuCanvas;
 
         private void OnMouseOver()
         {
@@ -24,17 +26,13 @@ namespace NPC
             {
                 if (menuInstance == null)
                 {
-                    var canvas = FindObjectOfType<Canvas>();
-                    if (canvas == null)
-                    {
-                        var canvasGO = new GameObject("ContextMenuCanvas", typeof(Canvas), typeof(CanvasScaler),
-                            typeof(GraphicRaycaster));
-                        var c = canvasGO.GetComponent<Canvas>();
-                        c.renderMode = RenderMode.ScreenSpaceOverlay;
-                        canvas = c;
-                    }
+                    var canvasGO = new GameObject("ContextMenuCanvas", typeof(Canvas), typeof(CanvasScaler),
+                        typeof(GraphicRaycaster));
+                    menuCanvas = canvasGO.GetComponent<Canvas>();
+                    menuCanvas.renderMode = RenderMode.ScreenSpaceOverlay;
+                    DontDestroyOnLoad(canvasGO);
 
-                    menuInstance = Instantiate(menuPrefab, canvas.transform);
+                    menuInstance = Instantiate(menuPrefab, menuCanvas.transform);
                 }
 
                 menuInstance.Show(this, Input.mousePosition);


### PR DESCRIPTION
## Summary
- keep a single NPC context menu across scene changes by creating a persistent canvas

## Testing
- `dotnet build` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a069b398a4832e8e4bd58720642343