### PR TITLE
Add bank filtering and sorting

### DIFF
--- a/Assets/Scripts/Bank/BankUI.cs
+++ b/Assets/Scripts/Bank/BankUI.cs
@@ -41,6 +41,9 @@ namespace BankSystem
         private GameObject draggingIcon;
         private int draggingIndex = -1;
 
+        private InputField searchInput;
+        private string currentFilter = string.Empty;
+
         private static BankUI instance;
         public static BankUI Instance => instance;
 
@@ -147,6 +150,73 @@ namespace BankSystem
             closeTextRect.anchorMax = Vector2.one;
             closeTextRect.offsetMin = Vector2.zero;
             closeTextRect.offsetMax = Vector2.zero;
+            float searchHeight = 20f;
+            float sortButtonWidth = 60f;
+            float filterSpacing = 4f;
+
+            GameObject sortBtnGO = new GameObject("SortButton", typeof(RectTransform), typeof(Image), typeof(Button));
+            sortBtnGO.transform.SetParent(window.transform, false);
+            var sortRect = sortBtnGO.GetComponent<RectTransform>();
+            sortRect.anchorMin = new Vector2(1f, 1f);
+            sortRect.anchorMax = new Vector2(1f, 1f);
+            sortRect.pivot = new Vector2(1f, 1f);
+            sortRect.sizeDelta = new Vector2(sortButtonWidth, searchHeight);
+            sortRect.anchoredPosition = new Vector2(-windowPadding.x, -headerHeight);
+            var sortImg = sortBtnGO.GetComponent<Image>();
+            sortImg.color = new Color(0.2f, 0.2f, 0.2f, 1f);
+            var sortBtn = sortBtnGO.GetComponent<Button>();
+            sortBtn.onClick.AddListener(SortByName);
+            GameObject sortTextGO = new GameObject("Text", typeof(Text));
+            sortTextGO.transform.SetParent(sortBtnGO.transform, false);
+            var sortText = sortTextGO.GetComponent<Text>();
+            sortText.font = defaultFont;
+            sortText.alignment = TextAnchor.MiddleCenter;
+            sortText.color = Color.white;
+            sortText.text = "A-Z";
+            var sortTextRect = sortTextGO.GetComponent<RectTransform>();
+            sortTextRect.anchorMin = Vector2.zero;
+            sortTextRect.anchorMax = Vector2.one;
+            sortTextRect.offsetMin = Vector2.zero;
+            sortTextRect.offsetMax = Vector2.zero;
+
+            GameObject searchGO = new GameObject("SearchField", typeof(RectTransform), typeof(Image), typeof(InputField));
+            searchGO.transform.SetParent(window.transform, false);
+            var searchRect = searchGO.GetComponent<RectTransform>();
+            searchRect.anchorMin = new Vector2(0f, 1f);
+            searchRect.anchorMax = new Vector2(1f, 1f);
+            searchRect.pivot = new Vector2(0f, 1f);
+            searchRect.offsetMin = new Vector2(windowPadding.x, -headerHeight - searchHeight);
+            searchRect.offsetMax = new Vector2(-windowPadding.x - sortButtonWidth - filterSpacing, -headerHeight);
+            var searchImg = searchGO.GetComponent<Image>();
+            searchImg.color = Color.white;
+            searchInput = searchGO.GetComponent<InputField>();
+            GameObject textGO = new GameObject("Text", typeof(Text));
+            textGO.transform.SetParent(searchGO.transform, false);
+            var text = textGO.GetComponent<Text>();
+            text.font = defaultFont;
+            text.alignment = TextAnchor.MiddleLeft;
+            text.color = Color.black;
+            var textRect = textGO.GetComponent<RectTransform>();
+            textRect.anchorMin = Vector2.zero;
+            textRect.anchorMax = Vector2.one;
+            textRect.offsetMin = new Vector2(5f, 0f);
+            textRect.offsetMax = new Vector2(-5f, 0f);
+            searchInput.textComponent = text;
+            GameObject placeholderGO = new GameObject("Placeholder", typeof(Text));
+            placeholderGO.transform.SetParent(searchGO.transform, false);
+            var placeholder = placeholderGO.GetComponent<Text>();
+            placeholder.font = defaultFont;
+            placeholder.alignment = TextAnchor.MiddleLeft;
+            placeholder.fontStyle = FontStyle.Italic;
+            placeholder.color = Color.gray;
+            placeholder.text = "Filter...";
+            var placeholderRect = placeholderGO.GetComponent<RectTransform>();
+            placeholderRect.anchorMin = Vector2.zero;
+            placeholderRect.anchorMax = Vector2.one;
+            placeholderRect.offsetMin = new Vector2(5f, 0f);
+            placeholderRect.offsetMax = new Vector2(-5f, 0f);
+            searchInput.placeholder = placeholder;
+            searchInput.onValueChanged.AddListener(FilterSlots);
 
             GameObject scrollGO = new GameObject("ScrollView", typeof(RectTransform), typeof(ScrollRect));
             scrollGO.transform.SetParent(window.transform, false);
@@ -156,7 +226,7 @@ namespace BankSystem
             scrollRect.anchorMax = new Vector2(1f, 1f);
             scrollRect.pivot = new Vector2(0.5f, 0.5f);
             scrollRect.offsetMin = new Vector2(windowPadding.x, windowPadding.y);
-            scrollRect.offsetMax = new Vector2(-windowPadding.x - scrollbarWidth, -windowPadding.y - headerHeight);
+            scrollRect.offsetMax = new Vector2(-windowPadding.x - scrollbarWidth, -windowPadding.y - headerHeight - searchHeight - filterSpacing);
 
             GameObject viewport = new GameObject("Viewport", typeof(RectTransform), typeof(Image), typeof(Mask));
             viewport.transform.SetParent(scrollGO.transform, false);
@@ -288,6 +358,48 @@ namespace BankSystem
                 slotCountTexts[index].text = string.Empty;
                 slotCountTexts[index].enabled = false;
             }
+
+            ApplyFilterToSlot(index);
+        }
+
+        private void FilterSlots(string filter)
+        {
+            currentFilter = filter ?? string.Empty;
+            UpdateFilteredSlots();
+        }
+
+        private void UpdateFilteredSlots()
+        {
+            for (int i = 0; i < items.Length; i++)
+                ApplyFilterToSlot(i);
+        }
+
+        private void ApplyFilterToSlot(int index)
+        {
+            if (slotImages == null || index < 0 || index >= slotImages.Length)
+                return;
+
+            var entry = items[index];
+            bool visible = string.IsNullOrEmpty(currentFilter) ||
+                           (entry.item != null &&
+                            entry.item.itemName != null &&
+                            entry.item.itemName.IndexOf(currentFilter, StringComparison.OrdinalIgnoreCase) >= 0);
+            slotImages[index].gameObject.SetActive(visible);
+        }
+
+        private void SortByName()
+        {
+            Array.Sort(items, (a, b) =>
+            {
+                string an = a.item != null ? a.item.itemName : string.Empty;
+                string bn = b.item != null ? b.item.itemName : string.Empty;
+                return string.Compare(an, bn, StringComparison.OrdinalIgnoreCase);
+            });
+
+            for (int i = 0; i < items.Length; i++)
+                UpdateSlotVisual(i);
+
+            UpdateFilteredSlots();
         }
 
         public void ShowTooltip(int bankIndex, RectTransform slotRect)
@@ -427,6 +539,11 @@ namespace BankSystem
             // Ensure latest saved state is loaded whenever the bank opens
             Load();
             uiRoot.SetActive(true);
+            if (searchInput != null)
+            {
+                searchInput.SetTextWithoutNotify(string.Empty);
+                FilterSlots(string.Empty);
+            }
         }
 
         public void Close()


### PR DESCRIPTION
## Summary
- add search input and sort button to bank UI
- allow filtering displayed slots as text is entered
- add A-Z sort to reorder bank items

## Testing
- `dotnet test` *(fails: project file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e9fbd710832e88de7c86ae9607fe