### PR TITLE
Prevent shop UI from losing references after scene reload

### DIFF
--- a/Assets/Scripts/Shop/ShopUI.cs
+++ b/Assets/Scripts/Shop/ShopUI.cs
@@ -55,6 +55,7 @@ namespace ShopSystem
             }
 
             instance = this;
+            DontDestroyOnLoad(gameObject);
 
             if (sharedUIRoot != null)
             {


### PR DESCRIPTION
## Summary
- Keep the ShopUI component alive across scene loads so slot references persist

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a06c3bb6ec832e808006bdd05fa09c