### PR TITLE
Reduce mining progress bar height

### DIFF
--- a/Assets/Scripts/Skills/Mining/UI/MiningUI.cs
+++ b/Assets/Scripts/Skills/Mining/UI/MiningUI.cs
@@ -13,7 +13,9 @@ namespace Skills.Mining
         private Transform target;
         private Image progressImage;
         private GameObject progressRoot;
-        private readonly Vector3 offset = new Vector3(0f, 1.5f, 0f);
+        // Offset from the targeted rock's position where the progress bar will appear.
+        // Reduced the vertical component to half of its previous value so the bar sits closer to the object.
+        private readonly Vector3 offset = new Vector3(0f, 0.75f, 0f);
 
         private float currentFill;
         private float nextFill;


### PR DESCRIPTION
## Summary
- Lower mining progress bar's world-space offset so it appears closer to mined rocks

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b0f33228832ea8abcb034ab14e70