### PR TITLE
fix: ensure saved pet follows player on start

### DIFF
--- a/Assets/Scripts/Pets/PetDropSystem.cs
+++ b/Assets/Scripts/Pets/PetDropSystem.cs
@@ -16,7 +16,7 @@ namespace Pets
         private static PetDefinition activePetDef;
         private static bool initialized;
 
-        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
         private static void AutoInit()
         {
             Initialize();


### PR DESCRIPTION
## Summary
- delay pet system initialization until after scenes load so saved pets can find the player and begin following immediately

## Testing
- `dotnet build` (fails: project file does not exist)


------
https://chatgpt.com/codex/tasks/task_e_68a22b5db858832e99cd81cff4b6e5c6