### PR TITLE
feat: add bank withdrawal options

### DIFF
--- a/Assets/Scripts/Bank/BankSlot.cs
+++ b/Assets/Scripts/Bank/BankSlot.cs
@@ -23,6 +23,8 @@ namespace BankSystem
         {
             if (eventData.button == PointerEventData.InputButton.Left && !eventData.dragging)
                 bank?.Withdraw(index);
+            else if (eventData.button == PointerEventData.InputButton.Right && !eventData.dragging)
+                bank?.ShowWithdrawMenu(index, eventData.position);
         }
 
         public void OnPointerEnter(PointerEventData eventData)

--- a/Assets/Scripts/Bank/BankWithdrawMenu.cs
+++ b/Assets/Scripts/Bank/BankWithdrawMenu.cs
@@ -1,0 +1,93 @@
+using UnityEngine;
+using UnityEngine.UI;
+using UnityEngine.Events;
+
+namespace BankSystem
+{
+    /// <summary>
+    /// Simple right-click context menu for bank withdrawal options.
+    /// Built entirely in code so no prefab is needed.
+    /// </summary>
+    public class BankWithdrawMenu : MonoBehaviour
+    {
+        private BankUI bank;
+        private int slotIndex;
+        private Font font;
+
+        public static BankWithdrawMenu Create(Transform parent, Font font)
+        {
+            var go = new GameObject("BankWithdrawMenu", typeof(Image), typeof(BankWithdrawMenu));
+            go.transform.SetParent(parent, false);
+            var menu = go.GetComponent<BankWithdrawMenu>();
+            menu.font = font;
+            menu.BuildUI();
+            go.SetActive(false);
+            return menu;
+        }
+
+        private void BuildUI()
+        {
+            var bg = GetComponent<Image>();
+            bg.color = new Color(0f, 0f, 0f, 0.9f);
+            var rect = GetComponent<RectTransform>();
+            rect.pivot = new Vector2(0f, 1f);
+
+            var layout = gameObject.AddComponent<VerticalLayoutGroup>();
+            layout.childAlignment = TextAnchor.UpperLeft;
+            layout.childControlWidth = true;
+            layout.childControlHeight = true;
+            layout.childForceExpandHeight = false;
+            layout.childForceExpandWidth = true;
+            layout.spacing = 2f;
+            layout.padding = new RectOffset(2, 2, 2, 2);
+
+            CreateButton("Withdraw 1", () => { bank?.Withdraw(slotIndex, 1); Hide(); });
+            CreateButton("Withdraw 5", () => { bank?.Withdraw(slotIndex, 5); Hide(); });
+            CreateButton("Withdraw 10", () => { bank?.Withdraw(slotIndex, 10); Hide(); });
+            CreateButton("Withdraw X", () => { bank?.PromptWithdrawAmount(slotIndex); Hide(); });
+        }
+
+        private void CreateButton(string label, UnityAction onClick)
+        {
+            var btnGO = new GameObject(label, typeof(Image), typeof(Button));
+            btnGO.transform.SetParent(transform, false);
+            var img = btnGO.GetComponent<Image>();
+            img.color = Color.white;
+            var btn = btnGO.GetComponent<Button>();
+            btn.onClick.AddListener(onClick);
+
+            var txtGO = new GameObject("Text", typeof(Text));
+            txtGO.transform.SetParent(btnGO.transform, false);
+            var txt = txtGO.GetComponent<Text>();
+            txt.font = font;
+            txt.alignment = TextAnchor.MiddleLeft;
+            txt.color = Color.black;
+            txt.text = label;
+
+            var rect = btnGO.GetComponent<RectTransform>();
+            rect.sizeDelta = new Vector2(100f, 20f);
+            rect.pivot = new Vector2(0f, 1f);
+
+            var txtRect = txtGO.GetComponent<RectTransform>();
+            txtRect.anchorMin = Vector2.zero;
+            txtRect.anchorMax = Vector2.one;
+            txtRect.offsetMin = Vector2.zero;
+            txtRect.offsetMax = Vector2.zero;
+        }
+
+        public void Show(BankUI bank, int index, Vector2 position)
+        {
+            this.bank = bank;
+            slotIndex = index;
+            transform.position = position;
+            gameObject.SetActive(true);
+            transform.SetAsLastSibling();
+        }
+
+        public void Hide()
+        {
+            gameObject.SetActive(false);
+            bank = null;
+        }
+    }
+}

--- a/Assets/Scripts/Bank/BankWithdrawMenu.cs.meta
+++ b/Assets/Scripts/Bank/BankWithdrawMenu.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 2b83a9f8cbea4b2fb9e69a8b8199d636
+timeCreated: 1735689600


### PR DESCRIPTION
## Summary
- left-click withdraws a single item from bank
- add right-click menu for withdrawing 1, 5, 10 or a custom amount
- verify inventory capacity before withdrawing

## Testing
- `dotnet test` *(fails: MSB1003 - no project or solution file found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b1f51608832eb3af5f63561395d2