### PR TITLE
Show axe sprite while chopping

### DIFF
--- a/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
@@ -40,6 +40,7 @@ namespace Skills.Woodcutting
         public bool IsChopping => currentTree != null;
         public TreeNode CurrentTree => currentTree;
         public int CurrentChopIntervalTicks => currentIntervalTicks;
+        public AxeDefinition CurrentAxe => currentAxe;
         public float ChopProgressNormalized
             => currentIntervalTicks <= 1 ? 0f : (float)chopProgress / (currentIntervalTicks - 1);
 


### PR DESCRIPTION
## Summary
- display current axe icon above trees when chopping
- expose current axe from woodcutting skill

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a27800b54c832eb96b7e669c78adf0