### PR TITLE
Load item data from Resources folder in debug menu

### DIFF
--- a/Assets/Scripts/Inventory/InventoryDebugMenu.cs
+++ b/Assets/Scripts/Inventory/InventoryDebugMenu.cs
@@ -11,9 +11,10 @@ namespace Inventory
     /// menu. When the menu is open, a button is shown for each item. Clicking a
     /// button adds that item to the inventory.
     ///
-    /// In the editor all items found under <c>Assets/Item</c> are listed using
-    /// <c>AssetDatabase</c>. In a player build it falls back to loading items from
-    /// a <c>Resources/Item</c> folder.
+    /// In the editor all items found under <c>Assets/Item</c> and
+    /// <c>Assets/Resources/Item</c> are listed using <c>AssetDatabase</c>. In a
+    /// player build it falls back to loading items from a <c>Resources/Item</c>
+    /// folder.
     /// </summary>
     [DisallowMultipleComponent]
     public class InventoryDebugMenu : MonoBehaviour
@@ -44,8 +45,11 @@ namespace Inventory
             }
 
 #if UNITY_EDITOR
-            // In the editor load all ItemData assets from Assets/Item
-            string[] guids = AssetDatabase.FindAssets("t:ItemData", new[] { "Assets/Item" });
+            // In the editor load all ItemData assets from Assets/Item and
+            // Assets/Resources/Item
+            string[] guids = AssetDatabase.FindAssets(
+                "t:ItemData",
+                new[] { "Assets/Item", "Assets/Resources/Item" });
             allItems = new ItemData[guids.Length];
             for (int i = 0; i < guids.Length; i++)
             {


### PR DESCRIPTION
## Summary
- include Items from Assets/Resources/Item in InventoryDebugMenu when running in editor
- document that Items are loaded from both Assets/Item and Assets/Resources/Item

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a08055b76c832ea31a3d6bb71e5df2