### PR TITLE
feat: allow custom floating text size

### DIFF
--- a/Assets/Scripts/Skills/Mining/UI/FloatingText.cs
+++ b/Assets/Scripts/Skills/Mining/UI/FloatingText.cs
@@ -10,8 +10,9 @@ namespace Skills.Mining
         [SerializeField] private float lifetime = 1.5f;
         [SerializeField] private Vector3 floatSpeed = new Vector3(0f, 1f, 0f);
         private TextMesh textMesh;
+        [SerializeField] private float textSize = 0.2f;
 
-        public static void Show(string message, Vector3 position, Color? color = null)
+        public static void Show(string message, Vector3 position, Color? color = null, float? size = null)
         {
             GameObject go = new GameObject("FloatingText");
             go.transform.position = position;
@@ -19,6 +20,9 @@ namespace Skills.Mining
             ft.textMesh = go.AddComponent<TextMesh>();
             ft.textMesh.text = message;
             ft.textMesh.color = color ?? Color.white;
+            float finalSize = size ?? ft.textSize;
+            ft.textMesh.characterSize = finalSize;
+            ft.textMesh.fontSize = Mathf.RoundToInt(64 * finalSize);
         }
 
         private void Update()


### PR DESCRIPTION
## Summary
- add serialized `textSize` for mining floating text
- allow overriding text size when showing floating text

## Testing
- `dotnet build` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a08da843cc832ea9c6ea8019fe18fa