### PR TITLE
Hide minimap markers when out of view

### DIFF
--- a/Assets/Scripts/World/Minimap.cs
+++ b/Assets/Scripts/World/Minimap.cs
@@ -377,6 +377,21 @@ namespace World
                 return;
 
             Vector3 viewport = mapCamera.WorldToViewportPoint(worldPos);
+
+            bool inside = viewport.x >= 0f && viewport.x <= 1f &&
+                          viewport.y >= 0f && viewport.y <= 1f &&
+                          viewport.z > 0f;
+
+            if (!inside)
+            {
+                if (icon.gameObject.activeSelf)
+                    icon.gameObject.SetActive(false);
+                return;
+            }
+
+            if (!icon.gameObject.activeSelf)
+                icon.gameObject.SetActive(true);
+
             Vector2 size = container.rect.size;
             Vector2 pos = new Vector2((viewport.x - 0.5f) * size.x, (viewport.y - 0.5f) * size.y);
 


### PR DESCRIPTION
## Summary
- Hide minimap markers when their world position lies outside the minimap camera's viewport

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a346b1847c832eb72940aa22df57da