### PR TITLE
Fix mining XP not increasing when inventory is full

### DIFF
--- a/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
@@ -148,22 +148,26 @@ namespace Skills.Mining
                         ? floatingTextAnchor.position
                         : transform.position;
 
+                    // Award XP regardless of inventory space so players always
+                    // progress their skill when successfully mining.
+                    xp += ore.XpPerOre;
+
                     if (!added)
                     {
                         FloatingText.Show("Inventory is full", anchorPos);
                     }
                     else
                     {
-                        xp += ore.XpPerOre;
                         FloatingText.Show($"+1 {ore.DisplayName}", anchorPos);
                         OnOreGained?.Invoke(ore.Id, 1);
-                        int newLevel = xpTable.GetLevel(xp);
-                        if (newLevel > level)
-                        {
-                            level = newLevel;
-                            FloatingText.Show($"Mining level {level}", anchorPos);
-                            OnLevelUp?.Invoke(level);
-                        }
+                    }
+
+                    int newLevel = xpTable.GetLevel(xp);
+                    if (newLevel > level)
+                    {
+                        level = newLevel;
+                        FloatingText.Show($"Mining level {level}", anchorPos);
+                        OnLevelUp?.Invoke(level);
                     }
                 }
 


### PR DESCRIPTION
## Summary
- Always award mining XP after successfully mining a rock, even if the ore can't be added to the inventory

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a1086c5b00832ebf8991fd413ac502