### PR TITLE
Allow selling items with full inventory

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -528,6 +528,29 @@ namespace Inventory
         }
 
         /// <summary>
+        /// Replaces the item at <paramref name="slotIndex"/> with
+        /// <paramref name="newItem"/> and sets its count. The slot must
+        /// currently contain <paramref name="oldItem"/>. Returns true on
+        /// success.
+        /// </summary>
+        public bool ReplaceItem(int slotIndex, ItemData oldItem, ItemData newItem, int newCount)
+        {
+            if (slotIndex < 0 || slotIndex >= items.Length)
+                return false;
+
+            var entry = items[slotIndex];
+            if (entry.item != oldItem)
+                return false;
+
+            entry.item = newItem;
+            entry.count = newCount;
+            items[slotIndex] = entry;
+            UpdateSlotVisual(slotIndex);
+            OnInventoryChanged?.Invoke();
+            return true;
+        }
+
+        /// <summary>
         /// Drops a quantity of the item from the specified slot.
         /// </summary>
         public void DropItem(int slotIndex, int quantity = 1)
@@ -659,14 +682,14 @@ namespace Inventory
                 return;
             if (slotIndex < 0 || slotIndex >= items.Length)
                 return;
-            var item = items[slotIndex].item;
-            if (item == null)
-                return;
-
             int sold = 0;
             for (int i = 0; i < quantity; i++)
             {
-                if (currentShop.Sell(item, this))
+                var item = items[slotIndex].item;
+                if (item == null)
+                    break;
+
+                if (currentShop.Sell(item, this, slotIndex))
                     sold++;
                 else
                     break;


### PR DESCRIPTION
## Summary
- Allow shops to sell items to the player even when their inventory is full by replacing the sold item with coins
- Add inventory utility to replace an item in a specific slot
- Update selling logic to support slot-based replacements

## Testing
- `dotnet build` *(fails: Specify a project or solution file. The current working directory does not contain a project or solution file.)*


------
https://chatgpt.com/codex/tasks/task_e_68a113cd6ebc832ea8eaa6e0447b4147