### PR TITLE
Handle equipment UI interactions and gear for skills

### DIFF
--- a/Assets/Scripts/Inventory/Equipment.cs
+++ b/Assets/Scripts/Inventory/Equipment.cs
@@ -75,13 +75,33 @@ namespace Inventory
 #endif
             if (toggle && uiRoot != null)
             {
-                if (!uiRoot.activeSelf)
-                    inventory?.CloseUI();
+                bool opening = !uiRoot.activeSelf;
+                if (opening)
+                {
+                    var minimap = World.Minimap.Instance;
+                    minimap?.CloseExpanded();
+                }
                 uiRoot.SetActive(!uiRoot.activeSelf);
             }
         }
 
         private int SlotIndex(EquipmentSlot slot) => (int)slot - 1;
+
+        public bool IsOpen => uiRoot != null && uiRoot.activeSelf;
+
+        public void CloseUI()
+        {
+            if (uiRoot != null)
+                uiRoot.SetActive(false);
+        }
+
+        public InventoryEntry GetEquipped(EquipmentSlot slot)
+        {
+            int index = SlotIndex(slot);
+            if (index < 0 || index >= equipped.Length)
+                return default;
+            return equipped[index];
+        }
 
         /// <summary>
         /// Equip an entry into its designated slot. Returns true on success.

--- a/Assets/Scripts/Skills/Mining/Core/PickaxeToUse.cs
+++ b/Assets/Scripts/Skills/Mining/Core/PickaxeToUse.cs
@@ -13,6 +13,7 @@ namespace Skills.Mining
     {
         [SerializeField] private List<PickaxeDefinition> allPickaxes = new List<PickaxeDefinition>();
         [SerializeField] private Inventory.Inventory inventory;
+        [SerializeField] private Inventory.Equipment equipment;
         [SerializeField] private MiningSkill skill;
 
         public PickaxeDefinition Current { get; private set; }
@@ -21,6 +22,8 @@ namespace Skills.Mining
         {
             if (inventory == null)
                 inventory = GetComponent<Inventory.Inventory>();
+            if (equipment == null)
+                equipment = GetComponent<Inventory.Equipment>();
             if (skill == null)
                 skill = GetComponent<MiningSkill>();
         }
@@ -52,6 +55,15 @@ namespace Skills.Mining
                 {
                     Current = pick;
                     break;
+                }
+                else if (equipment != null)
+                {
+                    var entry = equipment.GetEquipped(EquipmentSlot.Weapon);
+                    if (entry.item == item && skill.Level >= pick.LevelRequirement)
+                    {
+                        Current = pick;
+                        break;
+                    }
                 }
             }
         }

--- a/Assets/Scripts/Skills/SkillsUI.cs
+++ b/Assets/Scripts/Skills/SkillsUI.cs
@@ -101,6 +101,9 @@ namespace Skills
                         var inv = Object.FindObjectOfType<Inventory.Inventory>();
                         if (inv != null && inv.IsOpen)
                             inv.CloseUI();
+                        var eq = Object.FindObjectOfType<Inventory.Equipment>();
+                        if (eq != null && eq.IsOpen)
+                            eq.CloseUI();
                     }
                     uiRoot.SetActive(!uiRoot.activeSelf);
                 }

--- a/Assets/Scripts/Skills/Woodcutting/Core/AxeToUse.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Core/AxeToUse.cs
@@ -13,6 +13,7 @@ namespace Skills.Woodcutting
     {
         [SerializeField] private List<AxeDefinition> allAxes = new List<AxeDefinition>();
         [SerializeField] private Inventory.Inventory inventory;
+        [SerializeField] private Inventory.Equipment equipment;
         [SerializeField] private WoodcuttingSkill skill;
 
         public AxeDefinition Current { get; private set; }
@@ -21,6 +22,8 @@ namespace Skills.Woodcutting
         {
             if (inventory == null)
                 inventory = GetComponent<Inventory.Inventory>();
+            if (equipment == null)
+                equipment = GetComponent<Inventory.Equipment>();
             if (skill == null)
                 skill = GetComponent<WoodcuttingSkill>();
         }
@@ -52,6 +55,15 @@ namespace Skills.Woodcutting
                 {
                     Current = axe;
                     break;
+                }
+                else if (equipment != null)
+                {
+                    var entry = equipment.GetEquipped(EquipmentSlot.Weapon);
+                    if (entry.item == item && skill.Level >= axe.RequiredWoodcuttingLevel)
+                    {
+                        Current = axe;
+                        break;
+                    }
                 }
             }
         }

--- a/Assets/Scripts/World/Minimap.cs
+++ b/Assets/Scripts/World/Minimap.cs
@@ -286,6 +286,9 @@ namespace World
                 var inv = Object.FindObjectOfType<Inventory.Inventory>();
                 if (inv != null && inv.IsOpen)
                     inv.CloseUI();
+                var eq = Object.FindObjectOfType<Inventory.Equipment>();
+                if (eq != null && eq.IsOpen)
+                    eq.CloseUI();
             }
 
             expandedRoot.SetActive(opening);
@@ -299,6 +302,14 @@ namespace World
             var mover = playerObj != null ? playerObj.GetComponent<PlayerMover>() : null;
             if (mover != null)
                 mover.enabled = !opening;
+        }
+
+        public bool IsExpanded => expandedRoot != null && expandedRoot.activeSelf;
+
+        public void CloseExpanded()
+        {
+            if (IsExpanded)
+                ToggleExpanded();
         }
 
         public void Register(MinimapMarker marker)


### PR DESCRIPTION
## Summary
- Keep inventory open when toggling equipment and close expanded minimap instead
- Close equipment UI when opening skills or minimap
- Allow mining and woodcutting to use tools from weapon slot

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a35ea10adc832eaad4c6052d90dc07