### PR TITLE
fix: ensure npcs attack when in range

### DIFF
--- a/Assets/Scripts/NPC/NpcAttackController.cs
+++ b/Assets/Scripts/NPC/NpcAttackController.cs
@@ -30,10 +30,21 @@ namespace NPC
         private IEnumerator AttackRoutine(PlayerCombatTarget target)
         {
             var wait = new WaitForSeconds(4 * CombatMath.TICK_SECONDS);
+
+            // Wait until the player is within melee range before performing the first attack.
+            while (target != null && target.IsAlive && combatant.IsAlive &&
+                   Vector2.Distance(target.transform.position, transform.position) > CombatMath.MELEE_RANGE)
+            {
+                // Poll each frame until the target is close enough or combat ends.
+                yield return null;
+            }
+
             while (target != null && target.IsAlive && combatant.IsAlive)
             {
+                // If the player moves out of melee range, stop attacking.
                 if (Vector2.Distance(target.transform.position, transform.position) > CombatMath.MELEE_RANGE)
                     yield break;
+
                 ResolveAttack(target);
                 yield return wait;
             }


### PR DESCRIPTION
## Summary
- prevent NPC attack routine from exiting before player is in melee range

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a47388f120832eb9cf1542082e91d3