### PR TITLE
Add bank slot tooltip and drag features

### DIFF
--- a/Assets/Scripts/Bank/BankSlot.cs
+++ b/Assets/Scripts/Bank/BankSlot.cs
@@ -4,17 +4,55 @@ using UnityEngine.EventSystems;
 namespace BankSystem
 {
     /// <summary>
-    /// Handles click events for bank slots to withdraw items.
+    /// Handles pointer events for bank slots including clicks, hover tooltips
+    /// and drag-and-drop reordering of items inside the bank.
     /// </summary>
-    public class BankSlot : MonoBehaviour, IPointerClickHandler
+    public class BankSlot : MonoBehaviour,
+        IPointerClickHandler,
+        IPointerEnterHandler,
+        IPointerExitHandler,
+        IBeginDragHandler,
+        IDragHandler,
+        IEndDragHandler,
+        IDropHandler
     {
         [HideInInspector] public BankUI bank;
         [HideInInspector] public int index;
 
         public void OnPointerClick(PointerEventData eventData)
         {
-            if (eventData.button == PointerEventData.InputButton.Left)
+            if (eventData.button == PointerEventData.InputButton.Left && !eventData.dragging)
                 bank?.Withdraw(index);
+        }
+
+        public void OnPointerEnter(PointerEventData eventData)
+        {
+            bank?.ShowTooltip(index, transform as RectTransform);
+        }
+
+        public void OnPointerExit(PointerEventData eventData)
+        {
+            bank?.HideTooltip();
+        }
+
+        public void OnBeginDrag(PointerEventData eventData)
+        {
+            bank?.BeginDrag(index);
+        }
+
+        public void OnDrag(PointerEventData eventData)
+        {
+            bank?.Drag(eventData);
+        }
+
+        public void OnEndDrag(PointerEventData eventData)
+        {
+            bank?.EndDrag();
+        }
+
+        public void OnDrop(PointerEventData eventData)
+        {
+            bank?.Drop(index);
         }
     }
 }

--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -690,6 +690,21 @@ namespace Inventory
             tooltip.SetActive(true);
         }
 
+        public void ShowTooltip(ItemData item, RectTransform slotRect)
+        {
+            if (item == null || tooltip == null || tooltipNameText == null || tooltipDescriptionText == null) return;
+
+            string name = !string.IsNullOrEmpty(item.itemName) ? item.itemName : item.name;
+            tooltipNameText.text = name;
+            tooltipDescriptionText.text = item.description;
+
+            var tooltipRect = tooltip.GetComponent<RectTransform>();
+            LayoutRebuilder.ForceRebuildLayoutImmediate(tooltipRect);
+
+            tooltip.transform.position = slotRect.position + new Vector3(slotSize.x, 0f, 0f);
+            tooltip.SetActive(true);
+        }
+
         public void HideTooltip()
         {
             if (tooltip != null)


### PR DESCRIPTION
## Summary
- show item tooltips on bank slots
- enable dragging within the bank interface
- close inventory UI when the bank window closes

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ac976b30832eaed41ecf54ec0977