### PR TITLE
Enable basic NPC combat and health UI

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -78,6 +78,8 @@ namespace Combat
             float chance = CombatMath.ChanceToHit(atkRoll, defRoll);
             bool hit = Random.value < chance;
             int damage = 0;
+            var targetMb = target as MonoBehaviour;
+            string targetName = targetMb != null ? targetMb.name : "target";
             if (hit)
             {
                 int strEff = CombatMath.GetEffectiveStrength(attacker.StrengthLevel, attacker.Style);
@@ -87,6 +89,11 @@ namespace Combat
                 AwardXp(damage, attacker.Style);
                 if (!target.IsAlive)
                     OnTargetKilled?.Invoke(target);
+                Debug.Log($"Player dealt {damage} damage to {targetName}.");
+            }
+            else
+            {
+                Debug.Log($"Player missed {targetName}.");
             }
             OnAttackLanded?.Invoke(damage, hit);
         }

--- a/Assets/Scripts/NPC/NpcAttackController.cs
+++ b/Assets/Scripts/NPC/NpcAttackController.cs
@@ -1,0 +1,73 @@
+using System.Collections;
+using UnityEngine;
+using Combat;
+using EquipmentSystem;
+using Skills;
+using Player;
+
+namespace NPC
+{
+    /// <summary>
+    /// Handles NPC auto-attacks against the player during combat.
+    /// </summary>
+    [RequireComponent(typeof(NpcCombatant))]
+    public class NpcAttackController : MonoBehaviour
+    {
+        private NpcCombatant combatant;
+
+        private void Awake()
+        {
+            combatant = GetComponent<NpcCombatant>();
+        }
+
+        public void BeginAttacking(PlayerCombatTarget target)
+        {
+            StopAllCoroutines();
+            if (target != null)
+                StartCoroutine(AttackRoutine(target));
+        }
+
+        private IEnumerator AttackRoutine(PlayerCombatTarget target)
+        {
+            var wait = new WaitForSeconds(4 * CombatMath.TICK_SECONDS);
+            while (target != null && target.IsAlive && combatant.IsAlive)
+            {
+                ResolveAttack(target);
+                yield return wait;
+            }
+        }
+
+        private void ResolveAttack(PlayerCombatTarget target)
+        {
+            var attacker = combatant.GetCombatantStats();
+            var skills = target.GetComponent<SkillManager>();
+            var equipment = target.GetComponent<EquipmentAggregator>();
+            var loadout = target.GetComponent<PlayerCombatLoadout>();
+
+            var defender = CombatantStats.ForPlayer(skills, equipment,
+                loadout != null ? loadout.Style : CombatStyle.Defensive,
+                DamageType.Melee);
+
+            int attEff = CombatMath.GetEffectiveAttack(attacker.AttackLevel, attacker.Style);
+            int defEff = CombatMath.GetEffectiveDefence(defender.DefenceLevel, defender.Style);
+            int atkRoll = CombatMath.GetAttackRoll(attEff, attacker.Equip.attack);
+            int defBonus = defender.DamageType switch
+            {
+                DamageType.Magic => defender.Equip.magicDef,
+                DamageType.Ranged => defender.Equip.rangeDef,
+                _ => defender.Equip.meleeDef
+            };
+            int defRoll = CombatMath.GetDefenceRoll(defEff, defBonus);
+            bool hit = Random.value < CombatMath.ChanceToHit(atkRoll, defRoll);
+            int damage = 0;
+            if (hit)
+            {
+                int strEff = CombatMath.GetEffectiveStrength(attacker.StrengthLevel, attacker.Style);
+                int maxHit = CombatMath.GetMaxHit(strEff, attacker.Equip.strength);
+                damage = CombatMath.RollDamage(maxHit);
+                target.ApplyDamage(damage, attacker.DamageType, this);
+            }
+            Debug.Log($"{name} dealt {damage} damage to player.");
+        }
+    }
+}

--- a/Assets/Scripts/NPC/NpcAttackOnClick.cs
+++ b/Assets/Scripts/NPC/NpcAttackOnClick.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+using Combat;
+using Player;
+
+namespace NPC
+{
+    /// <summary>
+    /// Allows the player to left click an NPC to begin combat.
+    /// </summary>
+    [RequireComponent(typeof(NpcCombatant))]
+    public class NpcAttackOnClick : MonoBehaviour
+    {
+        private NpcCombatant combatant;
+
+        private void Awake()
+        {
+            combatant = GetComponent<NpcCombatant>();
+        }
+
+        private void OnMouseDown()
+        {
+            var playerController = FindObjectOfType<CombatController>();
+            if (playerController == null)
+                return;
+            if (playerController.TryAttackTarget(combatant))
+            {
+                var npcAttack = GetComponent<NpcAttackController>();
+                var playerTarget = playerController.GetComponent<PlayerCombatTarget>();
+                npcAttack?.BeginAttacking(playerTarget);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/NPC/NpcCombatant.cs
+++ b/Assets/Scripts/NPC/NpcCombatant.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using Combat;
+using MyGame.Drops;
 
 namespace NPC
 {
@@ -12,6 +13,9 @@ namespace NPC
         [SerializeField] private NpcCombatProfile profile;
         private int currentHp;
 
+        public event System.Action<int, int> OnHealthChanged; // current, max
+        public event System.Action OnDeath;
+
         public bool IsAlive => currentHp > 0;
         public DamageType PreferredDefenceType => profile != null ? profile.AttackType : DamageType.Melee;
         public int CurrentHP => currentHp;
@@ -20,12 +24,21 @@ namespace NPC
         private void Awake()
         {
             currentHp = profile != null ? profile.DefenceLevel : 1;
+            OnHealthChanged?.Invoke(currentHp, MaxHP);
         }
 
         /// <summary>Apply damage to this NPC.</summary>
         public void ApplyDamage(int amount, DamageType type, object source)
         {
             currentHp = Mathf.Max(0, currentHp - amount);
+            Debug.Log($"{name} took {amount} damage ({currentHp}/{MaxHP}).");
+            OnHealthChanged?.Invoke(currentHp, MaxHP);
+            if (currentHp <= 0)
+            {
+                OnDeath?.Invoke();
+                var dropper = GetComponent<NpcDropper>();
+                dropper?.OnDeath();
+            }
         }
 
         /// <summary>Get combat stats for this NPC.</summary>

--- a/Assets/Scripts/NPC/NpcHealthHUD.cs
+++ b/Assets/Scripts/NPC/NpcHealthHUD.cs
@@ -1,0 +1,102 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace NPC
+{
+    /// <summary>
+    /// Simple world-space health bar displayed above an NPC while in combat.
+    /// </summary>
+    [RequireComponent(typeof(NpcCombatant))]
+    public class NpcHealthHUD : MonoBehaviour
+    {
+        private NpcCombatant combatant;
+        private Canvas canvas;
+        private Image fill;
+        private Text text;
+
+        private void Awake()
+        {
+            combatant = GetComponent<NpcCombatant>();
+            combatant.OnHealthChanged += HandleHealthChanged;
+            combatant.OnDeath += HandleDeath;
+            CreateHud();
+            canvas.gameObject.SetActive(false);
+        }
+
+        private void CreateHud()
+        {
+            var go = new GameObject("NpcHealthHUD", typeof(Canvas), typeof(CanvasScaler), typeof(GraphicRaycaster));
+            canvas = go.GetComponent<Canvas>();
+            canvas.renderMode = RenderMode.WorldSpace;
+            canvas.transform.SetParent(transform, false);
+            canvas.transform.localPosition = new Vector3(0f, 1.5f, 0f);
+            canvas.transform.localRotation = Quaternion.identity;
+            canvas.GetComponent<RectTransform>().sizeDelta = new Vector2(1f, 0.15f);
+
+            var sprite = Sprite.Create(Texture2D.whiteTexture, new Rect(0f,0f,1f,1f), new Vector2(0.5f,0.5f));
+
+            var bg = new GameObject("BG", typeof(Image));
+            bg.transform.SetParent(canvas.transform, false);
+            var bgImg = bg.GetComponent<Image>();
+            bgImg.color = Color.red;
+            bgImg.sprite = sprite;
+            var bgRect = bgImg.rectTransform;
+            bgRect.anchorMin = Vector2.zero;
+            bgRect.anchorMax = Vector2.one;
+            bgRect.offsetMin = Vector2.zero;
+            bgRect.offsetMax = Vector2.zero;
+
+            var fillGO = new GameObject("Fill", typeof(Image));
+            fillGO.transform.SetParent(bg.transform, false);
+            fill = fillGO.GetComponent<Image>();
+            fill.color = Color.green;
+            fill.type = Image.Type.Filled;
+            fill.fillMethod = Image.FillMethod.Horizontal;
+            fill.fillOrigin = 0;
+            fill.sprite = sprite;
+            var fillRect = fill.rectTransform;
+            fillRect.anchorMin = Vector2.zero;
+            fillRect.anchorMax = Vector2.one;
+            fillRect.offsetMin = Vector2.zero;
+            fillRect.offsetMax = Vector2.zero;
+
+            var textGO = new GameObject("Text", typeof(Text));
+            textGO.transform.SetParent(bg.transform, false);
+            text = textGO.GetComponent<Text>();
+            text.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            text.alignment = TextAnchor.MiddleCenter;
+            text.color = Color.white;
+            text.fontSize = 11;
+            var textRect = text.rectTransform;
+            textRect.anchorMin = Vector2.zero;
+            textRect.anchorMax = Vector2.one;
+            textRect.offsetMin = Vector2.zero;
+            textRect.offsetMax = Vector2.zero;
+        }
+
+        private void HandleHealthChanged(int current, int max)
+        {
+            if (canvas != null && !canvas.gameObject.activeSelf)
+                canvas.gameObject.SetActive(true);
+            if (fill != null)
+                fill.fillAmount = max > 0 ? (float)current / max : 0f;
+            if (text != null)
+                text.text = $"{current}/{max}";
+        }
+
+        private void HandleDeath()
+        {
+            if (canvas != null)
+                canvas.gameObject.SetActive(false);
+        }
+
+        private void OnDestroy()
+        {
+            if (combatant != null)
+            {
+                combatant.OnHealthChanged -= HandleHealthChanged;
+                combatant.OnDeath -= HandleDeath;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Player/PlayerCombatTarget.cs
+++ b/Assets/Scripts/Player/PlayerCombatTarget.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+using Combat;
+
+namespace Player
+{
+    /// <summary>
+    /// Adapts the player into a CombatTarget so NPCs can attack.
+    /// </summary>
+    [RequireComponent(typeof(PlayerHitpoints))]
+    public class PlayerCombatTarget : MonoBehaviour, CombatTarget
+    {
+        private PlayerHitpoints hitpoints;
+
+        private void Awake()
+        {
+            hitpoints = GetComponent<PlayerHitpoints>();
+        }
+
+        public bool IsAlive => hitpoints.CurrentHp > 0;
+        public DamageType PreferredDefenceType => DamageType.Melee;
+        public int CurrentHP => hitpoints.CurrentHp;
+        public int MaxHP => hitpoints.MaxHp;
+
+        public void ApplyDamage(int amount, DamageType type, object source)
+        {
+            hitpoints.OnEnemyDealtDamage(amount);
+            Debug.Log($"Player took {amount} damage.");
+        }
+    }
+}

--- a/Assets/Scripts/Skills/SkillsUI.cs
+++ b/Assets/Scripts/Skills/SkillsUI.cs
@@ -71,7 +71,7 @@ namespace Skills
             var panelImage = panel.AddComponent<Image>();
             panelImage.color = new Color(0f, 0f, 0f, 0.5f);
             var panelRect = panel.GetComponent<RectTransform>();
-            panelRect.sizeDelta = new Vector2(200f, 100f);
+            panelRect.sizeDelta = new Vector2(200f, 200f);
             panelRect.anchoredPosition = Vector2.zero;
 
             var textGo = new GameObject("SkillText");


### PR DESCRIPTION
## Summary
- expand skills panel to 200x200
- add left-click NPC attack system with combat logging
- show NPC health bars and trigger drops on death

## Testing
- `dotnet build` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a44a3c8e04832eb25b3565a4dffcd5