### PR TITLE
Cancel mining when player starts moving

### DIFF
--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -31,6 +31,8 @@ namespace Player
         private int facingDir = 0;
         private Vector2 moveDir;
 
+        public bool IsMoving => moveDir.sqrMagnitude > 0f;
+
 #if ENABLE_INPUT_SYSTEM
         private InputAction moveAction;
 #endif

--- a/Assets/Scripts/Skills/Mining/Core/MinerController.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MinerController.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using Inventory;
+using Player;
 
 namespace Skills.Mining
 {
@@ -16,6 +17,7 @@ namespace Skills.Mining
         [Header("References")]
         [SerializeField] private MiningSkill miningSkill;
         [SerializeField] private PickaxeToUse pickaxeSelector;
+        [SerializeField] private PlayerMover playerMover;
 
         private MineableRock nearbyRock;
 
@@ -27,6 +29,8 @@ namespace Skills.Mining
                 miningSkill = GetComponent<MiningSkill>();
             if (pickaxeSelector == null)
                 pickaxeSelector = GetComponent<PickaxeToUse>();
+            if (playerMover == null)
+                playerMover = GetComponent<PlayerMover>();
             cam = Camera.main;
         }
 
@@ -53,7 +57,9 @@ namespace Skills.Mining
 
             if (miningSkill.IsMining)
             {
-                if (Vector3.Distance(transform.position, miningSkill.CurrentRock.transform.position) > cancelDistance)
+                if (playerMover != null && playerMover.IsMoving)
+                    miningSkill.StopMining();
+                else if (Vector3.Distance(transform.position, miningSkill.CurrentRock.transform.position) > cancelDistance)
                     miningSkill.StopMining();
             }
         }


### PR DESCRIPTION
## Summary
- expose PlayerMover.IsMoving
- stop mining instantly when movement input detected

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a09563a404832eb6aa7543572c815e