### PR TITLE
Add sprite flip options for pet animations

### DIFF
--- a/Assets/Scripts/Pets/PetDefinition.cs
+++ b/Assets/Scripts/Pets/PetDefinition.cs
@@ -53,6 +53,12 @@ namespace Pets
         [Tooltip("Frames for walking animation when facing right.")]
         public Sprite[] walkRight;
 
+        [Tooltip("If true, flip right-facing sprites to use for left-facing animations.")]
+        public bool useRightSpritesForLeft = true;
+
+        [Tooltip("If true, flip left-facing sprites to use for right-facing animations.")]
+        public bool useLeftSpritesForRight = false;
+
         [Header("UI")]
         [Tooltip("Optional color for drop announcement messages.")]
         public Color messageColor = Color.white;

--- a/Assets/Scripts/Pets/PetSpawner.cs
+++ b/Assets/Scripts/Pets/PetSpawner.cs
@@ -60,6 +60,8 @@ namespace Pets
                 spriteAnim.walkLeft = def.walkLeft;
                 spriteAnim.idleRight = def.idleRight;
                 spriteAnim.walkRight = def.walkRight;
+                spriteAnim.useFlipXForLeft = def.useRightSpritesForLeft;
+                spriteAnim.useFlipXForRight = def.useLeftSpritesForRight;
             }
 
             if (def.animationClips != null && def.animationClips.Length > 0)

--- a/Assets/Scripts/Pets/PetSpriteAnimator.cs
+++ b/Assets/Scripts/Pets/PetSpriteAnimator.cs
@@ -33,6 +33,9 @@ namespace Pets
         [Tooltip("If true, ignore Left arrays and flip the Right sprites for left-facing.")]
         public bool useFlipXForLeft = true;
 
+        [Tooltip("If true, ignore Right arrays and flip the Left sprites for right-facing.")]
+        public bool useFlipXForRight = false;
+
         [Tooltip("Frames per second for the sprite swapping animation.")]
         public float animationFPS = 6f;
 
@@ -71,21 +74,8 @@ namespace Pets
             if (frames <= 0) return;
 
             _animFrame = Mathf.FloorToInt(_animClock) % frames;
-            spriteRenderer.flipX = false;
-
-            if (useFlipXForLeft && _currentDir == 1)
-            {
-                Sprite[] rightSet = SelectSpriteSet(_currentlyMoving, 2, out frames);
-                if (frames > 0)
-                {
-                    _animFrame = Mathf.FloorToInt(_animClock) % frames;
-                    spriteRenderer.sprite = rightSet[_animFrame];
-                    spriteRenderer.flipX = true;
-                    return;
-                }
-            }
-
             spriteRenderer.sprite = set[_animFrame];
+            spriteRenderer.flipX = (_currentDir == 1 && useFlipXForLeft) || (_currentDir == 2 && useFlipXForRight);
         }
 
         /// <summary>Force the animator to face the given direction (0=Down,1=Left,2=Right,3=Up).</summary>
@@ -104,7 +94,7 @@ namespace Pets
                 {
                     case 0: set = walkDown; break;
                     case 1: set = useFlipXForLeft ? walkRight : walkLeft; break;
-                    case 2: set = walkRight; break;
+                    case 2: set = useFlipXForRight ? walkLeft : walkRight; break;
                     case 3: set = walkUp; break;
                 }
             }
@@ -118,7 +108,11 @@ namespace Pets
                             ? (idleRight != null && idleRight.Length > 0 ? idleRight : walkRight)
                             : (idleLeft != null && idleLeft.Length > 0 ? idleLeft : walkLeft);
                         break;
-                    case 2: set = idleRight != null && idleRight.Length > 0 ? idleRight : walkRight; break;
+                    case 2:
+                        set = useFlipXForRight
+                            ? (idleLeft != null && idleLeft.Length > 0 ? idleLeft : walkLeft)
+                            : (idleRight != null && idleRight.Length > 0 ? idleRight : walkRight);
+                        break;
                     case 3: set = idleUp != null && idleUp.Length > 0 ? idleUp : walkUp; break;
                 }
             }


### PR DESCRIPTION
## Summary
- Allow PetDefinition to reuse right or left sprites by flipping
- Support flipping either direction in PetSpriteAnimator
- Propagate flip settings during pet spawning

## Testing
- `dotnet test` *(fails: no project)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d0830ad0832eb9dfa8d20f6c19c0