### PR TITLE
Fix mining progress bar reset at 80%

### DIFF
--- a/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
@@ -35,7 +35,10 @@ namespace Skills.Mining
         public bool IsMining => currentRock != null;
         public MineableRock CurrentRock => currentRock;
         public int CurrentSwingSpeedTicks => currentPickaxe?.SwingSpeedTicks ?? 0;
-        public float SwingProgressNormalized => currentPickaxe == null || currentPickaxe.SwingSpeedTicks <= 0 ? 0f : (float)swingProgress / currentPickaxe.SwingSpeedTicks;
+        public float SwingProgressNormalized
+            => currentPickaxe == null || currentPickaxe.SwingSpeedTicks <= 1
+                ? 0f
+                : (float)swingProgress / (currentPickaxe.SwingSpeedTicks - 1);
 
         private void Awake()
         {


### PR DESCRIPTION
## Summary
- ensure mining progress bar reaches 100% before resetting by adjusting SwingProgressNormalized calculation

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b343d474832ea04d23b5c0b40875