### PR TITLE
Sync mining progress bar with game tick cycle

### DIFF
--- a/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
@@ -34,6 +34,7 @@ namespace Skills.Mining
         public int Level => level;
         public bool IsMining => currentRock != null;
         public MineableRock CurrentRock => currentRock;
+        public int CurrentSwingSpeedTicks => currentPickaxe?.SwingSpeedTicks ?? 0;
         public float SwingProgressNormalized => currentPickaxe == null || currentPickaxe.SwingSpeedTicks <= 0 ? 0f : (float)swingProgress / currentPickaxe.SwingSpeedTicks;
 
         private void Awake()


### PR DESCRIPTION
## Summary
- Track mining progress over game ticks with smooth interpolation
- Expose pickaxe swing speed to UI via `CurrentSwingSpeedTicks`

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ab693fcc832e92d3b5f182d7527f