### PR TITLE
Add basic tick-based combat system

### DIFF
--- a/Assets/Prefabs/Enemy.prefab
+++ b/Assets/Prefabs/Enemy.prefab
@@ -1,0 +1,148 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2}
+  - component: {fileID: 3}
+  - component: {fileID: 4}
+  - component: {fileID: 5}
+  - component: {fileID: 6}
+  m_Layer: 0
+  m_Name: Enemy
+  m_TagString: Enemy
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &3
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 0
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!50 &4
+Rigidbody2D:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!61 &5
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!114 &6
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cd344ee9d75f4d899c71a2425bf0d02b, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  maxHitpoints: 10
+  attack: 1
+  defence: 1
+  attackSpeedTicks: 4

--- a/Assets/Prefabs/Enemy.prefab.meta
+++ b/Assets/Prefabs/Enemy.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 92a741f94d4b4a77aa3c3e8ea9825825
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Combat.meta
+++ b/Assets/Scripts/Combat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b988b1635ee0466fbf8273fa79180502
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Combat/CombatManager.cs
+++ b/Assets/Scripts/Combat/CombatManager.cs
@@ -1,0 +1,66 @@
+using System.Collections;
+using UnityEngine;
+using Player;
+
+namespace Combat
+{
+    /// <summary>
+    /// Centralised tick based combat resolver. Handles attacks between
+    /// a player and a single enemy at a time, using Old School RuneScape's
+    /// 0.6 second tick rhythm.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class CombatManager : MonoBehaviour
+    {
+        public const float TickLength = 0.6f; // seconds
+        public static CombatManager Instance { get; private set; }
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+
+        public void Engage(PlayerCombat player, Enemy enemy)
+        {
+            if (player == null || enemy == null)
+                return;
+            StartCoroutine(CombatRoutine(player, enemy));
+        }
+
+        private IEnumerator CombatRoutine(PlayerCombat player, Enemy enemy)
+        {
+            int playerTimer = 0;
+            int enemyTimer = 0;
+            var playerHp = player.Hitpoints;
+
+            while (playerHp.CurrentHp > 0 && enemy.CurrentHitpoints > 0)
+            {
+                yield return new WaitForSeconds(TickLength);
+                playerTimer++;
+                enemyTimer++;
+
+                if (playerTimer >= player.AttackSpeedTicks)
+                {
+                    int dmg = Mathf.Max(0, player.AttackRoll() - enemy.Defence);
+                    enemy.ApplyDamage(dmg);
+                    playerHp.OnPlayerDealtDamage(dmg);
+                    playerTimer = 0;
+                }
+
+                if (enemyTimer >= enemy.AttackSpeedTicks)
+                {
+                    int dmg = Mathf.Max(0, enemy.Attack - player.Defence);
+                    if (dmg > 0)
+                        enemy.DealDamage(playerHp, dmg);
+                    enemyTimer = 0;
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Combat/CombatManager.cs.meta
+++ b/Assets/Scripts/Combat/CombatManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2280e54772774b6e9b1df3201319d8d6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Combat/Enemy.cs
+++ b/Assets/Scripts/Combat/Enemy.cs
@@ -1,0 +1,55 @@
+using UnityEngine;
+using Player;
+
+namespace Combat
+{
+    /// <summary>
+    /// Basic enemy implementation handling hitpoints, damage application
+    /// and simple attack stats. Designed for tick based combat.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class Enemy : MonoBehaviour
+    {
+        [SerializeField] private int maxHitpoints = 10;
+        [SerializeField] private int attack = 1;
+        [SerializeField] private int defence = 1;
+        [SerializeField] private int attackSpeedTicks = 4;
+
+        public int MaxHitpoints => maxHitpoints;
+        public int CurrentHitpoints { get; private set; }
+        public int Attack => attack;
+        public int Defence => defence;
+        public int AttackSpeedTicks => attackSpeedTicks;
+
+        public event System.Action<Enemy> OnDied;
+        public event System.Action<int> OnDamagedPlayer;
+
+        private void Awake()
+        {
+            CurrentHitpoints = maxHitpoints;
+        }
+
+        public void ApplyDamage(int amount)
+        {
+            if (amount <= 0 || CurrentHitpoints <= 0)
+                return;
+            CurrentHitpoints = Mathf.Max(0, CurrentHitpoints - amount);
+            if (CurrentHitpoints <= 0)
+                Die();
+        }
+
+        public void DealDamage(PlayerHitpoints player, int amount)
+        {
+            if (amount <= 0)
+                return;
+            player.OnEnemyDealtDamage(amount);
+            OnDamagedPlayer?.Invoke(amount);
+        }
+
+        private void Die()
+        {
+            OnDied?.Invoke(this);
+            Destroy(gameObject);
+        }
+    }
+}

--- a/Assets/Scripts/Combat/Enemy.cs.meta
+++ b/Assets/Scripts/Combat/Enemy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cd344ee9d75f4d899c71a2425bf0d02b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Inventory/Equipment.cs
+++ b/Assets/Scripts/Inventory/Equipment.cs
@@ -79,6 +79,9 @@ namespace Inventory
         private Text rangedDefenceBonusText;
         private Text magicDefenceBonusText;
 
+        public int TotalAttackBonus { get; private set; }
+        public int TotalDefenceBonus { get; private set; }
+
         private static readonly System.Collections.Generic.Dictionary<int, EquipmentSlot> cellToSlot = new()
         {
             {1, EquipmentSlot.Head},
@@ -217,6 +220,7 @@ namespace Inventory
         private void UpdateBonuses()
         {
             int strength = 0, range = 0, magic = 0, meleeDef = 0, rangeDef = 0, magicDef = 0;
+            int attackTotal = 0, defenceTotal = 0;
             foreach (var entry in equipped)
             {
                 if (entry.item == null)
@@ -227,6 +231,8 @@ namespace Inventory
                 meleeDef += entry.item.meleeDefenceBonus;
                 rangeDef += entry.item.rangedDefenceBonus;
                 magicDef += entry.item.magicDefenceBonus;
+                attackTotal += entry.item.attackBonus;
+                defenceTotal += entry.item.defenceBonus;
             }
 
             if (strengthBonusText != null) strengthBonusText.text = $"Melee = {strength}";
@@ -235,6 +241,9 @@ namespace Inventory
             if (meleeDefenceBonusText != null) meleeDefenceBonusText.text = $"Melee = {meleeDef}";
             if (magicDefenceBonusText != null) magicDefenceBonusText.text = $"Magic = {magicDef}";
             if (rangedDefenceBonusText != null) rangedDefenceBonusText.text = $"Range = {rangeDef}";
+
+            TotalAttackBonus = attackTotal;
+            TotalDefenceBonus = defenceTotal;
         }
 
         private Sprite GetSlotSprite(EquipmentSlot slot)

--- a/Assets/Scripts/Inventory/ItemData.cs
+++ b/Assets/Scripts/Inventory/ItemData.cs
@@ -49,6 +49,12 @@ namespace Inventory
         [Header("Equipment")] [Tooltip("Slot this item can be equipped to. Use None for non-equippable items.")]
         public EquipmentSlot equipmentSlot = EquipmentSlot.None;
 
+        [Header("Combat")]
+        public int attackBonus;
+        public int defenceBonus;
+        [Tooltip("Number of 0.6s ticks between attacks when equipped as a weapon.")]
+        public int attackSpeed = 4;
+
         [Header("Bonuses")] public int strengthBonus;
         public int rangeBonus;
         public int magicBonus;

--- a/Assets/Scripts/Player/PlayerCombat.cs
+++ b/Assets/Scripts/Player/PlayerCombat.cs
@@ -1,0 +1,52 @@
+using UnityEngine;
+using Inventory;
+using Combat;
+
+namespace Player
+{
+    /// <summary>
+    /// Handles player initiated combat interactions and forwards
+    /// attacks to the <see cref="CombatManager"/>.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class PlayerCombat : MonoBehaviour
+    {
+        [SerializeField] private PlayerHitpoints hitpoints;
+        [SerializeField] private Equipment equipment;
+        [SerializeField] private int baseAttack = 1;
+        [SerializeField] private int baseDefence = 1;
+
+        private Enemy currentTarget;
+
+        public PlayerHitpoints Hitpoints => hitpoints;
+        public int Attack => baseAttack + (equipment != null ? equipment.TotalAttackBonus : 0);
+        public int Defence => baseDefence + (equipment != null ? equipment.TotalDefenceBonus : 0);
+
+        public int AttackSpeedTicks
+        {
+            get
+            {
+                var weapon = equipment != null ? equipment.GetEquipped(EquipmentSlot.Weapon).item : null;
+                return weapon != null ? Mathf.Max(1, weapon.attackSpeed) : 4;
+            }
+        }
+
+        private void Update()
+        {
+            if (Input.GetMouseButtonDown(0) && currentTarget != null)
+            {
+                CombatManager.Instance?.Engage(this, currentTarget);
+            }
+        }
+
+        public void SetTarget(Enemy enemy)
+        {
+            currentTarget = enemy;
+        }
+
+        public int AttackRoll()
+        {
+            return Attack;
+        }
+    }
+}

--- a/Assets/Scripts/Player/PlayerCombat.cs.meta
+++ b/Assets/Scripts/Player/PlayerCombat.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5414ec3c30c645df89cf6298b7f38e96
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Player/PlayerHitpoints.cs
+++ b/Assets/Scripts/Player/PlayerHitpoints.cs
@@ -163,6 +163,11 @@ namespace Player
             GainHitpointsXP(damage * 1.33f);
         }
 
+        public void OnEnemyDealtDamage(int damage)
+        {
+            ApplyDamage(damage);
+        }
+
 #if UNITY_EDITOR
         public void DebugDealDamage(int dmg)
         {


### PR DESCRIPTION
## Summary
- Introduce Enemy component and CombatManager for tick-based fights
- Add PlayerCombat to trigger attacks and track equipment bonuses
- Expose attack/defence stats on items and aggregate them in Equipment

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a8764fcc832e8cbb03782516c994