### PR TITLE
Stop mining bar when rock is depleted

### DIFF
--- a/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
@@ -102,6 +102,13 @@ namespace Skills.Mining
             if (!IsMining)
                 return;
 
+            // Stop immediately if the current rock has already been depleted
+            if (currentRock == null || currentRock.IsDepleted)
+            {
+                StopMining();
+                return;
+            }
+
             swingProgress++;
             Debug.Log($"Mining tick: {swingProgress}/{currentPickaxe.SwingSpeedTicks}");
             if (swingProgress >= currentPickaxe.SwingSpeedTicks)


### PR DESCRIPTION
## Summary
- stop mining automatically if the current rock becomes depleted

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68a0af7d990c832eac085e5939b15154