### PR TITLE
Support multiple ticks per frame in Ticker

### DIFF
--- a/Assets/Scripts/Util/Ticker.cs
+++ b/Assets/Scripts/Util/Ticker.cs
@@ -16,6 +16,9 @@ namespace Util
 
         private float timer;
 
+        [SerializeField]
+        private bool logTicks;
+
         private void Awake()
         {
             if (Instance != null && Instance != this)
@@ -31,10 +34,13 @@ namespace Util
         private void Update()
         {
             timer += Time.deltaTime;
-            if (timer >= TickDuration)
+            while (timer >= TickDuration)
             {
                 timer -= TickDuration;
-                Debug.Log("Tick");
+                if (logTicks)
+                {
+                    Debug.Log("Tick");
+                }
                 OnTick?.Invoke();
             }
         }


### PR DESCRIPTION
## Summary
- ensure `Ticker` fires multiple ticks if a frame accumulates more than one tick duration
- add optional `logTicks` flag to prevent console flood from tick logs

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f5b73014832e98842ba44b1efc9e