### PR TITLE
Ensure UI windows close when incompatible

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -8,6 +8,7 @@ using UnityEngine.InputSystem;
 #endif
 using ShopSystem;
 using Player;
+using Skills;
 
 namespace Inventory
 {
@@ -98,7 +99,15 @@ namespace Inventory
 
         public event Action OnInventoryChanged;
 
+        public bool IsOpen => uiRoot != null && uiRoot.activeSelf;
+
         private bool CanDropItems => playerMover == null || playerMover.CanDrop;
+
+        public void CloseUI()
+        {
+            if (uiRoot != null)
+                uiRoot.SetActive(false);
+        }
 
         private void Awake()
         {
@@ -839,7 +848,15 @@ namespace Inventory
                 return;
             }
             if (toggle && uiRoot != null)
+            {
+                if (!uiRoot.activeSelf)
+                {
+                    var skills = SkillsUI.Instance;
+                    if (skills != null && skills.IsOpen)
+                        skills.Close();
+                }
                 uiRoot.SetActive(!uiRoot.activeSelf);
+            }
         }
 
         /// <summary>

--- a/Assets/Scripts/Shop/ShopUI.cs
+++ b/Assets/Scripts/Shop/ShopUI.cs
@@ -3,6 +3,7 @@ using UnityEngine.UI;
 using UnityEngine.EventSystems;
 using Inventory;
 using Player;
+using Skills;
 using NPC;
 
 namespace ShopSystem
@@ -46,6 +47,8 @@ namespace ShopSystem
         private static ShopUI instance;
         public static ShopUI Instance => instance;
 
+        public bool IsOpen => uiRoot != null && uiRoot.activeSelf;
+
         private void Awake()
         {
             if (instance != null && instance != this)
@@ -84,6 +87,9 @@ namespace ShopSystem
             if (shop == null) return;
             currentShop = shop;
             Refresh();
+            var skills = SkillsUI.Instance;
+            if (skills != null && skills.IsOpen)
+                skills.Close();
             uiRoot.SetActive(true);
             if (playerInventory != null)
             {
@@ -115,6 +121,7 @@ namespace ShopSystem
             {
                 playerInventory.OnInventoryChanged -= HandleInventoryChanged;
                 playerInventory.SetShopContext(null);
+                playerInventory.CloseUI();
             }
             if (playerMover != null)
             {


### PR DESCRIPTION
## Summary
- close inventory automatically when closing shop
- prevent skills UI from clashing with shop or inventory windows
- close skills or inventory UI when opening another UI type

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a110c58448832e9012adaf843bd4d8