### PR TITLE
Clamp minimum combat hit chance

### DIFF
--- a/Assets/Scripts/Combat/CombatMath.cs
+++ b/Assets/Scripts/Combat/CombatMath.cs
@@ -10,6 +10,8 @@ namespace Combat
         /// <summary>Seconds per OSRS tick.</summary>
         public const float TICK_SECONDS = 0.6f;
 
+        public const float MIN_HIT_CHANCE = 0.25f;
+
         public static int GetEffectiveAttack(int level, CombatStyle style)
         {
             int bonus = style switch
@@ -56,7 +58,7 @@ namespace Combat
                 chance = 1f - (defenceRoll + 2f) / (2f * (attackRoll + 1f));
             else
                 chance = attackRoll / (2f * (defenceRoll + 1f));
-            return Mathf.Clamp01(chance);
+            return Mathf.Clamp(chance, MIN_HIT_CHANCE, 1f);
         }
 
         public static int GetMaxHit(int effectiveStrength, int strengthBonus)


### PR DESCRIPTION
## Summary
- ensure hit chances can't drop below 25%

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a45c2fd5ac832e8fabb0fc910185ed