### PR TITLE
Fix tooltip rendering behind bank interface

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -308,6 +308,13 @@ namespace Inventory
             // Tooltip setup
             tooltip = new GameObject("Tooltip", typeof(Image), typeof(VerticalLayoutGroup), typeof(ContentSizeFitter));
             tooltip.transform.SetParent(uiRoot.transform, false);
+
+            // Ensure the tooltip is rendered above other interfaces like the bank
+            var tooltipCanvas = tooltip.AddComponent<Canvas>();
+            tooltipCanvas.overrideSorting = true;
+            tooltipCanvas.sortingOrder = 1000;
+            tooltip.AddComponent<GraphicRaycaster>();
+
             var bg = tooltip.GetComponent<Image>();
             bg.color = new Color(0f, 0f, 0f, 0.75f);
             bg.raycastTarget = false;


### PR DESCRIPTION
## Summary
- ensure inventory tooltip renders on top by giving it its own canvas with high sorting order

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a1af4bbc1c832e947d71988f042210