### PR TITLE
Fix tree respawn countdown label not showing

### DIFF
--- a/Assets/Scripts/Skills/Woodcutting/UI/TreeRespawnLabel.cs
+++ b/Assets/Scripts/Skills/Woodcutting/UI/TreeRespawnLabel.cs
@@ -17,7 +17,10 @@ namespace Skills.Woodcutting
         [SerializeField] private float outlineWidth = 0f;
 
         private TreeNode tree;
-        private TextMeshPro tmp;
+        // Using TMP_Text allows the label to work with either TextMeshPro or TextMeshProUGUI
+        // components. This avoids cases where GetComponent<TextMeshPro>() fails to find the
+        // existing text element, leaving the countdown blank.
+        private TMP_Text tmp;
         private Transform labelTransform;
         private SpriteRenderer treeRenderer;
         private double endTime;
@@ -71,7 +74,7 @@ namespace Skills.Woodcutting
             if (existing != null)
             {
                 labelTransform = existing;
-                tmp = existing.GetComponent<TextMeshPro>();
+                tmp = existing.GetComponent<TMP_Text>();
                 if (tmp == null)
                     tmp = existing.gameObject.AddComponent<TextMeshPro>();
             }
@@ -113,7 +116,7 @@ namespace Skills.Woodcutting
             int secs = Mathf.CeilToInt(respawnSeconds);
             lastSeconds = secs;
             if (tmp != null)
-                tmp.SetText("{0}", secs);
+                tmp.text = secs.ToString();
         }
 
         private void HandleRespawned(TreeNode node)
@@ -141,7 +144,8 @@ namespace Skills.Woodcutting
             if (secs != lastSeconds)
             {
                 lastSeconds = secs;
-                tmp.SetText("{0}", secs);
+                if (tmp != null)
+                    tmp.text = secs.ToString();
             }
 
             bool visible = treeRenderer == null || treeRenderer.isVisible;


### PR DESCRIPTION
## Summary
- Ensure tree respawn labels work with any TMP text component
- Populate countdown values using direct text assignment

## Testing
- `dotnet test` *(fails: project or solution file not found)*
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f58e3380832eb1e1b0c776b93a88