### PR TITLE
Add bank deposit context menu

### DIFF
--- a/Assets/Scripts/Bank/BankDepositMenu.cs
+++ b/Assets/Scripts/Bank/BankDepositMenu.cs
@@ -1,0 +1,94 @@
+using UnityEngine;
+using UnityEngine.UI;
+using UnityEngine.Events;
+
+namespace BankSystem
+{
+    /// <summary>
+    /// Simple right-click context menu for bank deposit options.
+    /// Built entirely in code so no prefab is needed.
+    /// </summary>
+    public class BankDepositMenu : MonoBehaviour
+    {
+        private BankUI bank;
+        private int slotIndex;
+        private Font font;
+
+        public static BankDepositMenu Create(Transform parent, Font font)
+        {
+            var go = new GameObject("BankDepositMenu", typeof(Image), typeof(BankDepositMenu));
+            go.transform.SetParent(parent, false);
+            var menu = go.GetComponent<BankDepositMenu>();
+            menu.font = font;
+            menu.BuildUI();
+            go.SetActive(false);
+            return menu;
+        }
+
+        private void BuildUI()
+        {
+            var bg = GetComponent<Image>();
+            bg.color = new Color(0f, 0f, 0f, 0.9f);
+            var rect = GetComponent<RectTransform>();
+            rect.pivot = new Vector2(0f, 1f);
+
+            var layout = gameObject.AddComponent<VerticalLayoutGroup>();
+            layout.childAlignment = TextAnchor.UpperLeft;
+            layout.childControlWidth = true;
+            layout.childControlHeight = true;
+            layout.childForceExpandHeight = false;
+            layout.childForceExpandWidth = true;
+            layout.spacing = 2f;
+            layout.padding = new RectOffset(2, 2, 2, 2);
+
+            CreateButton("Add 1", () => { bank?.DepositFromInventory(slotIndex, 1); Hide(); });
+            CreateButton("Add 5", () => { bank?.DepositFromInventory(slotIndex, 5); Hide(); });
+            CreateButton("Add 10", () => { bank?.DepositFromInventory(slotIndex, 10); Hide(); });
+            CreateButton("Add X", () => { bank?.PromptDepositAmount(slotIndex); Hide(); });
+        }
+
+        private void CreateButton(string label, UnityAction onClick)
+        {
+            var btnGO = new GameObject(label, typeof(Image), typeof(Button));
+            btnGO.transform.SetParent(transform, false);
+            var img = btnGO.GetComponent<Image>();
+            img.sprite = Resources.Load<Sprite>("Sprites/BankUI/Button_1");
+            img.color = new Color(0f, 0f, 0f, 0f);
+            var btn = btnGO.GetComponent<Button>();
+            btn.onClick.AddListener(onClick);
+
+            var txtGO = new GameObject("Text", typeof(Text));
+            txtGO.transform.SetParent(btnGO.transform, false);
+            var txt = txtGO.GetComponent<Text>();
+            txt.font = font;
+            txt.alignment = TextAnchor.MiddleLeft;
+            txt.color = Color.white;
+            txt.text = label;
+
+            var rect = btnGO.GetComponent<RectTransform>();
+            rect.sizeDelta = new Vector2(100f, 20f);
+            rect.pivot = new Vector2(0f, 1f);
+
+            var txtRect = txtGO.GetComponent<RectTransform>();
+            txtRect.anchorMin = Vector2.zero;
+            txtRect.anchorMax = Vector2.one;
+            txtRect.offsetMin = Vector2.zero;
+            txtRect.offsetMax = Vector2.zero;
+        }
+
+        public void Show(BankUI bank, int index, Vector2 position)
+        {
+            this.bank = bank;
+            slotIndex = index;
+            transform.position = position;
+            gameObject.SetActive(true);
+            transform.SetAsLastSibling();
+        }
+
+        public void Hide()
+        {
+            gameObject.SetActive(false);
+            bank = null;
+        }
+    }
+}

--- a/Assets/Scripts/Bank/BankDepositMenu.cs.meta
+++ b/Assets/Scripts/Bank/BankDepositMenu.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 580f937db3d14a71be985a3e3be70ca0
+timeCreated: 1735689600

--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -602,6 +602,25 @@ namespace Inventory
         }
 
         /// <summary>
+        /// Removes a quantity from the specified slot without dropping it in the world.
+        /// </summary>
+        public void RemoveFromSlot(int slotIndex, int quantity)
+        {
+            if (slotIndex < 0 || slotIndex >= items.Length) return;
+            var entry = items[slotIndex];
+            if (entry.item == null) return;
+
+            int remove = Mathf.Clamp(quantity, 1, entry.count);
+            entry.count -= remove;
+            if (entry.count <= 0)
+                entry.item = null;
+            items[slotIndex] = entry;
+            UpdateSlotVisual(slotIndex);
+            HideTooltip();
+            OnInventoryChanged?.Invoke();
+        }
+
+        /// <summary>
         /// Splits a stack within the inventory, moving <paramref name="quantity"/>
         /// items to a new slot if space is available.
         /// </summary>

--- a/Assets/Scripts/Inventory/InventorySlot.cs
+++ b/Assets/Scripts/Inventory/InventorySlot.cs
@@ -60,6 +60,8 @@ namespace Inventory
             {
                 if (eventData.button == PointerEventData.InputButton.Left)
                     BankSystem.BankUI.Instance?.DepositFromInventory(index);
+                else if (eventData.button == PointerEventData.InputButton.Right)
+                    BankSystem.BankUI.Instance?.ShowDepositMenu(index, eventData.position);
                 return;
             }
             bool shift = Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);


### PR DESCRIPTION
## Summary
- add BankDepositMenu for right-click Add options while banking
- support depositing specific quantities and prompting for custom amounts
- inventory slots open deposit menu and inventory can remove partial stacks

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c2ff519c832e828e4c4672ff1c82