### PR TITLE
Assign player transform to spawned pets

### DIFF
--- a/Assets/Scripts/Pets/PetDropSystem.cs
+++ b/Assets/Scripts/Pets/PetDropSystem.cs
@@ -142,7 +142,10 @@ namespace Pets
 
             DespawnActive();
             Vector3 spawnPos = position + (Vector3)(UnityEngine.Random.insideUnitCircle * 0.5f);
-            activePetGO = PetSpawner.Spawn(pet, spawnPos);
+
+            // Find the player once at spawn time so the follower knows whom to follow.
+            var playerTransform = GameObject.FindGameObjectWithTag("Player")?.transform;
+            activePetGO = PetSpawner.Spawn(pet, spawnPos, playerTransform);
             activePetDef = pet;
             PetSaveBridge.Save(pet.id);
             PetToastUI.Show("You have a funny feeling like you're being followed…", pet.messageColor);


### PR DESCRIPTION
## Summary
- Ensure spawned pets get the player transform so PetFollower works

## Testing
- `dotnet test` *(fails: MSBUILD: error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a2299b28cc832e9b81be197b754679