### PR TITLE
Add runtime mining skill UI

### DIFF
--- a/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
@@ -35,6 +35,7 @@ namespace Skills.Mining
         public event System.Action<int> OnLevelUp;
 
         public int Level => level;
+        public int Xp => xp;
         public bool IsMining => currentRock != null;
         public MineableRock CurrentRock => currentRock;
         public int CurrentSwingSpeedTicks => currentPickaxe?.SwingSpeedTicks ?? 0;

--- a/Assets/Scripts/Skills/SkillsUI.cs
+++ b/Assets/Scripts/Skills/SkillsUI.cs
@@ -1,0 +1,77 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Skills
+{
+    /// <summary>
+    /// Displays basic skill information. Currently shows the mining level and XP
+    /// and can be toggled with the 'O' key.
+    /// </summary>
+    public class SkillsUI : MonoBehaviour
+    {
+        private GameObject uiRoot;
+        private Text miningText;
+        private Mining.MiningSkill miningSkill;
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void CreateInstance()
+        {
+            var go = new GameObject("SkillsUI");
+            DontDestroyOnLoad(go);
+            go.AddComponent<SkillsUI>();
+        }
+
+        private void Awake()
+        {
+            miningSkill = FindObjectOfType<Mining.MiningSkill>();
+            CreateUI();
+            if (uiRoot != null)
+                uiRoot.SetActive(false);
+        }
+
+        private void CreateUI()
+        {
+            uiRoot = new GameObject("SkillsUIRoot");
+            uiRoot.transform.SetParent(transform, false);
+
+            var canvas = uiRoot.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            uiRoot.AddComponent<CanvasScaler>();
+            uiRoot.AddComponent<GraphicRaycaster>();
+
+            var panel = new GameObject("Panel");
+            panel.transform.SetParent(uiRoot.transform, false);
+            var panelImage = panel.AddComponent<Image>();
+            panelImage.color = new Color(0f, 0f, 0f, 0.5f);
+            var panelRect = panel.GetComponent<RectTransform>();
+            panelRect.sizeDelta = new Vector2(200f, 60f);
+            panelRect.anchoredPosition = Vector2.zero;
+
+            var textGo = new GameObject("MiningText");
+            textGo.transform.SetParent(panel.transform, false);
+            miningText = textGo.AddComponent<Text>();
+            miningText.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+            miningText.alignment = TextAnchor.MiddleCenter;
+            miningText.color = Color.white;
+            var textRect = miningText.rectTransform;
+            textRect.anchorMin = Vector2.zero;
+            textRect.anchorMax = Vector2.one;
+            textRect.offsetMin = Vector2.zero;
+            textRect.offsetMax = Vector2.zero;
+        }
+
+        private void Update()
+        {
+            if (Input.GetKeyDown(KeyCode.O))
+            {
+                if (uiRoot != null)
+                    uiRoot.SetActive(!uiRoot.activeSelf);
+            }
+
+            if (uiRoot != null && uiRoot.activeSelf && miningSkill != null)
+            {
+                miningText.text = $"Mining Level: {miningSkill.Level}  XP: {miningSkill.Xp}";
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Skills/SkillsUI.cs.meta
+++ b/Assets/Scripts/Skills/SkillsUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d83d1dff09fa4f3c85c75e9efb0a4df5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- expose mining XP via public property
- introduce runtime skills UI toggled with **O** key showing mining level and XP

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a1019215d8832eaf30eff4c4520293