### PR TITLE
feat(mining): show pickaxe while mining

### DIFF
--- a/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
@@ -38,6 +38,7 @@ namespace Skills.Mining
         public int Xp => xp;
         public bool IsMining => currentRock != null;
         public MineableRock CurrentRock => currentRock;
+        public PickaxeDefinition CurrentPickaxe => currentPickaxe;
         public int CurrentSwingSpeedTicks => currentPickaxe?.SwingSpeedTicks ?? 0;
         public float SwingProgressNormalized
             => currentPickaxe == null || currentPickaxe.SwingSpeedTicks <= 1


### PR DESCRIPTION
## Summary
- expose current pickaxe via MiningSkill
- display pickaxe sprite above targeted rock while mining

## Testing
- `dotnet test` *(fails: specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a2749fa9b4832e986b0ee4a821d737