### PR TITLE
Ensure bank slot icons display correctly

### DIFF
--- a/Assets/Scripts/Bank/BankUI.cs
+++ b/Assets/Scripts/Bank/BankUI.cs
@@ -225,19 +225,30 @@ namespace BankSystem
         private void UpdateSlotVisual(int index)
         {
             var entry = items[index];
-            if (entry.item != null)
+            bool hasItem = entry.item != null;
+
+            // Ensure the slot image component is always enabled so changes to
+            // the sprite or colour are visible after loading/saving.
+            var image = slotImages[index];
+            image.enabled = true;
+
+            if (hasItem)
             {
-                slotImages[index].sprite = entry.item.icon;
-                slotImages[index].type = Image.Type.Simple;
-                slotImages[index].color = Color.white;
+                image.sprite = entry.item.icon;
+                image.type = Image.Type.Simple;
+                image.color = Color.white;
+
                 slotCountTexts[index].text = entry.count > 1 ? entry.count.ToString() : string.Empty;
+                slotCountTexts[index].enabled = entry.count > 1;
             }
             else
             {
-                slotImages[index].sprite = null;
-                slotImages[index].type = Image.Type.Simple;
-                slotImages[index].color = emptySlotColor;
+                image.sprite = null;
+                image.type = Image.Type.Simple;
+                image.color = emptySlotColor;
+
                 slotCountTexts[index].text = string.Empty;
+                slotCountTexts[index].enabled = false;
             }
         }
 


### PR DESCRIPTION
## Summary
- always enable bank slot image and count UI when updating visuals
- hide count text when not needed to avoid invisible slots

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a196ce0ea4832e873912e35f131259