### PR TITLE
Add debug logs for player NPC combat

### DIFF
--- a/Assets/Scripts/Combat/CombatManager.cs
+++ b/Assets/Scripts/Combat/CombatManager.cs
@@ -30,6 +30,7 @@ namespace Combat
         {
             if (player == null || enemy == null)
                 return;
+            Debug.Log($"Combat started between {player.name} and {enemy.name}.");
             StartCoroutine(CombatRoutine(player, enemy));
         }
 
@@ -50,6 +51,7 @@ namespace Combat
                     int dmg = Mathf.Max(0, player.AttackRoll() - enemy.Defence);
                     enemy.ApplyDamage(dmg);
                     playerHp.OnPlayerDealtDamage(dmg);
+                    Debug.Log($"Player attacked {enemy.name} for {dmg} damage.");
                     playerTimer = 0;
                 }
 
@@ -57,7 +59,10 @@ namespace Combat
                 {
                     int dmg = Mathf.Max(0, enemy.Attack - player.Defence);
                     if (dmg > 0)
+                    {
                         enemy.DealDamage(playerHp, dmg);
+                        Debug.Log($"{enemy.name} attacked player for {dmg} damage.");
+                    }
                     enemyTimer = 0;
                 }
             }

--- a/Assets/Scripts/Combat/EnemyClickTarget.cs
+++ b/Assets/Scripts/Combat/EnemyClickTarget.cs
@@ -25,6 +25,8 @@ namespace Combat
             if (player == null)
                 return;
 
+            Debug.Log($"Player clicked {enemy.name} to attack.");
+
             player.SetTarget(enemy);
             CombatManager.Instance?.Engage(player, enemy);
         }


### PR DESCRIPTION
## Summary
- log when a player clicks an enemy to attack
- log combat start and damage exchanges between player and enemy

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a3af9b68a4832eb9cabb567b1bcb2d