### PR TITLE
Darken bank scrollbar and inventory slot

### DIFF
--- a/Assets/Scripts/Bank/BankUI.cs
+++ b/Assets/Scripts/Bank/BankUI.cs
@@ -194,7 +194,7 @@ namespace BankSystem
             GameObject handleGO = new GameObject("Handle", typeof(Image));
             handleGO.transform.SetParent(scrollbarGO.transform, false);
             var handleImg = handleGO.GetComponent<Image>();
-            handleImg.color = new Color(0.8f, 0.8f, 0.8f, 1f);
+            handleImg.color = new Color(0.3f, 0.3f, 0.3f, 1f);
             var handleRect = handleGO.GetComponent<RectTransform>();
             handleRect.anchorMin = Vector2.zero;
             handleRect.anchorMax = Vector2.one;

--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -54,7 +54,7 @@ namespace Inventory
         [Tooltip("Optional: frame sprite (9-sliced) to draw for each slot.")]
         public Sprite slotFrameSprite;
         [Tooltip("Color/tint for empty slots if no frame sprite, or tint over the frame.")]
-        public Color emptySlotColor = new Color(1f, 1f, 1f, 0.25f); // light translucent
+        public Color emptySlotColor = new Color(0f, 0f, 0f, 1f); // solid black
 
         [Header("Window")]
         [Tooltip("Background color for the inventory window.")]


### PR DESCRIPTION
## Summary
- darken the bank UI scrollbar handle for better contrast
- set inventory empty slot color to solid black (0,0,0,1)

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a3b27e64832ea3a7d644f3c6265f