### PR TITLE
Log NPC attack outcomes

### DIFF
--- a/Assets/Scripts/NPC/NpcAttackController.cs
+++ b/Assets/Scripts/NPC/NpcAttackController.cs
@@ -68,8 +68,12 @@ namespace NPC
                 int maxHit = CombatMath.GetMaxHit(strEff, attacker.Equip.strength);
                 damage = CombatMath.RollDamage(maxHit);
                 target.ApplyDamage(damage, attacker.DamageType, this);
+                Debug.Log($"{name} dealt {damage} damage to player.");
             }
-            Debug.Log($"{name} dealt {damage} damage to player.");
+            else
+            {
+                Debug.Log($"{name} missed player.");
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Log NPC damage when hitting the player and log misses separately

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a471cfdfc0832ea99b52e4d277798a