### PR TITLE
Add woodcutter controller with axe selection

### DIFF
--- a/Assets/Scripts/Skills/Woodcutting/Core/AxeToUse.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Core/AxeToUse.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using Inventory;
+
+namespace Skills.Woodcutting
+{
+    /// <summary>
+    /// Chooses the best axe available in the inventory that the player can use.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class AxeToUse : MonoBehaviour
+    {
+        [SerializeField] private List<AxeDefinition> allAxes = new List<AxeDefinition>();
+        [SerializeField] private Inventory inventory;
+        [SerializeField] private WoodcuttingSkill skill;
+
+        public AxeDefinition Current { get; private set; }
+
+        private void Awake()
+        {
+            if (inventory == null)
+                inventory = GetComponent<Inventory>();
+            if (skill == null)
+                skill = GetComponent<WoodcuttingSkill>();
+        }
+
+        /// <summary>
+        /// Returns the best usable axe. Refreshes the current axe cache.
+        /// </summary>
+        public AxeDefinition GetBestAxe()
+        {
+            Refresh();
+            return Current;
+        }
+
+        /// <summary>
+        /// Refreshes the cached axe from inventory.
+        /// </summary>
+        public void Refresh()
+        {
+            Current = null;
+            if (inventory == null || skill == null)
+                return;
+
+            foreach (var axe in allAxes.OrderByDescending(a => a.Power))
+            {
+                var item = Resources.Load<ItemData>("Item/" + axe.Id);
+                if (item == null)
+                    continue;
+                if (inventory.GetItemCount(item) > 0 && skill.Level >= axe.RequiredWoodcuttingLevel)
+                {
+                    Current = axe;
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Skills/Woodcutting/Core/WoodcutterController.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Core/WoodcutterController.cs
@@ -1,0 +1,123 @@
+using UnityEngine;
+using Inventory;
+using Player;
+using Skills.Mining;
+
+namespace Skills.Woodcutting
+{
+    /// <summary>
+    /// Handles player input and range checks for woodcutting.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class WoodcutterController : MonoBehaviour
+    {
+        [SerializeField] private float interactRange = 1.5f;
+        [SerializeField] private float cancelDistance = 3f;
+        [SerializeField] private LayerMask treeMask = ~0;
+
+        [Header("References")]
+        [SerializeField] private WoodcuttingSkill woodcuttingSkill;
+        [SerializeField] private AxeToUse axeSelector;
+        [SerializeField] private PlayerMover playerMover;
+
+        private TreeNode nearbyTree;
+        private Camera cam;
+
+        private void Awake()
+        {
+            if (woodcuttingSkill == null)
+                woodcuttingSkill = GetComponent<WoodcuttingSkill>();
+            if (axeSelector == null)
+                axeSelector = GetComponent<AxeToUse>();
+            if (playerMover == null)
+                playerMover = GetComponent<PlayerMover>();
+            cam = Camera.main;
+        }
+
+        private void Update()
+        {
+            if (Input.GetMouseButtonDown(0))
+            {
+                var tree = GetTreeUnderCursor();
+                if (tree != null)
+                    TryStartChopping(tree);
+            }
+
+            if (Input.GetKeyDown(KeyCode.Escape))
+                woodcuttingSkill.StopChopping();
+
+            if (nearbyTree != null && Input.GetKeyDown(KeyCode.E))
+                TryStartChopping(nearbyTree);
+
+            if (woodcuttingSkill.IsChopping)
+            {
+                if (playerMover != null && playerMover.IsMoving)
+                    woodcuttingSkill.StopChopping();
+                else if (Vector3.Distance(transform.position, woodcuttingSkill.CurrentTree.transform.position) > cancelDistance)
+                    woodcuttingSkill.StopChopping();
+                else if (woodcuttingSkill.CurrentTree.IsDepleted)
+                    woodcuttingSkill.StopChopping();
+            }
+        }
+
+        private TreeNode GetTreeUnderCursor()
+        {
+            if (cam == null)
+                cam = Camera.main;
+            Vector3 world = cam.ScreenToWorldPoint(Input.mousePosition);
+            var hit = Physics2D.Raycast(world, Vector2.zero, 0f, treeMask);
+            if (hit.collider != null)
+                return hit.collider.GetComponent<TreeNode>();
+            return null;
+        }
+
+        private void TryStartChopping(TreeNode tree)
+        {
+            if (tree == null || tree.IsDepleted || tree.IsBusy)
+                return;
+
+            float dist = Vector3.Distance(transform.position, tree.transform.position);
+            if (dist > interactRange)
+                return;
+
+            var axe = axeSelector.GetBestAxe();
+            if (axe == null)
+            {
+                FloatingText.Show("You need an axe", transform.position);
+                return;
+            }
+            if (woodcuttingSkill.Level < tree.def.RequiredWoodcuttingLevel)
+            {
+                FloatingText.Show($"You need Woodcutting level {tree.def.RequiredWoodcuttingLevel}", transform.position);
+                return;
+            }
+            if (woodcuttingSkill.Level < axe.RequiredWoodcuttingLevel)
+            {
+                FloatingText.Show($"You need Woodcutting level {axe.RequiredWoodcuttingLevel}", transform.position);
+                return;
+            }
+
+            if (!woodcuttingSkill.CanAddLog(tree.def))
+            {
+                FloatingText.Show("Your inventory is full", transform.position);
+                return;
+            }
+
+            woodcuttingSkill.StartChopping(tree, axe);
+        }
+
+        private void OnTriggerEnter2D(Collider2D other)
+        {
+            var tree = other.GetComponent<TreeNode>();
+            if (tree != null)
+                nearbyTree = tree;
+        }
+
+        private void OnTriggerExit2D(Collider2D other)
+        {
+            var tree = other.GetComponent<TreeNode>();
+            if (tree != null && tree == nearbyTree)
+                nearbyTree = null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `AxeToUse` component to pick the best usable axe from inventory
- Introduce `WoodcutterController` for tree interaction, range checks, and chop cancellation

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a2659b5294832e921587a985fb18a2