### PR TITLE
Add hitpoints configuration to NPC combat profile

### DIFF
--- a/Assets/NPCCombatProfile/Goblin.asset
+++ b/Assets/NPCCombatProfile/Goblin.asset
@@ -15,6 +15,7 @@ MonoBehaviour:
   AttackLevel: 1
   StrengthLevel: 1
   DefenceLevel: 1
+  HitpointsLevel: 10
   MeleeDefence: 0
   RangeDefence: 0
   MagicDefence: 0

--- a/Assets/Scripts/Combat/NpcCombatProfile.cs
+++ b/Assets/Scripts/Combat/NpcCombatProfile.cs
@@ -11,6 +11,7 @@ namespace Combat
         public int AttackLevel = 1;
         public int StrengthLevel = 1;
         public int DefenceLevel = 1;
+        public int HitpointsLevel = 10;
         public int MeleeDefence;
         public int RangeDefence;
         public int MagicDefence;

--- a/Assets/Scripts/NPC/NpcCombatant.cs
+++ b/Assets/Scripts/NPC/NpcCombatant.cs
@@ -19,11 +19,11 @@ namespace NPC
         public bool IsAlive => currentHp > 0;
         public DamageType PreferredDefenceType => profile != null ? profile.AttackType : DamageType.Melee;
         public int CurrentHP => currentHp;
-        public int MaxHP => profile != null ? profile.DefenceLevel : currentHp;
+        public int MaxHP => profile != null ? profile.HitpointsLevel : currentHp;
 
         private void Awake()
         {
-            currentHp = profile != null ? profile.DefenceLevel : 1;
+            currentHp = profile != null ? profile.HitpointsLevel : 1;
             OnHealthChanged?.Invoke(currentHp, MaxHP);
         }
 


### PR DESCRIPTION
## Summary
- allow NPC combat profiles to define hitpoints
- read NPC hitpoints from profile in combatant component
- add hitpoints value to Goblin profile asset

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a44dbed5d8832e8dbc6cd3aa2a9e20