### PR TITLE
Style bank withdraw buttons with transparent sprite

### DIFF
--- a/Assets/Scripts/Bank/BankWithdrawMenu.cs
+++ b/Assets/Scripts/Bank/BankWithdrawMenu.cs
@@ -52,7 +52,8 @@ namespace BankSystem
             var btnGO = new GameObject(label, typeof(Image), typeof(Button));
             btnGO.transform.SetParent(transform, false);
             var img = btnGO.GetComponent<Image>();
-            img.color = Color.white;
+            img.sprite = Resources.Load<Sprite>("Sprites/BankUI/Button_1");
+            img.color = new Color(0f, 0f, 0f, 0f);
             var btn = btnGO.GetComponent<Button>();
             btn.onClick.AddListener(onClick);
 
@@ -61,7 +62,7 @@ namespace BankSystem
             var txt = txtGO.GetComponent<Text>();
             txt.font = font;
             txt.alignment = TextAnchor.MiddleLeft;
-            txt.color = Color.black;
+            txt.color = Color.white;
             txt.text = label;
 
             var rect = btnGO.GetComponent<RectTransform>();


### PR DESCRIPTION
## Summary
- Give withdraw menu buttons a `Button_1` sprite with transparent color
- Render withdraw menu button text in white

## Testing
- `dotnet test` *(fails: no project or solution file)*
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b93af7f4832e92a4565299b0c111