### PR TITLE
Adjust bank UI width and scrollbar color

### DIFF
--- a/Assets/Scripts/Bank/BankUI.cs
+++ b/Assets/Scripts/Bank/BankUI.cs
@@ -94,7 +94,7 @@ namespace BankSystem
             windowRect.anchorMax = new Vector2(0.5f, 0.5f);
             windowRect.pivot = new Vector2(0.5f, 0.5f);
             windowRect.anchoredPosition = Vector2.zero;
-            float width = Columns * slotSize.x + (Columns - 1) * slotSpacing.x + windowPadding.x * 2f;
+            float width = Columns * slotSize.x + (Columns - 1) * slotSpacing.x + windowPadding.x * 2f + 20f;
             float visibleRows = 8f;
             float height = visibleRows * slotSize.y + (visibleRows - 1f) * slotSpacing.y + windowPadding.y * 2f + headerHeight;
             windowRect.sizeDelta = new Vector2(width, height);
@@ -194,7 +194,7 @@ namespace BankSystem
             GameObject handleGO = new GameObject("Handle", typeof(Image));
             handleGO.transform.SetParent(scrollbarGO.transform, false);
             var handleImg = handleGO.GetComponent<Image>();
-            handleImg.color = Color.white;
+            handleImg.color = new Color(0.8f, 0.8f, 0.8f, 1f);
             var handleRect = handleGO.GetComponent<RectTransform>();
             handleRect.anchorMin = Vector2.zero;
             handleRect.anchorMax = Vector2.one;


### PR DESCRIPTION
## Summary
- widen bank UI window by 20 units for extra space
- use light grey instead of white for scrollbar handle

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a1bcf174832e9fc5c56bbf282a31