### PR TITLE
Add equipment interface with equippable slots

### DIFF
--- a/Assets/Scripts/Inventory/Equipment.cs
+++ b/Assets/Scripts/Inventory/Equipment.cs
@@ -1,0 +1,269 @@
+// Assets/Scripts/Inventory/Equipment.cs
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+using UnityEngine.EventSystems;
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+#endif
+
+namespace Inventory
+{
+    /// <summary>
+    /// Handles equipping items into fixed slots and displays a simple UI
+    /// similar to the Old School RuneScape equipment interface. The UI is
+    /// generated at runtime and toggled with the "E" key.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class Equipment : MonoBehaviour
+    {
+        [Tooltip("Size of each slot in pixels.")]
+        public Vector2 slotSize = new(32f, 32f);
+
+        [Tooltip("Spacing between slots in pixels.")]
+        public Vector2 slotSpacing = new(4f, 4f);
+
+        [Tooltip("Reference resolution for the UI Canvas.")]
+        public Vector2 referenceResolution = new(640f, 360f);
+
+        [Tooltip("Optional frame sprite for slots (9 sliced).")]
+        public Sprite slotFrameSprite;
+
+        [Tooltip("Color for empty slots or tint for the frame.")]
+        public Color emptySlotColor = new(0f, 0f, 0f, 1f);
+
+        [Tooltip("Background color of the window.")]
+        public Color windowColor = new(0.15f, 0.15f, 0.15f, 0.95f);
+
+        private GameObject uiRoot;
+        private Image[] slotImages;
+        private Text[] slotCountTexts;
+        private InventoryEntry[] equipped;
+        private Inventory inventory;
+
+        private static readonly System.Collections.Generic.Dictionary<int, EquipmentSlot> cellToSlot = new()
+        {
+            {1, EquipmentSlot.Head},
+            {3, EquipmentSlot.Cape},
+            {4, EquipmentSlot.Amulet},
+            {5, EquipmentSlot.Arrow},
+            {6, EquipmentSlot.Weapon},
+            {7, EquipmentSlot.Body},
+            {10, EquipmentSlot.Legs},
+            {12, EquipmentSlot.Gloves},
+            {13, EquipmentSlot.Boots},
+            {14, EquipmentSlot.Ring}
+        };
+
+        private void Awake()
+        {
+            inventory = GetComponent<Inventory>();
+            equipped = new InventoryEntry[Enum.GetValues(typeof(EquipmentSlot)).Length - 1];
+            CreateUI();
+            if (uiRoot != null)
+                uiRoot.SetActive(false);
+        }
+
+        private void Update()
+        {
+#if ENABLE_INPUT_SYSTEM
+            bool toggle = Keyboard.current != null && Keyboard.current.eKey.wasPressedThisFrame;
+            toggle |= Input.GetKeyDown(KeyCode.E);
+#else
+            bool toggle = Input.GetKeyDown(KeyCode.E);
+#endif
+            if (toggle && uiRoot != null)
+            {
+                if (!uiRoot.activeSelf)
+                    inventory?.CloseUI();
+                uiRoot.SetActive(!uiRoot.activeSelf);
+            }
+        }
+
+        private int SlotIndex(EquipmentSlot slot) => (int)slot - 1;
+
+        /// <summary>
+        /// Equip an entry into its designated slot. Returns true on success.
+        /// </summary>
+        public bool Equip(InventoryEntry entry)
+        {
+            var slot = entry.item != null ? entry.item.equipmentSlot : EquipmentSlot.None;
+            if (slot == EquipmentSlot.None)
+                return false;
+
+            int index = SlotIndex(slot);
+            if (index < 0 || index >= equipped.Length)
+                return false;
+
+            var current = equipped[index];
+            if (current.item != null)
+            {
+                if (inventory != null && !inventory.AddItem(current.item, current.count))
+                    return false;
+            }
+
+            equipped[index] = entry;
+            UpdateSlotVisual(slot);
+            return true;
+        }
+
+        /// <summary>
+        /// Unequip the item in the given slot back into the inventory.
+        /// </summary>
+        public void Unequip(EquipmentSlot slot)
+        {
+            int index = SlotIndex(slot);
+            if (index < 0 || index >= equipped.Length)
+                return;
+
+            var entry = equipped[index];
+            if (entry.item == null)
+                return;
+
+            if (inventory != null && inventory.AddItem(entry.item, entry.count))
+            {
+                equipped[index].item = null;
+                equipped[index].count = 0;
+                UpdateSlotVisual(slot);
+            }
+        }
+
+        private void UpdateSlotVisual(EquipmentSlot slot)
+        {
+            int index = SlotIndex(slot);
+            if (index < 0 || index >= slotImages.Length)
+                return;
+            var img = slotImages[index];
+            var text = slotCountTexts[index];
+            var entry = equipped[index];
+            if (entry.item != null)
+            {
+                img.sprite = entry.item.icon ? entry.item.icon : slotFrameSprite;
+                img.color = Color.white;
+                text.text = entry.item.stackable && entry.count > 1 ? entry.count.ToString() : string.Empty;
+            }
+            else
+            {
+                img.sprite = slotFrameSprite;
+                img.color = emptySlotColor;
+                text.text = string.Empty;
+            }
+        }
+
+        private void CreateUI()
+        {
+            uiRoot = new GameObject("EquipmentUI", typeof(Canvas), typeof(CanvasScaler), typeof(GraphicRaycaster));
+            uiRoot.transform.SetParent(null, false);
+            DontDestroyOnLoad(uiRoot);
+
+            int uiLayer = LayerMask.NameToLayer("UI");
+            if (uiLayer >= 0) uiRoot.layer = uiLayer;
+
+            var canvas = uiRoot.GetComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            canvas.pixelPerfect = true;
+
+            var scaler = uiRoot.GetComponent<CanvasScaler>();
+            scaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+            scaler.referenceResolution = referenceResolution;
+            scaler.matchWidthOrHeight = 0f;
+
+            GameObject window = new GameObject("Window", typeof(RectTransform), typeof(Image));
+            window.transform.SetParent(uiRoot.transform, false);
+
+            var windowRect = window.GetComponent<RectTransform>();
+            windowRect.anchorMin = new Vector2(0.5f, 0.5f);
+            windowRect.anchorMax = new Vector2(0.5f, 0.5f);
+            windowRect.pivot = new Vector2(0.5f, 0.5f);
+            windowRect.anchoredPosition = Vector2.zero;
+
+            // Size to fit 3 columns x 5 rows
+            var contentSize = new Vector2(slotSize.x * 3 + slotSpacing.x * 2,
+                slotSize.y * 5 + slotSpacing.y * 4);
+            windowRect.sizeDelta = contentSize + new Vector2(16f, 16f);
+
+            var windowImg = window.GetComponent<Image>();
+            windowImg.color = windowColor;
+
+            GameObject panel = new GameObject("Slots", typeof(RectTransform), typeof(GridLayoutGroup));
+            panel.transform.SetParent(window.transform, false);
+
+            var rect = panel.GetComponent<RectTransform>();
+            rect.anchorMin = new Vector2(0.5f, 0.5f);
+            rect.anchorMax = new Vector2(0.5f, 0.5f);
+            rect.pivot = new Vector2(0.5f, 0.5f);
+            rect.anchoredPosition = Vector2.zero;
+            rect.sizeDelta = contentSize;
+
+            var grid = panel.GetComponent<GridLayoutGroup>();
+            grid.cellSize = slotSize;
+            grid.spacing = slotSpacing;
+            grid.childAlignment = TextAnchor.UpperLeft;
+            grid.constraint = GridLayoutGroup.Constraint.FixedColumnCount;
+            grid.constraintCount = 3;
+
+            slotImages = new Image[equipped.Length];
+            slotCountTexts = new Text[equipped.Length];
+
+            Font defaultFont = null;
+            try
+            {
+                defaultFont = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            }
+            catch (ArgumentException)
+            {
+                try { defaultFont = Resources.GetBuiltinResource<Font>("Arial.ttf"); }
+                catch (ArgumentException) { }
+            }
+
+            for (int i = 0; i < 15; i++)
+            {
+                GameObject cell = new GameObject($"Cell{i}", typeof(RectTransform));
+                cell.transform.SetParent(panel.transform, false);
+
+                if (cellToSlot.TryGetValue(i, out var slot))
+                {
+                    var img = cell.AddComponent<Image>();
+                    if (slotFrameSprite != null)
+                    {
+                        img.sprite = slotFrameSprite;
+                        img.type = Image.Type.Sliced;
+                        img.color = emptySlotColor;
+                    }
+                    else
+                    {
+                        img.color = emptySlotColor;
+                    }
+
+                    GameObject countGO = new GameObject("Count", typeof(Text));
+                    countGO.transform.SetParent(cell.transform, false);
+                    var countText = countGO.GetComponent<Text>();
+                    if (defaultFont != null)
+                        countText.font = defaultFont;
+                    countText.alignment = TextAnchor.LowerRight;
+                    countText.raycastTarget = false;
+                    countText.color = Color.white;
+                    countText.text = string.Empty;
+                    var countRect = countGO.GetComponent<RectTransform>();
+                    countRect.anchorMin = Vector2.zero;
+                    countRect.anchorMax = Vector2.one;
+                    countRect.offsetMin = Vector2.zero;
+                    countRect.offsetMax = Vector2.zero;
+
+                    var slotComponent = cell.AddComponent<EquipmentSlotUI>();
+                    slotComponent.equipment = this;
+                    slotComponent.slot = slot;
+
+                    slotImages[SlotIndex(slot)] = img;
+                    slotCountTexts[SlotIndex(slot)] = countText;
+                }
+                else
+                {
+                    var placeholder = cell.AddComponent<Image>();
+                    placeholder.color = Color.clear;
+                }
+            }
+        }
+    }
+}
+

--- a/Assets/Scripts/Inventory/Equipment.cs.meta
+++ b/Assets/Scripts/Inventory/Equipment.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d199cf9f7a6f954775e671b57bd22f10

--- a/Assets/Scripts/Inventory/EquipmentSlotUI.cs
+++ b/Assets/Scripts/Inventory/EquipmentSlotUI.cs
@@ -1,0 +1,28 @@
+// Assets/Scripts/Inventory/EquipmentSlotUI.cs
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace Inventory
+{
+    /// <summary>
+    /// Handles click events on an equipment slot. Left clicking returns the
+    /// item to the inventory.
+    /// </summary>
+    public class EquipmentSlotUI : MonoBehaviour, IPointerClickHandler
+    {
+        [HideInInspector]
+        public Equipment equipment;
+
+        [HideInInspector]
+        public EquipmentSlot slot;
+
+        public void OnPointerClick(PointerEventData eventData)
+        {
+            if (eventData.button == PointerEventData.InputButton.Left)
+            {
+                equipment?.Unequip(slot);
+            }
+        }
+    }
+}
+

--- a/Assets/Scripts/Inventory/EquipmentSlotUI.cs.meta
+++ b/Assets/Scripts/Inventory/EquipmentSlotUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9ab33a73cda9e1223d0981854cd680d6

--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -87,6 +87,7 @@ namespace Inventory
         private Shop currentShop;
 
         private PlayerMover playerMover;
+        private Equipment equipment;
 
         // UI
         private GameObject uiRoot; // Canvas root
@@ -104,6 +105,7 @@ namespace Inventory
         public bool IsOpen => uiRoot != null && uiRoot.activeSelf;
 
         public bool BankOpen { get; set; }
+        public bool InShop => currentShop != null;
 
         private bool CanDropItems => playerMover == null || playerMover.CanDrop;
 
@@ -132,6 +134,26 @@ namespace Inventory
             items[index].count = 0;
             UpdateSlotVisual(index);
             OnInventoryChanged?.Invoke();
+        }
+
+        /// <summary>
+        /// Equip the item in the given inventory slot if possible.
+        /// </summary>
+        public bool EquipItem(int index)
+        {
+            if (equipment == null)
+                return false;
+            if (index < 0 || index >= items.Length)
+                return false;
+            var entry = items[index];
+            if (entry.item == null || entry.item.equipmentSlot == EquipmentSlot.None)
+                return false;
+            if (equipment.Equip(entry))
+            {
+                ClearSlot(index);
+                return true;
+            }
+            return false;
         }
 
         private void Awake()
@@ -177,6 +199,7 @@ namespace Inventory
             }
 
             playerMover = GetComponent<PlayerMover>();
+            equipment = GetComponent<Equipment>();
 
             // Start completely hidden (inactive object so it’s clear in Hierarchy)
             if (uiRoot != null)

--- a/Assets/Scripts/Inventory/InventorySlot.cs
+++ b/Assets/Scripts/Inventory/InventorySlot.cs
@@ -69,10 +69,17 @@ namespace Inventory
             {
                 if (!eventData.dragging)
                 {
-                    if (shift)
-                        inventory?.PromptStackSplit(index, StackSplitType.Sell);
+                    if (inventory != null && inventory.InShop)
+                    {
+                        if (shift)
+                            inventory?.PromptStackSplit(index, StackSplitType.Sell);
+                        else
+                            inventory?.SellItem(index, 1);
+                    }
                     else
-                        inventory?.SellItem(index, 1);
+                    {
+                        inventory?.EquipItem(index);
+                    }
                 }
             }
             else if (eventData.button == PointerEventData.InputButton.Right)

--- a/Assets/Scripts/Inventory/ItemData.cs
+++ b/Assets/Scripts/Inventory/ItemData.cs
@@ -1,31 +1,56 @@
 using UnityEngine;
 
-/// <summary>
-/// Simple data container describing an item that can be stored in the
-/// player's inventory.  It is implemented as a ScriptableObject so items can
-/// be created easily via the Unity editor and referenced by pickup objects.
-/// </summary>
-[CreateAssetMenu(menuName = "Inventory/ItemData")]
-public class ItemData : ScriptableObject
+namespace Inventory
 {
-    [Header("Identification")]
-    public string id;
+    /// <summary>
+    /// Equipment slots available for equippable items. Items that are not
+    /// equippable should use <see cref="EquipmentSlot.None"/>.
+    /// </summary>
+    public enum EquipmentSlot
+    {
+        None,
+        Head,
+        Amulet,
+        Cape,
+        Arrow,
+        Body,
+        Legs,
+        Boots,
+        Gloves,
+        Ring,
+        Weapon
+    }
 
-    [Header("Display")]
-    public string itemName;
-    public Sprite icon;
+    /// <summary>
+    /// Simple data container describing an item that can be stored in the
+    /// player's inventory.  It is implemented as a ScriptableObject so items can
+    /// be created easily via the Unity editor and referenced by pickup objects.
+    /// </summary>
+    [CreateAssetMenu(menuName = "Inventory/ItemData")]
+    public class ItemData : ScriptableObject
+    {
+        [Header("Identification")]
+        public string id;
 
-    [Header("Description")]
-    [TextArea]
-    public string description;
+        [Header("Display")]
+        public string itemName;
+        public Sprite icon;
 
-    [Header("Stacking")]
-    [Tooltip("If true, multiple items can occupy a single inventory slot.")]
-    public bool stackable;
+        [Header("Description")]
+        [TextArea]
+        public string description;
 
-    [Tooltip("Maximum number of items per stack when stackable.")]
-    public int maxStack = 1;
+        [Header("Stacking")]
+        [Tooltip("If true, multiple items can occupy a single inventory slot.")]
+        public bool stackable;
 
-    [Tooltip("If true, stacks of this item can be split in the inventory.")]
-    public bool splittable = true;
-}
+        [Tooltip("Maximum number of items per stack when stackable.")]
+        public int maxStack = 1;
+
+        [Tooltip("If true, stacks of this item can be split in the inventory.")]
+        public bool splittable = true;
+
+        [Header("Equipment")]
+        [Tooltip("Slot this item can be equipped to. Use None for non-equippable items.")]
+        public EquipmentSlot equipmentSlot = EquipmentSlot.None;
+    }


### PR DESCRIPTION
## Summary
- add EquipmentSlot enum and slot field to ItemData
- implement runtime Equipment UI toggled with `E`
- allow inventory left-click to equip items and click on equipment slots to unequip
- add weapon slot and adjust slot layout to mirror OSRS

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a350890e10832e8af1831bc9e265b9