### PR TITLE
Add minimap markers for world objects

### DIFF
--- a/Assets/Scripts/Bank/BankOpener.cs
+++ b/Assets/Scripts/Bank/BankOpener.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using World;
 
 namespace BankSystem
 {
@@ -6,9 +7,17 @@ namespace BankSystem
     /// Attach to a bank object. Clicking it opens the bank if the player is
     /// within a specified distance.
     /// </summary>
+    [RequireComponent(typeof(MinimapMarker))]
     public class BankOpener : MonoBehaviour
     {
         public float openDistance = 1.5f;
+
+        private void Reset()
+        {
+            var marker = GetComponent<MinimapMarker>();
+            if (marker != null)
+                marker.type = MinimapMarker.MarkerType.Bank;
+        }
 
         private void OnMouseDown()
         {

--- a/Assets/Scripts/Shop/Shop.cs
+++ b/Assets/Scripts/Shop/Shop.cs
@@ -1,6 +1,7 @@
 using System;
 using UnityEngine;
 using Inventory;
+using World;
 
 namespace ShopSystem
 {
@@ -24,6 +25,7 @@ namespace ShopSystem
     /// <summary>
     /// Basic shop component that can hold up to 30 items and a currency type.
     /// </summary>
+    [RequireComponent(typeof(MinimapMarker))]
     public class Shop : MonoBehaviour
     {
         public const int MaxSlots = 30;
@@ -65,6 +67,13 @@ namespace ShopSystem
             restockTimers = new float[stock.Length];
             for (int i = 0; i < stock.Length; i++)
                 initialStock[i] = stock[i];
+        }
+
+        private void Reset()
+        {
+            var marker = GetComponent<MinimapMarker>();
+            if (marker != null)
+                marker.type = MinimapMarker.MarkerType.Shop;
         }
 
         private void Update()

--- a/Assets/Scripts/World/MinimapMarker.cs
+++ b/Assets/Scripts/World/MinimapMarker.cs
@@ -1,0 +1,37 @@
+using UnityEngine;
+
+namespace World
+{
+    /// <summary>
+    /// Component that registers itself with the <see cref="Minimap"/> so an
+    /// icon can be displayed at this object's world position.
+    /// </summary>
+    public class MinimapMarker : MonoBehaviour
+    {
+        public enum MarkerType
+        {
+            Bank,
+            Shop,
+            Ore,
+            Tree
+        }
+
+        [Tooltip("Type of icon to display on the minimap.")]
+        public MarkerType type = MarkerType.Bank;
+
+        // References to the generated UI icons so they can be updated/destroyed
+        internal RectTransform smallIcon;
+        internal RectTransform bigIcon;
+
+        private void OnEnable()
+        {
+            Minimap.Instance?.Register(this);
+        }
+
+        private void OnDisable()
+        {
+            Minimap.Instance?.Unregister(this);
+        }
+    }
+}
+

--- a/Assets/Scripts/World/MinimapMarker.cs.meta
+++ b/Assets/Scripts/World/MinimapMarker.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c081796b31d84299b4870b32ca9e2f94
+timeCreated: 1755550000


### PR DESCRIPTION
## Summary
- add `MinimapMarker` component that registers itself with the minimap
- extend `Minimap` to track markers, spawn icons and load sprites for banks, shops, ores and trees
- attach markers to `BankOpener` and `Shop` objects

## Testing
- `dotnet build` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a3156b79ec832e8ab0795ad6cc25a7