### PR TITLE
Ensure ticker exists to prevent frozen progress bars

### DIFF
--- a/Assets/Scripts/Util/Ticker.cs
+++ b/Assets/Scripts/Util/Ticker.cs
@@ -10,6 +10,16 @@ namespace Util
     {
         public const float TickDuration = 0.6f;
 
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        private static void Initialize()
+        {
+            if (Instance == null)
+            {
+                var go = new GameObject(nameof(Ticker));
+                go.AddComponent<Ticker>();
+            }
+        }
+
         public static Ticker Instance { get; private set; }
 
         private readonly List<ITickable> subscribers = new List<ITickable>();


### PR DESCRIPTION
## Summary
- Automatically create a `Ticker` instance at startup if one is missing.

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a39d634f28832e99812a8f4af1b5fd