### PR TITLE
Add F2 debug menu for adjusting player skills

### DIFF
--- a/Assets/Scripts/Player/PlayerHitpoints.cs
+++ b/Assets/Scripts/Player/PlayerHitpoints.cs
@@ -168,6 +168,24 @@ namespace Player
             ApplyDamage(damage);
         }
 
+        /// <summary>
+        /// Debug helper to directly set the hitpoints level. Adjusts XP and
+        /// clamps the current HP to the new maximum.
+        /// </summary>
+        public void DebugSetLevel(int newLevel)
+        {
+            if (xpTable == null)
+                return;
+
+            newLevel = Mathf.Clamp(newLevel, 1, 99);
+            xp = xpTable.GetXpForLevel(newLevel);
+            level = newLevel;
+            if (currentHp > MaxHp)
+                currentHp = MaxHp;
+            OnHitpointsLevelChanged?.Invoke(level);
+            OnHealthChanged?.Invoke(currentHp, MaxHp);
+        }
+
 #if UNITY_EDITOR
         public void DebugDealDamage(int dmg)
         {

--- a/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
@@ -224,6 +224,21 @@ namespace Skills.Mining
             return inventory.CanAddItem(item);
         }
 
+        /// <summary>
+        /// Debug helper to directly set the mining level. Adjusts XP and
+        /// triggers the level up event.
+        /// </summary>
+        public void DebugSetLevel(int newLevel)
+        {
+            if (xpTable == null)
+                return;
+
+            newLevel = Mathf.Clamp(newLevel, 1, 99);
+            xp = xpTable.GetXpForLevel(newLevel);
+            level = newLevel;
+            OnLevelUp?.Invoke(level);
+        }
+
         private void PreloadOreItems()
         {
             oreItems = new Dictionary<string, ItemData>();

--- a/Assets/Scripts/Skills/SkillManager.cs
+++ b/Assets/Scripts/Skills/SkillManager.cs
@@ -91,6 +91,22 @@ namespace Skills
             return skills.TryGetValue(skill, out var record) ? record.xp : 0f;
         }
 
+        /// <summary>
+        /// Debug helper to directly set a skill level. Updates both level and XP
+        /// without awarding XP. Values are clamped to the XP table range.
+        /// </summary>
+        public void DebugSetLevel(SkillType skill, int level)
+        {
+            if (xpTable == null)
+                return;
+
+            level = Mathf.Clamp(level, 1, 99);
+            var record = skills.ContainsKey(skill) ? skills[skill] : new SkillRecord();
+            record.level = level;
+            record.xp = xpTable.GetXpForLevel(level);
+            skills[skill] = record;
+        }
+
         private IEnumerator SaveLoop()
         {
             while (true)

--- a/Assets/Scripts/Skills/SkillsDebugMenu.cs
+++ b/Assets/Scripts/Skills/SkillsDebugMenu.cs
@@ -1,0 +1,127 @@
+using UnityEngine;
+using Player;
+using Skills.Mining;
+using Skills.Woodcutting;
+
+namespace Skills
+{
+    /// <summary>
+    /// Debug menu that allows setting player skill levels. Toggle with F2.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class SkillsDebugMenu : MonoBehaviour
+    {
+        private PlayerHitpoints hitpoints;
+        private SkillManager skillManager;
+        private MiningSkill miningSkill;
+        private WoodcuttingSkill woodcuttingSkill;
+
+        private bool visible;
+        private string hpLevel = "";
+        private string attackLevel = "";
+        private string strengthLevel = "";
+        private string defenceLevel = "";
+        private string miningLevel = "";
+        private string woodcuttingLevel = "";
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void Create()
+        {
+            var go = new GameObject("SkillsDebugMenu");
+            DontDestroyOnLoad(go);
+            go.AddComponent<SkillsDebugMenu>();
+        }
+
+        private void Awake()
+        {
+            DontDestroyOnLoad(gameObject);
+        }
+
+        private void Update()
+        {
+            if (Input.GetKeyDown(KeyCode.F2))
+            {
+                visible = !visible;
+                if (visible)
+                    RefreshFields();
+            }
+
+            if (!visible)
+                return;
+
+            // Ensure references are valid in case scenes change
+            if (hitpoints == null)
+                hitpoints = FindObjectOfType<PlayerHitpoints>();
+            if (skillManager == null)
+                skillManager = FindObjectOfType<SkillManager>();
+            if (miningSkill == null)
+                miningSkill = FindObjectOfType<MiningSkill>();
+            if (woodcuttingSkill == null)
+                woodcuttingSkill = FindObjectOfType<WoodcuttingSkill>();
+        }
+
+        private void RefreshFields()
+        {
+            hitpoints = FindObjectOfType<PlayerHitpoints>();
+            skillManager = FindObjectOfType<SkillManager>();
+            miningSkill = FindObjectOfType<MiningSkill>();
+            woodcuttingSkill = FindObjectOfType<WoodcuttingSkill>();
+
+            hpLevel = hitpoints != null ? hitpoints.Level.ToString() : "";
+            attackLevel = skillManager != null ? skillManager.GetLevel(SkillType.Attack).ToString() : "";
+            strengthLevel = skillManager != null ? skillManager.GetLevel(SkillType.Strength).ToString() : "";
+            defenceLevel = skillManager != null ? skillManager.GetLevel(SkillType.Defence).ToString() : "";
+            miningLevel = miningSkill != null ? miningSkill.Level.ToString() : "";
+            woodcuttingLevel = woodcuttingSkill != null ? woodcuttingSkill.Level.ToString() : "";
+        }
+
+        private void OnGUI()
+        {
+            if (!visible)
+                return;
+
+            const float width = 220f;
+            const float height = 220f;
+            Rect area = new Rect(10f, 10f, width, height);
+            GUILayout.BeginArea(area, GUI.skin.box);
+
+            GUILayout.Label("Hitpoints Level");
+            hpLevel = GUILayout.TextField(hpLevel);
+
+            GUILayout.Label("Attack Level");
+            attackLevel = GUILayout.TextField(attackLevel);
+
+            GUILayout.Label("Strength Level");
+            strengthLevel = GUILayout.TextField(strengthLevel);
+
+            GUILayout.Label("Defence Level");
+            defenceLevel = GUILayout.TextField(defenceLevel);
+
+            GUILayout.Label("Mining Level");
+            miningLevel = GUILayout.TextField(miningLevel);
+
+            GUILayout.Label("Woodcutting Level");
+            woodcuttingLevel = GUILayout.TextField(woodcuttingLevel);
+
+            if (GUILayout.Button("Apply"))
+            {
+                if (hitpoints != null && int.TryParse(hpLevel, out var hp))
+                    hitpoints.DebugSetLevel(hp);
+                if (skillManager != null && int.TryParse(attackLevel, out var atk))
+                    skillManager.DebugSetLevel(SkillType.Attack, atk);
+                if (skillManager != null && int.TryParse(strengthLevel, out var str))
+                    skillManager.DebugSetLevel(SkillType.Strength, str);
+                if (skillManager != null && int.TryParse(defenceLevel, out var def))
+                    skillManager.DebugSetLevel(SkillType.Defence, def);
+                if (miningSkill != null && int.TryParse(miningLevel, out var mine))
+                    miningSkill.DebugSetLevel(mine);
+                if (woodcuttingSkill != null && int.TryParse(woodcuttingLevel, out var wood))
+                    woodcuttingSkill.DebugSetLevel(wood);
+
+                RefreshFields();
+            }
+
+            GUILayout.EndArea();
+        }
+    }
+}

--- a/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
@@ -223,6 +223,21 @@ namespace Skills.Woodcutting
             return inventory.CanAddItem(item);
         }
 
+        /// <summary>
+        /// Debug helper to directly set the woodcutting level. Adjusts XP and
+        /// triggers the level up event.
+        /// </summary>
+        public void DebugSetLevel(int newLevel)
+        {
+            if (xpTable == null)
+                return;
+
+            newLevel = Mathf.Clamp(newLevel, 1, 99);
+            xp = xpTable.GetXpForLevel(newLevel);
+            level = newLevel;
+            OnLevelUp?.Invoke(level);
+        }
+
         private void PreloadLogItems()
         {
             logItems = new Dictionary<string, ItemData>();


### PR DESCRIPTION
## Summary
- add `DebugSetLevel` helpers for combat, hitpoints, mining, and woodcutting skills
- introduce `SkillsDebugMenu` toggled with F2 to change player skill levels

## Testing
- `dotnet build` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a462bf2168832e97f062a92a589231