### PR TITLE
fix: revert SaveManager to synchronous loading

### DIFF
--- a/Assets/Scripts/Core/Save/SaveManager.cs
+++ b/Assets/Scripts/Core/Save/SaveManager.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Threading.Tasks;
 using UnityEngine;
 
 namespace Core.Save
@@ -37,7 +36,7 @@ namespace Core.Save
 
         private static SaveData cache;
 
-        private static async Task<SaveData> LoadAll()
+        private static SaveData LoadAll()
         {
             if (cache != null)
                 return cache;
@@ -46,7 +45,7 @@ namespace Core.Save
             {
                 try
                 {
-                    string json = await File.ReadAllTextAsync(FilePath);
+                    string json = File.ReadAllText(FilePath);
                     cache = JsonUtility.FromJson<SaveData>(json);
                 }
                 catch (Exception e)
@@ -63,12 +62,12 @@ namespace Core.Save
             return cache;
         }
 
-        private static async Task SaveAll()
+        private static void SaveAll()
         {
             try
             {
                 string json = JsonUtility.ToJson(cache);
-                await File.WriteAllTextAsync(FilePath, json);
+                File.WriteAllText(FilePath, json);
             }
             catch (Exception e)
             {
@@ -76,9 +75,9 @@ namespace Core.Save
             }
         }
 
-        public static async Task SaveAsync<T>(string key, T data)
+        public static void Save<T>(string key, T data)
         {
-            var all = await LoadAll();
+            var all = LoadAll();
             string json = JsonUtility.ToJson(new Wrapper<T> { value = data });
             var entry = all.entries.Find(e => e.key == key);
             if (entry != null)
@@ -86,17 +85,12 @@ namespace Core.Save
             else
                 all.entries.Add(new Entry { key = key, value = json });
 
-            await SaveAll();
+            SaveAll();
         }
 
-        public static void Save<T>(string key, T data)
+        public static T Load<T>(string key)
         {
-            SaveAsync<T>(key, data).GetAwaiter().GetResult();
-        }
-
-        public static async Task<T> LoadAsync<T>(string key)
-        {
-            var all = await LoadAll();
+            var all = LoadAll();
             var entry = all.entries.Find(e => e.key == key);
             if (entry == null || string.IsNullOrEmpty(entry.value))
                 return default;
@@ -112,16 +106,11 @@ namespace Core.Save
             }
         }
 
-        public static T Load<T>(string key)
-        {
-            return LoadAsync<T>(key).GetAwaiter().GetResult();
-        }
-
         public static void Delete(string key)
         {
-            var all = LoadAll().GetAwaiter().GetResult();
+            var all = LoadAll();
             all.entries.RemoveAll(e => e.key == key);
-            SaveAll().GetAwaiter().GetResult();
+            SaveAll();
         }
     }
 }


### PR DESCRIPTION
## Summary
- revert SaveManager to synchronous file operations and remove async usage

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68a124e95248832e958feb3505c2d03a