### PR TITLE
Add tree respawn countdown label

### DIFF
--- a/Assets/Scripts/Skills/Woodcutting/Core/TreeNode.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Core/TreeNode.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 using Util;
 
@@ -16,6 +17,9 @@ namespace Skills.Woodcutting
 
         public bool IsDepleted { get; private set; }
         public bool IsBusy { get; set; }
+
+        public event Action<TreeNode, float> OnTreeDepleted;
+        public event Action<TreeNode> OnTreeRespawned;
 
         private double respawnAt;
 
@@ -80,6 +84,7 @@ namespace Skills.Woodcutting
             if (col) col.enabled = false;
             if (sr && depletedSprite) sr.sprite = depletedSprite;
             IsBusy = false;
+            OnTreeDepleted?.Invoke(this, def != null ? def.RespawnSeconds : 0f);
         }
 
         private void Respawn()
@@ -88,6 +93,7 @@ namespace Skills.Woodcutting
             var col = GetComponent<Collider2D>();
             if (col) col.enabled = true;
             if (sr && aliveSprite) sr.sprite = aliveSprite;
+            OnTreeRespawned?.Invoke(this);
         }
     }
 }

--- a/Assets/Scripts/Skills/Woodcutting/UI/TreeRespawnLabel.cs
+++ b/Assets/Scripts/Skills/Woodcutting/UI/TreeRespawnLabel.cs
@@ -1,0 +1,143 @@
+using TMPro;
+using UnityEngine;
+using Util;
+
+namespace Skills.Woodcutting
+{
+    /// <summary>
+    /// Displays a world-space countdown above a depleted tree until it respawns.
+    /// </summary>
+    public class TreeRespawnLabel : MonoBehaviour, ITickable
+    {
+        [SerializeField] private Vector3 worldOffset = new Vector3(0f, 0.6f, 0f);
+        [SerializeField] private Color textColor = Color.white;
+        [SerializeField] private int fontSize = 32;
+        [SerializeField] private TMP_FontAsset font;
+        [SerializeField] private Color outlineColor = Color.black;
+        [SerializeField] private float outlineWidth = 0f;
+
+        private TreeNode tree;
+        private TextMeshPro tmp;
+        private Transform labelTransform;
+        private SpriteRenderer treeRenderer;
+        private double endTime;
+        private bool counting;
+        private int lastSeconds = -1;
+
+        private void Awake()
+        {
+            tree = GetComponent<TreeNode>();
+            if (tree == null)
+                tree = GetComponentInParent<TreeNode>();
+            treeRenderer = tree != null ? tree.GetComponent<SpriteRenderer>() : null;
+            CreateLabel();
+        }
+
+        private void OnEnable()
+        {
+            if (tree != null)
+            {
+                tree.OnTreeDepleted += HandleDepleted;
+                tree.OnTreeRespawned += HandleRespawned;
+            }
+            if (Ticker.Instance != null)
+                Ticker.Instance.Subscribe(this);
+        }
+
+        private void Start()
+        {
+            if (Ticker.Instance != null)
+                Ticker.Instance.Subscribe(this);
+        }
+
+        private void OnDisable()
+        {
+            if (Ticker.Instance != null)
+                Ticker.Instance.Unsubscribe(this);
+            if (tree != null)
+            {
+                tree.OnTreeDepleted -= HandleDepleted;
+                tree.OnTreeRespawned -= HandleRespawned;
+            }
+        }
+
+        private void CreateLabel()
+        {
+            if (tree == null || labelTransform != null)
+                return;
+
+            var go = new GameObject("TreeRespawnLabel");
+            labelTransform = go.transform;
+            labelTransform.SetParent(tree.transform, false);
+
+            tmp = go.AddComponent<TextMeshPro>();
+            tmp.alignment = TextAlignmentOptions.Center;
+            tmp.color = textColor;
+            tmp.fontSize = fontSize;
+            tmp.enableWordWrapping = false;
+            if (font != null) tmp.font = font;
+            if (outlineWidth > 0f)
+            {
+                tmp.outlineWidth = outlineWidth;
+                tmp.outlineColor = outlineColor;
+            }
+            go.SetActive(false);
+        }
+
+        private void HandleDepleted(TreeNode node, float respawnSeconds)
+        {
+            endTime = Time.timeAsDouble + respawnSeconds;
+            counting = true;
+            lastSeconds = -1;
+
+            if (labelTransform != null)
+                labelTransform.gameObject.SetActive(true);
+
+            int secs = Mathf.CeilToInt(respawnSeconds);
+            lastSeconds = secs;
+            tmp.SetText("{0}", secs);
+        }
+
+        private void HandleRespawned(TreeNode node)
+        {
+            counting = false;
+            if (labelTransform != null)
+                labelTransform.gameObject.SetActive(false);
+        }
+
+        public void OnTick()
+        {
+            if (!counting)
+                return;
+
+            double remaining = endTime - Time.timeAsDouble;
+            int secs = remaining > 0 ? Mathf.CeilToInt((float)remaining) : 0;
+            if (secs <= 0)
+            {
+                counting = false;
+                if (labelTransform != null)
+                    labelTransform.gameObject.SetActive(false);
+                return;
+            }
+
+            if (secs != lastSeconds)
+            {
+                lastSeconds = secs;
+                tmp.SetText("{0}", secs);
+            }
+
+            bool visible = treeRenderer == null || treeRenderer.isVisible;
+            if (labelTransform != null)
+            {
+                if (labelTransform.gameObject.activeSelf != visible)
+                    labelTransform.gameObject.SetActive(visible);
+                if (visible)
+                {
+                    labelTransform.position = tree.transform.position + worldOffset;
+                    if (Camera.main != null)
+                        labelTransform.rotation = Camera.main.transform.rotation;
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Skills/Woodcutting/UI/TreeRespawnLabel.cs.meta
+++ b/Assets/Scripts/Skills/Woodcutting/UI/TreeRespawnLabel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b0771e849b064cddb2c9824c8bf74526
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add TreeRespawnLabel MonoBehaviour to show world-space countdown above depleted trees
- expose TreeNode events for depletion and respawn

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a27a003b88832e9f25c0f12af52300