### PR TITLE
Spawn pets when dropping pet items with debug logs

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -10,6 +10,7 @@ using UnityEngine.InputSystem;
 using ShopSystem;
 using Player;
 using Skills;
+using Pets;
 
 namespace Inventory
 {
@@ -591,6 +592,9 @@ namespace Inventory
             var entry = items[slotIndex];
             if (entry.item == null) return;
 
+            // Cache the item before modifying the slot so we can check for pets.
+            var droppedItem = entry.item;
+
             int remove = Mathf.Clamp(quantity, 1, entry.count);
             entry.count -= remove;
             if (entry.count <= 0)
@@ -599,6 +603,20 @@ namespace Inventory
             UpdateSlotVisual(slotIndex);
             HideTooltip();
             OnInventoryChanged?.Invoke();
+
+            // Attempt to spawn a pet for this item if one exists.
+            var pet = PetDropSystem.FindPetByItem(droppedItem);
+            if (pet != null)
+            {
+                var player = GameObject.FindGameObjectWithTag("Player");
+                Vector3 pos = player != null ? player.transform.position : Vector3.zero;
+                Debug.Log($"Dropping pet item '{droppedItem.name}', spawning pet '{pet.displayName}'.");
+                PetDropSystem.SpawnPet(pet, pos);
+            }
+            else
+            {
+                Debug.Log($"Dropped item '{droppedItem.name}' with no associated pet.");
+            }
         }
 
         /// <summary>

--- a/Assets/Scripts/Pets/PetDropSystem.cs
+++ b/Assets/Scripts/Pets/PetDropSystem.cs
@@ -132,7 +132,10 @@ namespace Pets
         private static GameObject SpawnPetInternal(PetDefinition pet, Vector3 position)
         {
             if (pet == null)
+            {
+                Debug.LogError("SpawnPetInternal called with null pet.");
                 return null;
+            }
 
             DespawnActive();
             Vector3 spawnPos = position + (Vector3)(UnityEngine.Random.insideUnitCircle * 0.5f);
@@ -142,6 +145,7 @@ namespace Pets
             PetSaveBridge.Save(pet.id);
 #endif
             PetToastUI.Show("You have a funny feeling like you're being followed…", pet.messageColor);
+            Debug.Log($"Spawned pet '{pet.displayName}' at {spawnPos}.");
             return activePetGO;
         }
 
@@ -185,10 +189,17 @@ namespace Pets
         {
             Initialize();
             if (tables.Count == 0 || tables[0].entries.Count == 0)
+            {
+                Debug.LogWarning("DebugForceFirstDrop: no pet drop tables or entries found.");
                 return false;
+            }
             var entry = tables[0].entries[0];
             if (entry.pet == null)
+            {
+                Debug.LogWarning("DebugForceFirstDrop: first entry has no pet.");
                 return false;
+            }
+            Debug.Log("DebugForceFirstDrop spawning first pet drop.");
             SpawnPetInternal(entry.pet, position);
             return true;
         }


### PR DESCRIPTION
## Summary
- spawn pets when dropping their items
- add debug logging for pet spawning and debug drop hotkey

## Testing
- `dotnet test` *(fails: MSB1003, specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a20b08480c832eb29b5ac3dc7bd4b0