### PR TITLE
Fix path corner z assignment

### DIFF
--- a/Assets/Scripts/Pets/PetFollower.cs
+++ b/Assets/Scripts/Pets/PetFollower.cs
@@ -258,7 +258,11 @@ namespace Pets
                 pathCorners.AddRange(navPath.corners);
                 pathIndex = 0;
                 for (int i = 0; i < pathCorners.Count; i++)
-                    pathCorners[i].z = transform.position.z;
+                {
+                    Vector3 corner = pathCorners[i];
+                    corner.z = transform.position.z;
+                    pathCorners[i] = corner;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- avoid modifying temporary struct in path corner loop by storing corner, updating z, and reassigning

## Testing
- `dotnet test` *(fails: MSBUILD: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a23efd340c832e86505fea1aab8227