### PR TITLE
Add inventory input toggle and ensure player has required components

### DIFF
--- a/Assets/Scripts/Inventory/InventoryInput.cs
+++ b/Assets/Scripts/Inventory/InventoryInput.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+
+namespace Inventory
+{
+    /// <summary>
+    /// Handles input for toggling the inventory UI.
+    /// </summary>
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(InventoryModel), typeof(InventoryUI), typeof(InventoryDragHandler), typeof(InventoryTooltip))]
+    public class InventoryInput : MonoBehaviour
+    {
+        private InventoryUI ui;
+
+        private void Awake()
+        {
+            ui = GetComponent<InventoryUI>();
+        }
+
+        private void Update()
+        {
+            if (Input.GetKeyDown(KeyCode.I))
+            {
+                if (ui.IsOpen)
+                    ui.CloseUI();
+                else
+                    ui.OpenUI();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -10,6 +10,7 @@ namespace Player
     [RequireComponent(typeof(Rigidbody2D))]
     [RequireComponent(typeof(Animator))]
     [RequireComponent(typeof(SpriteRenderer))]
+    [RequireComponent(typeof(Inventory.InventoryInput))]
     public class PlayerMover : MonoBehaviour
     {
         [Header("Movement")]


### PR DESCRIPTION
## Summary
- Add `InventoryInput` component to toggle inventory UI with the **I** key
- Require inventory input on `PlayerMover` so player includes all inventory components

## Testing
- `dotnet test` *(fails: MSB1003 - no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a1308dcb6c832e8f9578b9c515235b