### PR TITLE
fix: ensure item database loads lazily

### DIFF
--- a/Assets/Scripts/Inventory/ItemDatabase.cs
+++ b/Assets/Scripts/Inventory/ItemDatabase.cs
@@ -5,7 +5,8 @@ namespace Inventory
 {
     /// <summary>
     /// Loads all <see cref="ItemData"/> assets at startup and provides
-    /// fast lookup by item id.
+    /// fast lookup by item id. The database will initialize itself on first use
+    /// so callers do not need to ensure the component exists ahead of time.
     /// </summary>
     public class ItemDatabase : MonoBehaviour
     {
@@ -13,22 +14,33 @@ namespace Inventory
         private readonly Dictionary<string, ItemData> items = new();
 
         /// <summary>
+        /// Ensure the database exists and has loaded its items. This is invoked
+        /// automatically by <see cref="GetItem"/> but may be called manually by
+        /// systems that need the database before any lookups occur.
+        /// </summary>
+        private static void EnsureInstance()
+        {
+            if (instance != null)
+                return;
+
+            // Create a new hidden GameObject so the database survives scene loads.
+            var go = new GameObject(nameof(ItemDatabase));
+            instance = go.AddComponent<ItemDatabase>();
+        }
+
+        /// <summary>
         /// Retrieve an item by its unique identifier.
         /// </summary>
         public static ItemData GetItem(string id)
         {
-            if (instance == null)
-            {
-                Debug.LogError("ItemDatabase has not been initialized.");
-                return null;
-            }
-
+            EnsureInstance();
             instance.items.TryGetValue(id, out var item);
             return item;
         }
 
         private void Awake()
         {
+            // Singleton enforcement.
             if (instance != null && instance != this)
             {
                 Destroy(gameObject);


### PR DESCRIPTION
## Summary
- prevent missing ItemDatabase initialization by creating instance on first use

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a27cf2e33c832eaea96a4fd98ae2ea