### PR TITLE
Add scroll view to skills debug menu

### DIFF
--- a/Assets/Scripts/Skills/SkillsDebugMenu.cs
+++ b/Assets/Scripts/Skills/SkillsDebugMenu.cs
@@ -24,6 +24,9 @@ namespace Skills
         private string miningLevel = "";
         private string woodcuttingLevel = "";
 
+        // Scroll position for the debug menu
+        private Vector2 scrollPos;
+
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
         private static void Create()
         {
@@ -85,6 +88,9 @@ namespace Skills
             Rect area = new Rect(10f, 10f, width, height);
             GUILayout.BeginArea(area, GUI.skin.box);
 
+            // Begin scroll view so all fields are accessible even if the window is small
+            scrollPos = GUILayout.BeginScrollView(scrollPos, false, true);
+
             GUILayout.Label("Hitpoints Level");
             hpLevel = GUILayout.TextField(hpLevel);
 
@@ -120,6 +126,8 @@ namespace Skills
 
                 RefreshFields();
             }
+
+            GUILayout.EndScrollView();
 
             GUILayout.EndArea();
         }


### PR DESCRIPTION
## Summary
- add scroll view to F2 skills debug menu so all input fields and Apply button are accessible

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a4685a173c832e8bd166783e579f70