### PR TITLE
Replace HealthHUD default sprite creation

### DIFF
--- a/Assets/Scripts/Player/HealthHUD.cs
+++ b/Assets/Scripts/Player/HealthHUD.cs
@@ -23,7 +23,9 @@ namespace Player
             hud.hitpoints = hp;
             go.transform.SetParent(parent, false);
 
-            var sprite = Resources.GetBuiltinResource<Sprite>("UI/Skin/UISprite.psd");
+            var sprite = Sprite.Create(Texture2D.whiteTexture,
+                new Rect(0f, 0f, 1f, 1f),
+                new Vector2(0.5f, 0.5f));
 
             const float height = 12f;
             const float margin = 4f;


### PR DESCRIPTION
## Summary
- create a 1x1 white sprite using `Texture2D.whiteTexture` for the health HUD

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a4dc4464832eab53052a8f9dc29d