### PR TITLE
Use ShopUI singleton instead of FindObjectOfType

### DIFF
--- a/Assets/Scripts/NPC/NPCInteractable.cs
+++ b/Assets/Scripts/NPC/NPCInteractable.cs
@@ -47,7 +47,7 @@ namespace NPC
         public void OpenShop()
         {
             if (shop == null) return;
-            var ui = FindObjectOfType<ShopSystem.ShopUI>();
+            var ui = ShopUI.Instance;
             if (ui != null)
             {
                 ui.Open(shop, GetComponent<NpcRandomMovement>());


### PR DESCRIPTION
## Summary
- Replace FindObjectOfType call in NPCInteractable with ShopUI.Instance
- Utilize ShopUI's static Instance property for easier access

## Testing
- `dotnet test` *(fails: project or solution file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fa2adcd4832ebc6c1b0b94ac33dc