### PR TITLE
Return previous pet item when swapping pets

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -608,6 +608,12 @@ namespace Inventory
             var pet = PetDropSystem.FindPetByItem(droppedItem);
             if (pet != null)
             {
+                // If a different pet is already active, return its pickup item to the inventory
+                // before spawning the new one so players don't lose their previous pet item.
+                var currentPet = PetDropSystem.ActivePet;
+                if (currentPet != null && currentPet != pet && currentPet.pickupItem != null)
+                    AddItem(currentPet.pickupItem);
+
                 var player = GameObject.FindGameObjectWithTag("Player");
                 Vector3 pos = player != null ? player.transform.position : Vector3.zero;
                 Debug.Log($"Dropping pet item '{droppedItem.name}', spawning pet '{pet.displayName}'.");


### PR DESCRIPTION
## Summary
- ensure previous pet's item is returned when spawning new pet

## Testing
- `dotnet test` *(fails: project or solution file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a259deefc4832e93b20564f077d424