### PR TITLE
Add frame-based sprite animation options for pets

### DIFF
--- a/Assets/Scripts/Pets/PetDefinition.cs
+++ b/Assets/Scripts/Pets/PetDefinition.cs
@@ -28,6 +28,31 @@ namespace Pets
         [Tooltip("Optional animation clips. If set, the pet will play these using an Animator.")]
         public AnimationClip[] animationClips;
 
+        [Header("Frame-based Sprites")]
+        [Tooltip("Frames for idle animation when facing up.")]
+        public Sprite[] idleUp;
+
+        [Tooltip("Frames for walking animation when facing up.")]
+        public Sprite[] walkUp;
+
+        [Tooltip("Frames for idle animation when facing down.")]
+        public Sprite[] idleDown;
+
+        [Tooltip("Frames for walking animation when facing down.")]
+        public Sprite[] walkDown;
+
+        [Tooltip("Frames for idle animation when facing left.")]
+        public Sprite[] idleLeft;
+
+        [Tooltip("Frames for walking animation when facing left.")]
+        public Sprite[] walkLeft;
+
+        [Tooltip("Frames for idle animation when facing right.")]
+        public Sprite[] idleRight;
+
+        [Tooltip("Frames for walking animation when facing right.")]
+        public Sprite[] walkRight;
+
         [Header("UI")]
         [Tooltip("Optional color for drop announcement messages.")]
         public Color messageColor = Color.white;

--- a/Assets/Scripts/Pets/PetFollower.cs
+++ b/Assets/Scripts/Pets/PetFollower.cs
@@ -18,11 +18,13 @@ namespace Pets
         private Vector3 offset;
         private Rigidbody2D body;
         private SpriteRenderer sprite;
+        private PetSpriteAnimator spriteAnimator;
 
         private void Awake()
         {
             body = GetComponent<Rigidbody2D>();
             sprite = GetComponent<SpriteRenderer>();
+            spriteAnimator = GetComponent<PetSpriteAnimator>();
             FindPlayer();
             ChooseOffset();
         }
@@ -56,12 +58,15 @@ namespace Pets
 
             Vector3 newPos = Vector3.MoveTowards(transform.position, target, moveSpeed * Time.deltaTime);
             newPos.y += Mathf.Sin(Time.time * 5f) * jitter;
+            Vector2 velocity = (newPos - transform.position) / Time.deltaTime;
             body.MovePosition(newPos);
 
             if (Vector3.Distance(transform.position, player.position) < followRadius * 0.5f)
                 ChooseOffset();
 
-            if (sprite != null)
+            if (spriteAnimator != null)
+                spriteAnimator.UpdateVisuals(velocity);
+            else if (sprite != null)
                 sprite.flipX = newPos.x > player.position.x;
         }
     }

--- a/Assets/Scripts/Pets/PetSpawner.cs
+++ b/Assets/Scripts/Pets/PetSpawner.cs
@@ -26,10 +26,45 @@ namespace Pets
             go.transform.position = position;
 
             var sr = go.AddComponent<SpriteRenderer>();
-            sr.sprite = def.sprite;
             sr.sortingLayerName = "Characters";
-            if (def.sprite != null && def.sprite.texture != null)
-                def.sprite.texture.filterMode = FilterMode.Point;
+            sr.sprite = def.sprite;
+            if (sr.sprite == null)
+            {
+                if (def.idleDown != null && def.idleDown.Length > 0) sr.sprite = def.idleDown[0];
+                else if (def.walkDown != null && def.walkDown.Length > 0) sr.sprite = def.walkDown[0];
+                else if (def.idleRight != null && def.idleRight.Length > 0) sr.sprite = def.idleRight[0];
+                else if (def.walkRight != null && def.walkRight.Length > 0) sr.sprite = def.walkRight[0];
+                else if (def.idleUp != null && def.idleUp.Length > 0) sr.sprite = def.idleUp[0];
+                else if (def.walkUp != null && def.walkUp.Length > 0) sr.sprite = def.walkUp[0];
+                else if (def.idleLeft != null && def.idleLeft.Length > 0) sr.sprite = def.idleLeft[0];
+                else if (def.walkLeft != null && def.walkLeft.Length > 0) sr.sprite = def.walkLeft[0];
+            }
+            if (sr.sprite != null && sr.sprite.texture != null)
+                sr.sprite.texture.filterMode = FilterMode.Point;
+
+            bool hasFrameSprites =
+                (def.idleUp != null && def.idleUp.Length > 0) ||
+                (def.walkUp != null && def.walkUp.Length > 0) ||
+                (def.idleDown != null && def.idleDown.Length > 0) ||
+                (def.walkDown != null && def.walkDown.Length > 0) ||
+                (def.idleLeft != null && def.idleLeft.Length > 0) ||
+                (def.walkLeft != null && def.walkLeft.Length > 0) ||
+                (def.idleRight != null && def.idleRight.Length > 0) ||
+                (def.walkRight != null && def.walkRight.Length > 0);
+
+            if (hasFrameSprites && (def.animationClips == null || def.animationClips.Length == 0))
+            {
+                var spriteAnim = go.AddComponent<PetSpriteAnimator>();
+                spriteAnim.spriteRenderer = sr;
+                spriteAnim.idleUp = def.idleUp;
+                spriteAnim.walkUp = def.walkUp;
+                spriteAnim.idleDown = def.idleDown;
+                spriteAnim.walkDown = def.walkDown;
+                spriteAnim.idleLeft = def.idleLeft;
+                spriteAnim.walkLeft = def.walkLeft;
+                spriteAnim.idleRight = def.idleRight;
+                spriteAnim.walkRight = def.walkRight;
+            }
 
             if (def.animationClips != null && def.animationClips.Length > 0)
             {

--- a/Assets/Scripts/Pets/PetSpriteAnimator.cs
+++ b/Assets/Scripts/Pets/PetSpriteAnimator.cs
@@ -1,0 +1,139 @@
+using UnityEngine;
+
+namespace Pets
+{
+    /// <summary>
+    /// Handles simple sprite swapping animation for pets based on movement direction.
+    /// </summary>
+    public class PetSpriteAnimator : MonoBehaviour
+    {
+        [Tooltip("SpriteRenderer used for displaying pet sprites (auto-found if null).")]
+        public SpriteRenderer spriteRenderer;
+
+        [Tooltip("Frames used when idle and facing up.")]
+        public Sprite[] idleUp;
+        [Tooltip("Frames used when walking and facing up.")]
+        public Sprite[] walkUp;
+
+        [Tooltip("Frames used when idle and facing down.")]
+        public Sprite[] idleDown;
+        [Tooltip("Frames used when walking and facing down.")]
+        public Sprite[] walkDown;
+
+        [Tooltip("Frames used when idle and facing left.")]
+        public Sprite[] idleLeft;
+        [Tooltip("Frames used when walking and facing left.")]
+        public Sprite[] walkLeft;
+
+        [Tooltip("Frames used when idle and facing right.")]
+        public Sprite[] idleRight;
+        [Tooltip("Frames used when walking and facing right.")]
+        public Sprite[] walkRight;
+
+        [Tooltip("If true, ignore Left arrays and flip the Right sprites for left-facing.")]
+        public bool useFlipXForLeft = true;
+
+        [Tooltip("Frames per second for the sprite swapping animation.")]
+        public float animationFPS = 6f;
+
+        private int _currentDir = 0; // 0=Down,1=Left,2=Right,3=Up
+        private bool _currentlyMoving = false;
+        private float _animClock = 0f;
+        private int _animFrame = 0;
+
+        private void Awake()
+        {
+            if (spriteRenderer == null)
+                spriteRenderer = GetComponent<SpriteRenderer>() ?? GetComponentInChildren<SpriteRenderer>();
+        }
+
+        /// <summary>
+        /// Update the visual state based on movement velocity.
+        /// </summary>
+        public void UpdateVisuals(Vector2 velocity)
+        {
+            _currentlyMoving = velocity.sqrMagnitude > 0.0001f;
+
+            if (_currentlyMoving)
+            {
+                if (Mathf.Abs(velocity.x) > Mathf.Abs(velocity.y))
+                    _currentDir = velocity.x < 0f ? 1 : 2; // Left : Right
+                else
+                    _currentDir = velocity.y < 0f ? 0 : 3; // Down : Up
+            }
+
+            if (spriteRenderer == null) return;
+
+            float fps = Mathf.Max(0.01f, animationFPS);
+            _animClock += Time.deltaTime * fps;
+            Sprite[] set = SelectSpriteSet(_currentlyMoving, _currentDir, out int frames);
+
+            if (frames <= 0) return;
+
+            _animFrame = Mathf.FloorToInt(_animClock) % frames;
+            spriteRenderer.flipX = false;
+
+            if (useFlipXForLeft && _currentDir == 1)
+            {
+                Sprite[] rightSet = SelectSpriteSet(_currentlyMoving, 2, out frames);
+                if (frames > 0)
+                {
+                    _animFrame = Mathf.FloorToInt(_animClock) % frames;
+                    spriteRenderer.sprite = rightSet[_animFrame];
+                    spriteRenderer.flipX = true;
+                    return;
+                }
+            }
+
+            spriteRenderer.sprite = set[_animFrame];
+        }
+
+        private Sprite[] SelectSpriteSet(bool moving, int dir, out int frames)
+        {
+            Sprite[] set = null;
+
+            if (moving)
+            {
+                switch (dir)
+                {
+                    case 0: set = walkDown; break;
+                    case 1: set = useFlipXForLeft ? walkRight : walkLeft; break;
+                    case 2: set = walkRight; break;
+                    case 3: set = walkUp; break;
+                }
+            }
+            else
+            {
+                switch (dir)
+                {
+                    case 0: set = idleDown != null && idleDown.Length > 0 ? idleDown : walkDown; break;
+                    case 1:
+                        set = useFlipXForLeft
+                            ? (idleRight != null && idleRight.Length > 0 ? idleRight : walkRight)
+                            : (idleLeft != null && idleLeft.Length > 0 ? idleLeft : walkLeft);
+                        break;
+                    case 2: set = idleRight != null && idleRight.Length > 0 ? idleRight : walkRight; break;
+                    case 3: set = idleUp != null && idleUp.Length > 0 ? idleUp : walkUp; break;
+                }
+            }
+
+            if (set == null || set.Length == 0)
+            {
+                if (!moving)
+                {
+                    if (idleDown != null && idleDown.Length > 0) { frames = idleDown.Length; return idleDown; }
+                    if (walkDown != null && walkDown.Length > 0) { frames = walkDown.Length; return walkDown; }
+                }
+                else
+                {
+                    if (walkRight != null && walkRight.Length > 0) { frames = walkRight.Length; return walkRight; }
+                    if (walkDown != null && walkDown.Length > 0) { frames = walkDown.Length; return walkDown; }
+                }
+            }
+
+            frames = set != null ? set.Length : 0;
+            return set ?? System.Array.Empty<Sprite>();
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- allow PetDefinition to specify directional idle and walk sprite frames
- add PetSpriteAnimator and update spawner and follower to drive sprite frame animations

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a20dbd400c832e95fe05425cb9f1df