### PR TITLE
Avoid runtime player lookups for pets

### DIFF
--- a/Assets/Scripts/Pets/PetFollower.cs
+++ b/Assets/Scripts/Pets/PetFollower.cs
@@ -17,7 +17,7 @@ namespace Pets
         public float offsetLerpSpeed = 5f;
         public float headingRefreshAngle = 30f;
 
-        private Transform player;
+        [SerializeField] private Transform player;
         private Vector3 offset;
         private Vector3 targetOffset;
         private Vector2 lastHeading;
@@ -32,18 +32,17 @@ namespace Pets
             body = GetComponent<Rigidbody2D>();
             sprite = GetComponent<SpriteRenderer>();
             spriteAnimator = GetComponent<PetSpriteAnimator>();
-            FindPlayer();
             if (player != null)
                 lastPlayerPos = player.position;
             ChooseOffset(Vector2.right);
             offset = targetOffset;
         }
 
-        private void FindPlayer()
+        public void SetPlayer(Transform newPlayer)
         {
-            var go = GameObject.FindGameObjectWithTag("Player");
-            if (go != null)
-                player = go.transform;
+            player = newPlayer;
+            if (player != null)
+                lastPlayerPos = player.position;
         }
 
         private void ChooseOffset(Vector2 heading)
@@ -56,11 +55,7 @@ namespace Pets
         private void FixedUpdate()
         {
             if (player == null)
-            {
-                FindPlayer();
-                if (player == null)
-                    return;
-            }
+                return;
 
             Vector3 playerPos = player.position;
             Vector3 playerVel = (playerPos - lastPlayerPos) / Time.fixedDeltaTime;

--- a/Assets/Scripts/Pets/PetSpawner.cs
+++ b/Assets/Scripts/Pets/PetSpawner.cs
@@ -10,7 +10,7 @@ namespace Pets
         /// <summary>
         /// Create a pet game object at the given position.
         /// </summary>
-        public static GameObject Spawn(PetDefinition def, Vector3 position)
+        public static GameObject Spawn(PetDefinition def, Vector3 position, Transform player = null)
         {
             if (def == null)
             {
@@ -103,7 +103,9 @@ namespace Pets
             col.isTrigger = true;
             col.radius = 0.3f;
 
-            go.AddComponent<PetFollower>();
+            var follower = go.AddComponent<PetFollower>();
+            if (player != null)
+                follower.SetPlayer(player);
             var clickable = go.AddComponent<PetClickable>();
             clickable.Init(def);
 


### PR DESCRIPTION
## Summary
- Serialize player reference and expose setter on `PetFollower`
- Remove `FindPlayer` logic and early out if player not assigned
- Allow `PetSpawner` to pass player references directly

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a2246bb14c832e952afcbc6e148749