### PR TITLE
Enable pet collisions excluding player/NPC

### DIFF
--- a/Assets/Scripts/Pets/PetFollower.cs
+++ b/Assets/Scripts/Pets/PetFollower.cs
@@ -8,6 +8,7 @@ namespace Pets
     /// </summary>
     [RequireComponent(typeof(Rigidbody2D))]
     [RequireComponent(typeof(SpriteRenderer))]
+    [RequireComponent(typeof(Collider2D))]
     public class PetFollower : MonoBehaviour
     {
         public float followRadius = 0.6f;
@@ -25,6 +26,7 @@ namespace Pets
         private Rigidbody2D body;
         private SpriteRenderer sprite;
         private PetSpriteAnimator spriteAnimator;
+        private Collider2D col;
         private PlayerMover playerMover;
         private Vector3 currentVelocity;
 
@@ -33,11 +35,14 @@ namespace Pets
             body = GetComponent<Rigidbody2D>();
             sprite = GetComponent<SpriteRenderer>();
             spriteAnimator = GetComponent<PetSpriteAnimator>();
+            col = GetComponent<Collider2D>();
             if (player != null)
             {
                 lastPlayerPos = player.position;
                 playerMover = player.GetComponent<PlayerMover>();
+                IgnorePlayer();
             }
+            IgnoreNPCs();
             ChooseOffset(Vector2.right);
             offset = targetOffset;
         }
@@ -49,6 +54,7 @@ namespace Pets
             {
                 lastPlayerPos = player.position;
                 playerMover = player.GetComponent<PlayerMover>();
+                IgnorePlayer();
             }
         }
 
@@ -109,6 +115,34 @@ namespace Pets
                 else
                     sprite.flipX = newPos.x > player.position.x;
             }
+        }
+
+        private void IgnorePlayer()
+        {
+            if (player == null || col == null)
+                return;
+            foreach (var pCol in player.GetComponentsInChildren<Collider2D>())
+                Physics2D.IgnoreCollision(col, pCol);
+        }
+
+        private void IgnoreNPCs()
+        {
+            if (col == null)
+                return;
+            var cols = FindObjectsOfType<Collider2D>();
+            foreach (var c in cols)
+            {
+                if (c == col)
+                    continue;
+                if (c.gameObject.name.Contains("NPC"))
+                    Physics2D.IgnoreCollision(col, c);
+            }
+        }
+
+        private void OnCollisionEnter2D(Collision2D collision)
+        {
+            if (collision.collider.gameObject.name.Contains("NPC"))
+                Physics2D.IgnoreCollision(col, collision.collider);
         }
     }
 }

--- a/Assets/Scripts/Pets/PetSpawner.cs
+++ b/Assets/Scripts/Pets/PetSpawner.cs
@@ -96,11 +96,12 @@ namespace Pets
             }
 
             var rb = go.AddComponent<Rigidbody2D>();
-            rb.isKinematic = true;
+            rb.isKinematic = false;
             rb.gravityScale = 0f;
+            rb.freezeRotation = true;
 
             var col = go.AddComponent<CircleCollider2D>();
-            col.isTrigger = true;
+            col.isTrigger = false;
             col.radius = 0.3f;
 
             var follower = go.AddComponent<PetFollower>();

--- a/Assets/Scripts/Pets/PhysicsLayerUtility.cs
+++ b/Assets/Scripts/Pets/PhysicsLayerUtility.cs
@@ -3,7 +3,7 @@
 namespace Pets
 {
     /// <summary>
-    /// Ensures a dedicated physics layer for pets that collides with nothing.
+    /// Ensures a dedicated physics layer for pets.
     /// </summary>
     public static class PhysicsLayerUtility
     {
@@ -11,7 +11,7 @@ namespace Pets
         private static bool initialized;
 
         /// <summary>
-        /// Ensure the Pets layer exists and ignores all collisions.
+        /// Ensure the Pets layer exists.
         /// </summary>
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         public static void Ensure()
@@ -47,11 +47,7 @@ namespace Pets
             if (layer < 0)
             {
                 Debug.LogWarning("Pets layer missing. Please add a layer named 'Pets' in Project Settings > Tags and Layers.");
-                return;
             }
-
-            for (int i = 0; i < 32; i++)
-                Physics2D.IgnoreLayerCollision(layer, i, true);
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow pets to use solid colliders driven by physics
- add filtering so pets ignore collisions with the player and any object named with "NPC"
- remove global collision ignoring for pets layer

## Testing
- `dotnet test` *(fails: project or solution file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a22fd27804832ebeb047826e6b203d