### PR TITLE
Ensure tree respawn label appears on depletion

### DIFF
--- a/Assets/Scripts/Skills/Woodcutting/UI/TreeRespawnLabel.cs
+++ b/Assets/Scripts/Skills/Woodcutting/UI/TreeRespawnLabel.cs
@@ -90,12 +90,17 @@ namespace Skills.Woodcutting
             counting = true;
             lastSeconds = -1;
 
+            // Ensure the label exists before trying to show it.
+            if (labelTransform == null)
+                CreateLabel();
+
             if (labelTransform != null)
                 labelTransform.gameObject.SetActive(true);
 
             int secs = Mathf.CeilToInt(respawnSeconds);
             lastSeconds = secs;
-            tmp.SetText("{0}", secs);
+            if (tmp != null)
+                tmp.SetText("{0}", secs);
         }
 
         private void HandleRespawned(TreeNode node)


### PR DESCRIPTION
## Summary
- Ensure respawn label GameObject is created and shown whenever a tree enters its depleted state

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a27e71b978832ebe5126b40993bd32