### PR TITLE
Ensure trees resubscribe to ticker before respawning

### DIFF
--- a/Assets/Scripts/Skills/Woodcutting/Core/TreeNode.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Core/TreeNode.cs
@@ -37,6 +37,12 @@ namespace Skills.Woodcutting
                 Ticker.Instance.Subscribe(this);
         }
 
+        private void Start()
+        {
+            if (Ticker.Instance != null)
+                Ticker.Instance.Subscribe(this);
+        }
+
         private void OnDisable()
         {
             if (Ticker.Instance != null)


### PR DESCRIPTION
## Summary
- Make TreeNode resubscribe to the global Ticker during Start so respawn ticks fire even if the ticker initializes later

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a26e8b1c24832eb2ba3a75858f3010