### PR TITLE
Fix tree respawn label reuse

### DIFF
--- a/Assets/Scripts/Skills/Woodcutting/UI/TreeRespawnLabel.cs
+++ b/Assets/Scripts/Skills/Woodcutting/UI/TreeRespawnLabel.cs
@@ -66,22 +66,35 @@ namespace Skills.Woodcutting
             if (tree == null || labelTransform != null)
                 return;
 
-            var go = new GameObject("TreeRespawnLabel");
-            labelTransform = go.transform;
-            labelTransform.SetParent(tree.transform, false);
-
-            tmp = go.AddComponent<TextMeshPro>();
-            tmp.alignment = TextAlignmentOptions.Center;
-            tmp.color = textColor;
-            tmp.fontSize = fontSize;
-            tmp.enableWordWrapping = false;
-            if (font != null) tmp.font = font;
-            if (outlineWidth > 0f)
+            // Reuse an existing label if one was already created for this tree.
+            var existing = tree.transform.Find("TreeRespawnLabel");
+            if (existing != null)
             {
-                tmp.outlineWidth = outlineWidth;
-                tmp.outlineColor = outlineColor;
+                labelTransform = existing;
+                tmp = existing.GetComponent<TextMeshPro>();
+                if (tmp == null)
+                    tmp = existing.gameObject.AddComponent<TextMeshPro>();
             }
-            go.SetActive(false);
+            else
+            {
+                var go = new GameObject("TreeRespawnLabel");
+                labelTransform = go.transform;
+                labelTransform.SetParent(tree.transform, false);
+
+                tmp = go.AddComponent<TextMeshPro>();
+                tmp.alignment = TextAlignmentOptions.Center;
+                tmp.color = textColor;
+                tmp.fontSize = fontSize;
+                tmp.enableWordWrapping = false;
+                if (font != null) tmp.font = font;
+                if (outlineWidth > 0f)
+                {
+                    tmp.outlineWidth = outlineWidth;
+                    tmp.outlineColor = outlineColor;
+                }
+            }
+
+            labelTransform.gameObject.SetActive(false);
         }
 
         private void HandleDepleted(TreeNode node, float respawnSeconds)


### PR DESCRIPTION
## Summary
- Reuse existing TreeRespawnLabel children instead of creating a new one each chop
- Ensure label activates when tree is depleted

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a28162d8c4832e96b5cc53175b1283