### PR TITLE
Prevent mining crash when floating text anchor destroyed

### DIFF
--- a/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
@@ -144,20 +144,24 @@ namespace Skills.Mining
                     if (item != null && inventory != null)
                         added = inventory.AddItem(item);
 
+                    Vector3 anchorPos = floatingTextAnchor != null
+                        ? floatingTextAnchor.position
+                        : transform.position;
+
                     if (!added)
                     {
-                        FloatingText.Show("Inventory is full", floatingTextAnchor.position);
+                        FloatingText.Show("Inventory is full", anchorPos);
                     }
                     else
                     {
-                        FloatingText.Show($"+1 {ore.DisplayName}", floatingTextAnchor.position);
                         xp += ore.XpPerOre;
+                        FloatingText.Show($"+1 {ore.DisplayName}", anchorPos);
                         OnOreGained?.Invoke(ore.Id, 1);
                         int newLevel = xpTable.GetLevel(xp);
                         if (newLevel > level)
                         {
                             level = newLevel;
-                            FloatingText.Show($"Mining level {level}", floatingTextAnchor.position);
+                            FloatingText.Show($"Mining level {level}", anchorPos);
                             OnLevelUp?.Invoke(level);
                         }
                     }


### PR DESCRIPTION
## Summary
- Guard against missing floating text anchor so mining XP is still applied

## Testing
- `mcs Assets/Scripts/Skills/Mining/Core/MiningSkill.cs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a106712180832ea6dd9e83b5ecd4b4