### PR TITLE
feat: add GameManager singleton for global services

### DIFF
--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -1,0 +1,61 @@
+using System;
+using UnityEngine;
+using Util;
+using World;
+using Inventory;
+
+namespace Core
+{
+    /// <summary>
+    /// Central bootstrapper that persists across scenes and exposes global services.
+    /// </summary>
+    public class GameManager : MonoBehaviour
+    {
+        public static GameManager Instance { get; private set; }
+
+        private Ticker ticker;
+        private ScreenFader screenFader;
+        private ItemDatabase itemDatabase;
+
+        /// <summary>
+        /// Event fired once all services are initialized.
+        /// </summary>
+        public static event Action ServicesReady;
+
+        public static Ticker Ticker => Instance.ticker;
+        public static ScreenFader ScreenFader => Instance.screenFader;
+        public static ItemDatabase ItemDatabase => Instance.itemDatabase;
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+
+            ticker = FindOrCreate<Ticker>();
+            screenFader = FindOrCreate<ScreenFader>();
+            itemDatabase = FindOrCreate<ItemDatabase>();
+
+            ServicesReady?.Invoke();
+        }
+
+        /// <summary>
+        /// Finds an existing service of type <typeparamref name="T"/> or creates a new one.
+        /// </summary>
+        private static T FindOrCreate<T>() where T : Component
+        {
+            var service = FindObjectOfType<T>();
+            if (service == null)
+            {
+                var go = new GameObject(typeof(T).Name);
+                service = go.AddComponent<T>();
+            }
+            return service;
+        }
+    }
+}

--- a/Assets/Scripts/Core/GameManager.cs.meta
+++ b/Assets/Scripts/Core/GameManager.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 90bc5f973cd14884beff3967ea2e0eb5
+timeCreated: 1755390556


### PR DESCRIPTION
## Summary
- add a persistent GameManager singleton
- initialize Ticker, ScreenFader, ItemDatabase, and expose them via getters

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a121e7cdd0832eae258ba4928c916d