### PR TITLE
Display weapon over combat target and ensure NPC drops

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -15,6 +15,7 @@ namespace Combat
         public event System.Action OnAttackStart;
         public event System.Action<int, bool> OnAttackLanded;
         public event System.Action<CombatTarget> OnTargetKilled;
+        public event System.Action<CombatTarget> OnCombatTargetChanged;
 
         private SkillManager skills;
         private PlayerHitpoints hitpoints;
@@ -45,15 +46,17 @@ namespace Combat
 
         private IEnumerator AttackRoutine(CombatTarget target)
         {
+            OnCombatTargetChanged?.Invoke(target);
             while (target != null && target.IsAlive)
             {
                 if (Vector2.Distance(transform.position, target.transform.position) > CombatMath.MELEE_RANGE)
-                    yield break;
+                    break;
                 OnAttackStart?.Invoke();
                 ResolveAttack(target);
                 float interval = equipment != null ? equipment.GetCombinedStats().attackSpeedTicks * CombatMath.TICK_SECONDS : 4 * CombatMath.TICK_SECONDS;
                 yield return new WaitForSeconds(interval);
             }
+            OnCombatTargetChanged?.Invoke(null);
         }
 
         private void ResolveAttack(CombatTarget target)

--- a/Assets/Scripts/Combat/CombatWeaponHUD.cs
+++ b/Assets/Scripts/Combat/CombatWeaponHUD.cs
@@ -1,0 +1,79 @@
+using UnityEngine;
+using Inventory;
+
+namespace Combat
+{
+    /// <summary>
+    /// Displays the player's current weapon sprite above the active combat target.
+    /// </summary>
+    public class CombatWeaponHUD : MonoBehaviour
+    {
+        private CombatController controller;
+        private Equipment equipment;
+        private Transform target;
+        private GameObject weaponRoot;
+        private SpriteRenderer weaponRenderer;
+        private readonly Vector3 offset = new Vector3(0f, 0.75f, 0f);
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void CreateInstance()
+        {
+            var go = new GameObject("CombatWeaponHUD");
+            DontDestroyOnLoad(go);
+            go.AddComponent<CombatWeaponHUD>();
+        }
+
+        private void Awake()
+        {
+            controller = FindObjectOfType<CombatController>();
+            if (controller != null)
+                controller.OnCombatTargetChanged += HandleTargetChanged;
+            if (controller != null)
+                equipment = controller.GetComponent<Equipment>();
+            CreateWeaponSprite();
+        }
+
+        private void CreateWeaponSprite()
+        {
+            weaponRoot = new GameObject("CombatWeaponSprite");
+            weaponRoot.transform.SetParent(transform);
+            weaponRenderer = weaponRoot.AddComponent<SpriteRenderer>();
+            weaponRenderer.sortingOrder = 100;
+            weaponRoot.SetActive(false);
+        }
+
+        private void HandleTargetChanged(CombatTarget newTarget)
+        {
+            if (newTarget != null)
+            {
+                target = newTarget.transform;
+                var entry = equipment != null ? equipment.GetEquipped(EquipmentSlot.Weapon) : default;
+                if (entry.item != null && entry.item.icon != null)
+                {
+                    weaponRenderer.sprite = entry.item.icon;
+                    weaponRoot.SetActive(true);
+                }
+            }
+            else
+            {
+                target = null;
+                if (weaponRenderer != null)
+                    weaponRenderer.sprite = null;
+                if (weaponRoot != null)
+                    weaponRoot.SetActive(false);
+            }
+        }
+
+        private void Update()
+        {
+            if (target != null && weaponRoot != null && weaponRoot.activeSelf)
+                weaponRoot.transform.position = target.position + offset;
+        }
+
+        private void OnDestroy()
+        {
+            if (controller != null)
+                controller.OnCombatTargetChanged -= HandleTargetChanged;
+        }
+    }
+}

--- a/Assets/Scripts/NPC/NpcCombatant.cs
+++ b/Assets/Scripts/NPC/NpcCombatant.cs
@@ -7,7 +7,7 @@ namespace NPC
     /// <summary>
     /// Simple adaptor tying an NPC to the combat system using a combat profile.
     /// </summary>
-    [DisallowMultipleComponent]
+    [DisallowMultipleComponent, RequireComponent(typeof(NpcDropper))]
     public class NpcCombatant : MonoBehaviour, CombatTarget
     {
         [SerializeField] private NpcCombatProfile profile;


### PR DESCRIPTION
## Summary
- require `NpcDropper` on NPC combatants so death rolls add loot directly to the player's inventory
- expose combat target change events and notify when combat starts or stops
- show the player's equipped weapon sprite above the current target using a new `CombatWeaponHUD`

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a46495f5e8832e87c4458a5de52c9b