### PR TITLE
Require proximity for combat

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -36,6 +36,8 @@ namespace Combat
         {
             if (target == null || !target.IsAlive)
                 return false;
+            if (Vector2.Distance(transform.position, target.transform.position) > CombatMath.MELEE_RANGE)
+                return false;
             StopAllCoroutines();
             StartCoroutine(AttackRoutine(target));
             return true;
@@ -45,6 +47,8 @@ namespace Combat
         {
             while (target != null && target.IsAlive)
             {
+                if (Vector2.Distance(transform.position, target.transform.position) > CombatMath.MELEE_RANGE)
+                    yield break;
                 OnAttackStart?.Invoke();
                 ResolveAttack(target);
                 float interval = equipment != null ? equipment.GetCombinedStats().attackSpeedTicks * CombatMath.TICK_SECONDS : 4 * CombatMath.TICK_SECONDS;

--- a/Assets/Scripts/Combat/CombatMath.cs
+++ b/Assets/Scripts/Combat/CombatMath.cs
@@ -12,6 +12,9 @@ namespace Combat
 
         public const float MIN_HIT_CHANCE = 0.25f;
 
+        /// <summary>Maximum distance allowed for melee combat.</summary>
+        public const float MELEE_RANGE = 1.5f;
+
         public static int GetEffectiveAttack(int level, CombatStyle style)
         {
             int bonus = style switch

--- a/Assets/Scripts/NPC/NpcAttackController.cs
+++ b/Assets/Scripts/NPC/NpcAttackController.cs
@@ -32,6 +32,8 @@ namespace NPC
             var wait = new WaitForSeconds(4 * CombatMath.TICK_SECONDS);
             while (target != null && target.IsAlive && combatant.IsAlive)
             {
+                if (Vector2.Distance(target.transform.position, transform.position) > CombatMath.MELEE_RANGE)
+                    yield break;
                 ResolveAttack(target);
                 yield return wait;
             }

--- a/Assets/Scripts/NPC/NpcAttackOnClick.cs
+++ b/Assets/Scripts/NPC/NpcAttackOnClick.cs
@@ -22,6 +22,8 @@ namespace NPC
             var playerController = FindObjectOfType<CombatController>();
             if (playerController == null)
                 return;
+            if (Vector2.Distance(playerController.transform.position, transform.position) > CombatMath.MELEE_RANGE)
+                return;
             if (playerController.TryAttackTarget(combatant))
             {
                 var npcAttack = GetComponent<NpcAttackController>();


### PR DESCRIPTION
## Summary
- restrict combat initiation to targets within melee range
- halt player and NPC attack routines when combatants separate

## Testing
- `dotnet test` *(fails: MSBUILD error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a461312c30832e8533dd98e27808f5