### PR TITLE
Use cached item database for inventory loading

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -828,7 +828,7 @@ namespace Inventory
                 var slot = data.slots[i];
                 if (!string.IsNullOrEmpty(slot.id))
                 {
-                    var item = Resources.Load<ItemData>("Item/" + slot.id);
+                    var item = ItemDatabase.GetItem(slot.id);
                     items[i].item = item;
                     items[i].count = slot.count;
                 }

--- a/Assets/Scripts/Inventory/ItemDatabase.cs
+++ b/Assets/Scripts/Inventory/ItemDatabase.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Inventory
+{
+    /// <summary>
+    /// Loads all <see cref="ItemData"/> assets at startup and provides
+    /// fast lookup by item id.
+    /// </summary>
+    public class ItemDatabase : MonoBehaviour
+    {
+        private static ItemDatabase instance;
+        private readonly Dictionary<string, ItemData> items = new();
+
+        /// <summary>
+        /// Retrieve an item by its unique identifier.
+        /// </summary>
+        public static ItemData GetItem(string id)
+        {
+            if (instance == null)
+            {
+                Debug.LogError("ItemDatabase has not been initialized.");
+                return null;
+            }
+
+            instance.items.TryGetValue(id, out var item);
+            return item;
+        }
+
+        private void Awake()
+        {
+            if (instance != null && instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            instance = this;
+            DontDestroyOnLoad(gameObject);
+
+            var loadedItems = Resources.LoadAll<ItemData>("Item");
+            foreach (var item in loadedItems)
+            {
+                if (!string.IsNullOrEmpty(item.id))
+                    items[item.id] = item;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ItemDatabase` singleton that preloads all `ItemData` assets for quick lookup
- use `ItemDatabase.GetItem` in `Inventory.Load` instead of `Resources.Load`

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a1285c87c8832eb396073007b9c539