### PR TITLE
Return previous pet item when spawning a new pet

### DIFF
--- a/Assets/Scripts/Pets/PetDropSystem.cs
+++ b/Assets/Scripts/Pets/PetDropSystem.cs
@@ -14,6 +14,7 @@ namespace Pets
         private static readonly Dictionary<ItemData, PetDefinition> itemToPet = new();
         private static GameObject activePetGO;
         private static PetDefinition activePetDef;
+        public static PetDefinition ActivePet => activePetDef;
         private static bool initialized;
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]

--- a/Assets/Scripts/Pets/PetUseHandler.cs
+++ b/Assets/Scripts/Pets/PetUseHandler.cs
@@ -19,6 +19,12 @@ namespace Pets
 
             var player = GameObject.FindGameObjectWithTag("Player");
             Vector3 pos = player != null ? player.transform.position : Vector3.zero;
+
+            var inventory = player != null ? player.GetComponent<Inventory.Inventory>() : null;
+            var currentPet = PetDropSystem.ActivePet;
+            if (inventory != null && currentPet != null && currentPet != pet && currentPet.pickupItem != null)
+                inventory.AddItem(currentPet.pickupItem);
+
             PetDropSystem.SpawnPet(pet, pos);
             return true;
         }


### PR DESCRIPTION
## Summary
- Expose the currently active pet through `PetDropSystem.ActivePet`
- When using a pet item, return the existing pet's item to the player's inventory before spawning the new pet

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a2516be874832e9e8ced663230855e