### PR TITLE
Persist combat skill levels across sessions

### DIFF
--- a/Assets/Scripts/Skills/SkillManager.cs
+++ b/Assets/Scripts/Skills/SkillManager.cs
@@ -1,6 +1,8 @@
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using Skills.Mining;
+using Core.Save;
 
 namespace Skills
 {
@@ -12,8 +14,11 @@ namespace Skills
     public class SkillManager : MonoBehaviour
     {
         [SerializeField] private XpTable xpTable;
+        [SerializeField] private MonoBehaviour saveProvider; // optional custom save provider
 
         private readonly Dictionary<SkillType, SkillRecord> skills = new();
+        private ICombatSkillSave save;
+        private Coroutine saveRoutine;
 
         private struct SkillRecord
         {
@@ -23,15 +28,36 @@ namespace Skills
 
         private void Awake()
         {
+            save = saveProvider as ICombatSkillSave ?? new SaveManagerCombatSkillSave();
             InitialiseSkill(SkillType.Attack);
             InitialiseSkill(SkillType.Strength);
             InitialiseSkill(SkillType.Defence);
         }
 
+        private void OnEnable()
+        {
+            saveRoutine = StartCoroutine(SaveLoop());
+        }
+
+        private void OnDisable()
+        {
+            if (saveRoutine != null)
+                StopCoroutine(saveRoutine);
+        }
+
+        private void OnApplicationQuit()
+        {
+            Save();
+        }
+
         private void InitialiseSkill(SkillType type)
         {
-            if (!skills.ContainsKey(type))
-                skills[type] = new SkillRecord { xp = 0f, level = 1 };
+            if (skills.ContainsKey(type))
+                return;
+
+            float xp = save.LoadXp(type);
+            int lvl = xpTable != null ? xpTable.GetLevel(Mathf.FloorToInt(xp)) : 1;
+            skills[type] = new SkillRecord { xp = xp, level = lvl };
         }
 
         /// <summary>
@@ -63,6 +89,42 @@ namespace Skills
         public float GetXp(SkillType skill)
         {
             return skills.TryGetValue(skill, out var record) ? record.xp : 0f;
+        }
+
+        private IEnumerator SaveLoop()
+        {
+            while (true)
+            {
+                yield return new WaitForSeconds(10f);
+                Save();
+            }
+        }
+
+        private void Save()
+        {
+            foreach (var kvp in skills)
+                save.SaveXp(kvp.Key, kvp.Value.xp);
+        }
+    }
+
+    public interface ICombatSkillSave
+    {
+        float LoadXp(SkillType type);
+        void SaveXp(SkillType type, float xp);
+    }
+
+    public class SaveManagerCombatSkillSave : ICombatSkillSave
+    {
+        private static string Key(SkillType type) => $"{type.ToString().ToLowerInvariant()}_xp";
+
+        public float LoadXp(SkillType type)
+        {
+            return SaveManager.Load<float>(Key(type));
+        }
+
+        public void SaveXp(SkillType type, float xp)
+        {
+            SaveManager.Save(Key(type), xp);
         }
     }
 }


### PR DESCRIPTION
## Summary
- persist attack, strength and defence XP using SaveManager
- add save loop and custom save-provider interface for combat skills

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a45d9cdea8832eb33e0afed0b86b0e