### PR TITLE
Fix pet pickup click detection

### DIFF
--- a/Assets/Scripts/Pets/PetClickable.cs
+++ b/Assets/Scripts/Pets/PetClickable.cs
@@ -11,7 +11,6 @@ namespace Pets
     public class PetClickable : MonoBehaviour
     {
         private PetDefinition definition;
-        private int layerMask;
 
         public void Init(PetDefinition def)
         {
@@ -20,7 +19,6 @@ namespace Pets
 
         private void Awake()
         {
-            layerMask = LayerMask.GetMask("Pets");
             var col = GetComponent<Collider2D>();
             col.isTrigger = true;
         }
@@ -31,7 +29,7 @@ namespace Pets
             {
                 Vector3 world = Camera.main.ScreenToWorldPoint(Input.mousePosition);
                 Vector2 p = new Vector2(world.x, world.y);
-                var hit = Physics2D.OverlapPoint(p, layerMask);
+                var hit = Physics2D.OverlapPoint(p);
                 if (hit != null && hit.gameObject == gameObject)
                     OnClicked();
             }


### PR DESCRIPTION
## Summary
- Remove reliance on `Pets` physics layer when clicking pets
- Allow `PetClickable` to detect clicks without dedicated layer

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a24c7b1604832eb64c9040b445fc92