### PR TITLE
Refactor NPC movement to use shared sprite animator

### DIFF
--- a/Assets/Scripts/NPC/NPCPathFollower.cs
+++ b/Assets/Scripts/NPC/NPCPathFollower.cs
@@ -15,7 +15,6 @@ namespace NPC
     public class NpcPathFollower : MonoBehaviour
     {
         public enum LoopType { Loop, PingPong, Once }
-        public enum VisualMode { Animator, SpriteSwap }
 
         [Header("Path Reference (preferred)")]
         [Tooltip("Reusable scene path. If set, used instead of the legacy Waypoints array.")]
@@ -40,34 +39,8 @@ namespace NPC
         public bool snapToFirstOnStart = false;
 
         [Header("Visuals")]
-        public VisualMode visualMode = VisualMode.Animator;
-
-        [Tooltip("Animator with parameters Dir(int 0=Down,1=Left,2=Right,3=Up) and IsMoving(bool). Used in Animator mode.")]
-        public Animator animator;
-        public string dirParam = "Dir";
-        public string isMovingParam = "IsMoving";
-
-        [Tooltip("SpriteRenderer used in SpriteSwap mode (auto-found if null).")]
-        public SpriteRenderer spriteRenderer;
-
-        [Header("SpriteSwap Sets (used only in SpriteSwap mode)")]
-        [Tooltip("Frames used when idle (Down). Leave empty to fall back to first frame of WalkDown.")]
-        public Sprite[] idleDown;
-        public Sprite[] idleLeft;
-        public Sprite[] idleRight;
-        public Sprite[] idleUp;
-
-        [Tooltip("Frames used when moving (Down/Left/Right/Up).")]
-        public Sprite[] walkDown;
-        public Sprite[] walkLeft;
-        public Sprite[] walkRight;
-        public Sprite[] walkUp;
-
-        [Tooltip("If true, ignore Left arrays and flip the Right sprites for left-facing.")]
-        public bool useFlipXForLeft = true;
-
-        [Tooltip("Frames per second for SpriteSwap animation.")]
-        public float animationFPS = 6f;
+        [Tooltip("Component handling sprite animation/animator updates.")]
+        public NpcSpriteAnimator spriteAnimator;
 
         // Internal state
         private Rigidbody2D _rb;
@@ -83,16 +56,9 @@ namespace NPC
         // Legacy auto-discovered container
         private Transform _legacyPathContainer;
 
-        // Visual state
-        private int _currentDir = 0; // 0=Down,1=Left,2=Right,3=Up
-        private bool _currentlyMoving = false;
-        private float _animClock = 0f;
-        private int _animFrame = 0;
-
         private void Reset()
         {
-            animator = GetComponent<Animator>() ?? GetComponentInChildren<Animator>();
-            spriteRenderer = GetComponent<SpriteRenderer>() ?? GetComponentInChildren<SpriteRenderer>();
+            spriteAnimator = GetComponent<NpcSpriteAnimator>() ?? GetComponentInChildren<NpcSpriteAnimator>();
         }
 
         private void Awake()
@@ -100,8 +66,7 @@ namespace NPC
             _rb = GetComponent<Rigidbody2D>();
             if (_rb != null) _rb.bodyType = RigidbodyType2D.Kinematic;
 
-            if (animator == null) animator = GetComponent<Animator>() ?? GetComponentInChildren<Animator>();
-            if (spriteRenderer == null) spriteRenderer = GetComponent<SpriteRenderer>() ?? GetComponentInChildren<SpriteRenderer>();
+            if (spriteAnimator == null) spriteAnimator = GetComponent<NpcSpriteAnimator>() ?? GetComponentInChildren<NpcSpriteAnimator>();
 
             // Legacy auto-discovery (only used if no WaypointPath and no manual array)
             if (path == null && (waypoints == null || waypoints.Length == 0))
@@ -139,14 +104,14 @@ namespace NPC
             }
 
             _lastPos = GetPosition2D();
-            UpdateVisuals(Vector2.zero); // init as idle
+            if (spriteAnimator != null) spriteAnimator.UpdateVisuals(Vector2.zero); // init as idle
         }
 
         private void FixedUpdate()
         {
             if (_waiting || GetPointCount() == 0)
             {
-                UpdateVisuals(Vector2.zero);
+                if (spriteAnimator != null) spriteAnimator.UpdateVisuals(Vector2.zero);
                 return;
             }
 
@@ -166,7 +131,7 @@ namespace NPC
                 {
                     AdvanceIndex();
                 }
-                UpdateVisuals(Vector2.zero);
+                if (spriteAnimator != null) spriteAnimator.UpdateVisuals(Vector2.zero);
                 return;
             }
 
@@ -179,14 +144,14 @@ namespace NPC
             else transform.position = next;
 
             Vector2 velocity = (next - _lastPos) / Time.fixedDeltaTime;
-            UpdateVisuals(velocity);
+            if (spriteAnimator != null) spriteAnimator.UpdateVisuals(velocity);
             _lastPos = next;
         }
 
         private IEnumerator WaitThenAdvance(float seconds)
         {
             _waiting = true;
-            UpdateVisuals(Vector2.zero);
+            if (spriteAnimator != null) spriteAnimator.UpdateVisuals(Vector2.zero);
             yield return new WaitForSeconds(seconds);
             AdvanceIndex();
             _waiting = false;
@@ -287,105 +252,6 @@ namespace NPC
             }
         }
 
-        // ------- Visuals -------
-        private void UpdateVisuals(Vector2 velocity)
-        {
-            _currentlyMoving = velocity.sqrMagnitude > 0.0001f;
-
-            // Determine facing dir from dominant axis (Down/Left/Right/Up)
-            if (_currentlyMoving)
-            {
-                if (Mathf.Abs(velocity.x) > Mathf.Abs(velocity.y))
-                    _currentDir = velocity.x < 0f ? 1 : 2; // Left : Right
-                else
-                    _currentDir = velocity.y < 0f ? 0 : 3; // Down : Up
-            }
-
-            if (visualMode == VisualMode.Animator)
-            {
-                if (animator == null) return;
-                animator.SetBool(isMovingParam, _currentlyMoving);
-                if (_currentlyMoving)
-                    animator.SetInteger(dirParam, _currentDir);
-                return;
-            }
-
-            // SpriteSwap mode
-            if (spriteRenderer == null) return;
-
-            // Advance animation clock if moving, else idle clock
-            float fps = Mathf.Max(0.01f, animationFPS);
-            _animClock += Time.fixedDeltaTime * fps;
-            int frames;
-            Sprite[] set = SelectSpriteSet(_currentlyMoving, _currentDir, out frames);
-
-            if (frames <= 0) return;
-
-            _animFrame = Mathf.FloorToInt(_animClock) % frames;
-            spriteRenderer.flipX = false; // reset; may set below
-
-            // Handle flip-left using right set if requested
-            if (useFlipXForLeft && _currentDir == 1) // Left
-            {
-                Sprite[] rightSet = SelectSpriteSet(_currentlyMoving, 2, out frames); // use right
-                if (frames > 0)
-                {
-                    _animFrame = Mathf.FloorToInt(_animClock) % frames;
-                    spriteRenderer.sprite = rightSet[_animFrame];
-                    spriteRenderer.flipX = true;
-                    return;
-                }
-            }
-
-            spriteRenderer.sprite = set[_animFrame];
-        }
-
-        private Sprite[] SelectSpriteSet(bool moving, int dir, out int frames)
-        {
-            Sprite[] set = null;
-
-            if (moving)
-            {
-                switch (dir)
-                {
-                    case 0: set = walkDown; break;
-                    case 1: set = useFlipXForLeft ? walkRight : walkLeft; break;
-                    case 2: set = walkRight; break;
-                    case 3: set = walkUp; break;
-                }
-            }
-            else
-            {
-                switch (dir)
-                {
-                    case 0: set = idleDown != null && idleDown.Length > 0 ? idleDown : (walkDown ?? idleDown); break;
-                    case 1: set = useFlipXForLeft
-                            ? (idleRight != null && idleRight.Length > 0 ? idleRight : walkRight)
-                            : (idleLeft != null && idleLeft.Length > 0 ? idleLeft : walkLeft);
-                        break;
-                    case 2: set = idleRight != null && idleRight.Length > 0 ? idleRight : (walkRight ?? idleRight); break;
-                    case 3: set = idleUp != null && idleUp.Length > 0 ? idleUp : (walkUp ?? idleUp); break;
-                }
-            }
-
-            if (set == null || set.Length == 0)
-            {
-                // Fallback: try a single frame from down/right
-                if (!moving)
-                {
-                    if (idleDown != null && idleDown.Length > 0) { frames = idleDown.Length; return idleDown; }
-                    if (walkDown != null && walkDown.Length > 0) { frames = walkDown.Length; return walkDown; }
-                }
-                else
-                {
-                    if (walkRight != null && walkRight.Length > 0) { frames = walkRight.Length; return walkRight; }
-                    if (walkDown != null && walkDown.Length > 0) { frames = walkDown.Length; return walkDown; }
-                }
-            }
-
-            frames = set != null ? set.Length : 0;
-            return set ?? System.Array.Empty<Sprite>();
-        }
 
 #if UNITY_EDITOR
         private void OnDrawGizmosSelected()

--- a/Assets/Scripts/NPC/NpcRandomMovement.cs
+++ b/Assets/Scripts/NPC/NpcRandomMovement.cs
@@ -19,28 +19,8 @@ namespace NPC
         public float maxIdleTime = 2f;
 
         [Header("Visuals")]
-        public NpcPathFollower.VisualMode visualMode = NpcPathFollower.VisualMode.Animator;
-        [Tooltip("Animator with parameters Dir(int 0=Down,1=Left,2=Right,3=Up) and IsMoving(bool). Used in Animator mode.")]
-        public Animator animator;
-        public string dirParam = "Dir";
-        public string isMovingParam = "IsMoving";
-        [Tooltip("SpriteRenderer used in SpriteSwap mode (auto-found if null).")]
-        public SpriteRenderer spriteRenderer;
-        [Header("SpriteSwap Sets (used only in SpriteSwap mode)")]
-        [Tooltip("Frames used when idle (Down). Leave empty to fall back to first frame of WalkDown.")]
-        public Sprite[] idleDown;
-        public Sprite[] idleLeft;
-        public Sprite[] idleRight;
-        public Sprite[] idleUp;
-        [Tooltip("Frames used when moving (Down/Left/Right/Up).")]
-        public Sprite[] walkDown;
-        public Sprite[] walkLeft;
-        public Sprite[] walkRight;
-        public Sprite[] walkUp;
-        [Tooltip("If true, ignore Left arrays and flip the Right sprites for left-facing.")]
-        public bool useFlipXForLeft = true;
-        [Tooltip("Frames per second for SpriteSwap animation.")]
-        public float animationFPS = 6f;
+        [Tooltip("Component handling sprite animation/animator updates.")]
+        public NpcSpriteAnimator spriteAnimator;
 
         private Rigidbody2D _rb;
         private Vector2 _origin;
@@ -48,15 +28,10 @@ namespace NPC
         private bool _waiting;
         private float _waitTimer;
         private Vector2 _lastPos;
-        private bool _currentlyMoving;
-        private int _currentDir;
-        private float _animClock;
-        private int _animFrame;
 
         private void Reset()
         {
-            animator = GetComponent<Animator>() ?? GetComponentInChildren<Animator>();
-            spriteRenderer = GetComponent<SpriteRenderer>() ?? GetComponentInChildren<SpriteRenderer>();
+            spriteAnimator = GetComponent<NpcSpriteAnimator>() ?? GetComponentInChildren<NpcSpriteAnimator>();
         }
 
         private void Awake()
@@ -64,8 +39,7 @@ namespace NPC
             _rb = GetComponent<Rigidbody2D>();
             if (_rb != null) _rb.bodyType = RigidbodyType2D.Kinematic;
 
-            if (animator == null) animator = GetComponent<Animator>() ?? GetComponentInChildren<Animator>();
-            if (spriteRenderer == null) spriteRenderer = GetComponent<SpriteRenderer>() ?? GetComponentInChildren<SpriteRenderer>();
+            if (spriteAnimator == null) spriteAnimator = GetComponent<NpcSpriteAnimator>() ?? GetComponentInChildren<NpcSpriteAnimator>();
         }
 
         private void Start()
@@ -79,7 +53,7 @@ namespace NPC
         {
             _waiting = true;
             _waitTimer = Random.Range(minIdleTime, maxIdleTime);
-            UpdateVisuals(Vector2.zero);
+            if (spriteAnimator != null) spriteAnimator.UpdateVisuals(Vector2.zero);
         }
 
         private void ChooseNewTarget()
@@ -97,7 +71,7 @@ namespace NPC
                 _waitTimer -= Time.fixedDeltaTime;
                 if (_waitTimer <= 0f)
                     ChooseNewTarget();
-                UpdateVisuals(Vector2.zero);
+                if (spriteAnimator != null) spriteAnimator.UpdateVisuals(Vector2.zero);
                 return;
             }
 
@@ -111,103 +85,8 @@ namespace NPC
             if (Vector2.Distance(next, _target) <= arriveDistance)
                 BeginIdle();
 
-            UpdateVisuals(velocity);
+            if (spriteAnimator != null) spriteAnimator.UpdateVisuals(velocity);
             _lastPos = next;
-        }
-
-        private void UpdateVisuals(Vector2 velocity)
-        {
-            _currentlyMoving = velocity.sqrMagnitude > 0.0001f;
-
-            if (_currentlyMoving)
-            {
-                if (Mathf.Abs(velocity.x) > Mathf.Abs(velocity.y))
-                    _currentDir = velocity.x < 0f ? 1 : 2; // Left : Right
-                else
-                    _currentDir = velocity.y < 0f ? 0 : 3; // Down : Up
-            }
-
-            if (visualMode == NpcPathFollower.VisualMode.Animator)
-            {
-                if (animator == null) return;
-                animator.SetBool(isMovingParam, _currentlyMoving);
-                if (_currentlyMoving)
-                    animator.SetInteger(dirParam, _currentDir);
-                return;
-            }
-
-            if (spriteRenderer == null) return;
-
-            float fps = Mathf.Max(0.01f, animationFPS);
-            _animClock += Time.fixedDeltaTime * fps;
-            int frames;
-            Sprite[] set = SelectSpriteSet(_currentlyMoving, _currentDir, out frames);
-
-            if (frames <= 0) return;
-
-            _animFrame = Mathf.FloorToInt(_animClock) % frames;
-            spriteRenderer.flipX = false;
-
-            if (useFlipXForLeft && _currentDir == 1)
-            {
-                Sprite[] rightSet = SelectSpriteSet(_currentlyMoving, 2, out frames);
-                if (frames > 0)
-                {
-                    _animFrame = Mathf.FloorToInt(_animClock) % frames;
-                    spriteRenderer.sprite = rightSet[_animFrame];
-                    spriteRenderer.flipX = true;
-                    return;
-                }
-            }
-
-            spriteRenderer.sprite = set[_animFrame];
-        }
-
-        private Sprite[] SelectSpriteSet(bool moving, int dir, out int frames)
-        {
-            Sprite[] set = null;
-
-            if (moving)
-            {
-                switch (dir)
-                {
-                    case 0: set = walkDown; break;
-                    case 1: set = useFlipXForLeft ? walkRight : walkLeft; break;
-                    case 2: set = walkRight; break;
-                    case 3: set = walkUp; break;
-                }
-            }
-            else
-            {
-                switch (dir)
-                {
-                    case 0: set = idleDown != null && idleDown.Length > 0 ? idleDown : (walkDown ?? idleDown); break;
-                    case 1:
-                        set = useFlipXForLeft
-                            ? (idleRight != null && idleRight.Length > 0 ? idleRight : walkRight)
-                            : (idleLeft != null && idleLeft.Length > 0 ? idleLeft : walkLeft);
-                        break;
-                    case 2: set = idleRight != null && idleRight.Length > 0 ? idleRight : (walkRight ?? idleRight); break;
-                    case 3: set = idleUp != null && idleUp.Length > 0 ? idleUp : (walkUp ?? idleUp); break;
-                }
-            }
-
-            if (set == null || set.Length == 0)
-            {
-                if (!moving)
-                {
-                    if (idleDown != null && idleDown.Length > 0) { frames = idleDown.Length; return idleDown; }
-                    if (walkDown != null && walkDown.Length > 0) { frames = walkDown.Length; return walkDown; }
-                }
-                else
-                {
-                    if (walkRight != null && walkRight.Length > 0) { frames = walkRight.Length; return walkRight; }
-                    if (walkDown != null && walkDown.Length > 0) { frames = walkDown.Length; return walkDown; }
-                }
-            }
-
-            frames = set != null ? set.Length : 0;
-            return set ?? System.Array.Empty<Sprite>();
         }
 
 #if UNITY_EDITOR

--- a/Assets/Scripts/NPC/NpcSpriteAnimator.cs
+++ b/Assets/Scripts/NPC/NpcSpriteAnimator.cs
@@ -1,0 +1,158 @@
+using UnityEngine;
+
+namespace NPC
+{
+    /// <summary>
+    /// Handles sprite-based visuals for NPCs using either an Animator or manual sprite swapping.
+    /// </summary>
+    public class NpcSpriteAnimator : MonoBehaviour
+    {
+        public enum VisualMode { Animator, SpriteSwap }
+
+        [Header("Visuals")]
+        public VisualMode visualMode = VisualMode.Animator;
+
+        [Tooltip("Animator with parameters Dir(int 0=Down,1=Left,2=Right,3=Up) and IsMoving(bool). Used in Animator mode.")]
+        public Animator animator;
+        public string dirParam = "Dir";
+        public string isMovingParam = "IsMoving";
+
+        [Tooltip("SpriteRenderer used in SpriteSwap mode (auto-found if null).")]
+        public SpriteRenderer spriteRenderer;
+
+        [Header("SpriteSwap Sets (used only in SpriteSwap mode)")]
+        [Tooltip("Frames used when idle (Down). Leave empty to fall back to first frame of WalkDown.")]
+        public Sprite[] idleDown;
+        public Sprite[] idleLeft;
+        public Sprite[] idleRight;
+        public Sprite[] idleUp;
+
+        [Tooltip("Frames used when moving (Down/Left/Right/Up).")]
+        public Sprite[] walkDown;
+        public Sprite[] walkLeft;
+        public Sprite[] walkRight;
+        public Sprite[] walkUp;
+
+        [Tooltip("If true, ignore Left arrays and flip the Right sprites for left-facing.")]
+        public bool useFlipXForLeft = true;
+
+        [Tooltip("Frames per second for SpriteSwap animation.")]
+        public float animationFPS = 6f;
+
+        private int _currentDir = 0;
+        private bool _currentlyMoving = false;
+        private float _animClock = 0f;
+        private int _animFrame = 0;
+
+        private void Reset()
+        {
+            animator = GetComponent<Animator>() ?? GetComponentInChildren<Animator>();
+            spriteRenderer = GetComponent<SpriteRenderer>() ?? GetComponentInChildren<SpriteRenderer>();
+        }
+
+        private void Awake()
+        {
+            if (animator == null) animator = GetComponent<Animator>() ?? GetComponentInChildren<Animator>();
+            if (spriteRenderer == null) spriteRenderer = GetComponent<SpriteRenderer>() ?? GetComponentInChildren<SpriteRenderer>();
+        }
+
+        /// <summary>
+        /// Update the visual state based on movement velocity.
+        /// </summary>
+        public void UpdateVisuals(Vector2 velocity)
+        {
+            _currentlyMoving = velocity.sqrMagnitude > 0.0001f;
+
+            if (_currentlyMoving)
+            {
+                if (Mathf.Abs(velocity.x) > Mathf.Abs(velocity.y))
+                    _currentDir = velocity.x < 0f ? 1 : 2; // Left : Right
+                else
+                    _currentDir = velocity.y < 0f ? 0 : 3; // Down : Up
+            }
+
+            if (visualMode == VisualMode.Animator)
+            {
+                if (animator == null) return;
+                animator.SetBool(isMovingParam, _currentlyMoving);
+                if (_currentlyMoving)
+                    animator.SetInteger(dirParam, _currentDir);
+                return;
+            }
+
+            if (spriteRenderer == null) return;
+
+            float fps = Mathf.Max(0.01f, animationFPS);
+            _animClock += Time.fixedDeltaTime * fps;
+            int frames;
+            Sprite[] set = SelectSpriteSet(_currentlyMoving, _currentDir, out frames);
+
+            if (frames <= 0) return;
+
+            _animFrame = Mathf.FloorToInt(_animClock) % frames;
+            spriteRenderer.flipX = false;
+
+            if (useFlipXForLeft && _currentDir == 1)
+            {
+                Sprite[] rightSet = SelectSpriteSet(_currentlyMoving, 2, out frames);
+                if (frames > 0)
+                {
+                    _animFrame = Mathf.FloorToInt(_animClock) % frames;
+                    spriteRenderer.sprite = rightSet[_animFrame];
+                    spriteRenderer.flipX = true;
+                    return;
+                }
+            }
+
+            spriteRenderer.sprite = set[_animFrame];
+        }
+
+        private Sprite[] SelectSpriteSet(bool moving, int dir, out int frames)
+        {
+            Sprite[] set = null;
+
+            if (moving)
+            {
+                switch (dir)
+                {
+                    case 0: set = walkDown; break;
+                    case 1: set = useFlipXForLeft ? walkRight : walkLeft; break;
+                    case 2: set = walkRight; break;
+                    case 3: set = walkUp; break;
+                }
+            }
+            else
+            {
+                switch (dir)
+                {
+                    case 0: set = idleDown != null && idleDown.Length > 0 ? idleDown : (walkDown ?? idleDown); break;
+                    case 1:
+                        set = useFlipXForLeft
+                            ? (idleRight != null && idleRight.Length > 0 ? idleRight : walkRight)
+                            : (idleLeft != null && idleLeft.Length > 0 ? idleLeft : walkLeft);
+                        break;
+                    case 2: set = idleRight != null && idleRight.Length > 0 ? idleRight : (walkRight ?? idleRight); break;
+                    case 3: set = idleUp != null && idleUp.Length > 0 ? idleUp : (walkUp ?? idleUp); break;
+                }
+            }
+
+            if (set == null || set.Length == 0)
+            {
+                if (!moving)
+                {
+                    if (idleDown != null && idleDown.Length > 0) { frames = idleDown.Length; return idleDown; }
+                    if (walkDown != null && walkDown.Length > 0) { frames = walkDown.Length; return walkDown; }
+                }
+                else
+                {
+                    if (walkRight != null && walkRight.Length > 0) { frames = walkRight.Length; return walkRight; }
+                    if (walkDown != null && walkDown.Length > 0) { frames = walkDown.Length; return walkDown; }
+                }
+            }
+
+            frames = set != null ? set.Length : 0;
+            return set ?? System.Array.Empty<Sprite>();
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `NpcSpriteAnimator` component to centralize sprite animation logic
- hook `NpcRandomMovement` and `NpcPathFollower` into the shared animator

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f6c427f8832e99aa7dab0e4c1dcf