### PR TITLE
Add tick-based enemy respawn timer

### DIFF
--- a/Assets/Scripts/Combat/Enemy.cs
+++ b/Assets/Scripts/Combat/Enemy.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using Player;
+using Util;
 
 namespace Combat
 {
@@ -8,12 +9,16 @@ namespace Combat
     /// and simple attack stats. Designed for tick based combat.
     /// </summary>
     [DisallowMultipleComponent]
-    public class Enemy : MonoBehaviour
+    public class Enemy : MonoBehaviour, ITickable
     {
         [SerializeField] private int maxHitpoints = 10;
         [SerializeField] private int attack = 1;
         [SerializeField] private int defence = 1;
         [SerializeField] private int attackSpeedTicks = 4;
+
+        [Header("Respawn")]
+        [Tooltip("Number of ticks before this enemy respawns after dying. 0 disables respawning.")]
+        [SerializeField] private int respawnTicks = 0;
 
         public int MaxHitpoints => maxHitpoints;
         public int CurrentHitpoints { get; private set; }
@@ -24,9 +29,27 @@ namespace Combat
         public event System.Action<Enemy> OnDied;
         public event System.Action<int> OnDamagedPlayer;
 
+        private int respawnTimer;
+        private Collider2D col;
+        private SpriteRenderer sr;
+
         private void Awake()
         {
             CurrentHitpoints = maxHitpoints;
+            col = GetComponent<Collider2D>();
+            sr = GetComponent<SpriteRenderer>();
+        }
+
+        private void OnEnable()
+        {
+            if (Ticker.Instance != null)
+                Ticker.Instance.Subscribe(this);
+        }
+
+        private void OnDisable()
+        {
+            if (Ticker.Instance != null)
+                Ticker.Instance.Unsubscribe(this);
         }
 
         public void ApplyDamage(int amount)
@@ -46,10 +69,34 @@ namespace Combat
             OnDamagedPlayer?.Invoke(amount);
         }
 
+        public void OnTick()
+        {
+            if (CurrentHitpoints > 0 || respawnTicks <= 0)
+                return;
+            if (--respawnTimer <= 0)
+                Respawn();
+        }
+
         private void Die()
         {
             OnDied?.Invoke(this);
-            Destroy(gameObject);
+            if (respawnTicks > 0)
+            {
+                respawnTimer = respawnTicks;
+                if (col) col.enabled = false;
+                if (sr) sr.enabled = false;
+            }
+            else
+            {
+                Destroy(gameObject);
+            }
+        }
+
+        private void Respawn()
+        {
+            CurrentHitpoints = maxHitpoints;
+            if (col) col.enabled = true;
+            if (sr) sr.enabled = true;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add configurable respawn timer to Enemy
- drive respawn countdown via per-tick callbacks

## Testing
- `dotnet test` (fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)

------
https://chatgpt.com/codex/tasks/task_e_68a3b245626c832e9a0d55101e3ad9d2