### PR TITLE
Enable combat-ready pets

### DIFF
--- a/Assets/Scripts/NPC/NPCInteractable.cs
+++ b/Assets/Scripts/NPC/NPCInteractable.cs
@@ -1,6 +1,8 @@
 using UnityEngine;
 using UnityEngine.UI;
 using ShopSystem;
+using Pets;
+using Combat;
 
 namespace NPC
 {
@@ -57,6 +59,14 @@ namespace NPC
         public void Examine()
         {
             Debug.Log($"You examine {name}.");
+        }
+
+        public void AttackWithPet()
+        {
+            var pet = PetDropSystem.ActivePetCombat;
+            var target = GetComponent<CombatTarget>();
+            if (pet != null && target != null)
+                pet.CommandAttack(target);
         }
     }
 }

--- a/Assets/Scripts/NPC/RightClickMenu.cs
+++ b/Assets/Scripts/NPC/RightClickMenu.cs
@@ -1,5 +1,7 @@
 using UnityEngine;
 using UnityEngine.UI;
+using Pets;
+using Combat;
 
 namespace NPC
 {
@@ -11,6 +13,7 @@ namespace NPC
         public Button talkButton;
         public Button shopButton;
         public Button examineButton;
+        public Button petAttackButton;
 
         private NpcInteractable current;
 
@@ -23,12 +26,16 @@ namespace NPC
                 shopButton.onClick.AddListener(() => { current?.OpenShop(); Hide(); });
             if (examineButton != null)
                 examineButton.onClick.AddListener(() => { current?.Examine(); Hide(); });
+            if (petAttackButton != null)
+                petAttackButton.onClick.AddListener(() => { current?.AttackWithPet(); Hide(); });
         }
 
         public void Show(NpcInteractable npc, Vector2 position)
         {
             current = npc;
             transform.position = position;
+            if (petAttackButton != null)
+                petAttackButton.gameObject.SetActive(PetDropSystem.ActivePetCombat != null && npc.GetComponent<CombatTarget>() != null);
             gameObject.SetActive(true);
         }
 

--- a/Assets/Scripts/Pets/PetCombatController.cs
+++ b/Assets/Scripts/Pets/PetCombatController.cs
@@ -1,0 +1,138 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.AI;
+using Combat;
+using EquipmentSystem;
+using NPC;
+
+namespace Pets
+{
+    /// <summary>
+    /// Handles combat behaviour for pets that can fight alongside the player.
+    /// </summary>
+    [RequireComponent(typeof(PetFollower))]
+    [RequireComponent(typeof(NavMeshAgent))]
+    public class PetCombatController : MonoBehaviour
+    {
+        public PetDefinition definition;
+
+        private NavMeshAgent agent;
+        private PetFollower follower;
+        private Animator animator;
+        private CombatTarget currentTarget;
+        private Coroutine attackRoutine;
+
+        private void Awake()
+        {
+            agent = GetComponent<NavMeshAgent>();
+            follower = GetComponent<PetFollower>();
+            animator = GetComponent<Animator>();
+            if (agent != null)
+            {
+                agent.updateRotation = false;
+                agent.updateUpAxis = false;
+            }
+        }
+
+        /// <summary>Returns true if this pet has combat capabilities.</summary>
+        public bool CanFight => definition != null && definition.canFight;
+
+        /// <summary>Order the pet to attack the given combat target.</summary>
+        public void CommandAttack(CombatTarget target)
+        {
+            if (!CanFight || target == null || !target.IsAlive)
+                return;
+
+            currentTarget = target;
+            if (attackRoutine != null)
+                StopCoroutine(attackRoutine);
+            attackRoutine = StartCoroutine(AttackRoutine());
+        }
+
+        private IEnumerator AttackRoutine()
+        {
+            follower.enabled = false;
+            while (currentTarget != null && currentTarget.IsAlive)
+            {
+                agent.SetDestination(currentTarget.transform.position);
+                float dist = Vector2.Distance(transform.position, currentTarget.transform.position);
+                if (dist <= CombatMath.MELEE_RANGE)
+                {
+                    ResolveAttack(currentTarget);
+                    yield return new WaitForSeconds(definition.attackSpeedTicks * CombatMath.TICK_SECONDS);
+                }
+                else if (dist > CombatMath.MELEE_RANGE * 5f)
+                {
+                    break;
+                }
+                else
+                {
+                    yield return null;
+                }
+            }
+            follower.enabled = true;
+            attackRoutine = null;
+            currentTarget = null;
+        }
+
+        private void ResolveAttack(CombatTarget target)
+        {
+            var attacker = new CombatantStats
+            {
+                AttackLevel = definition.petAttackLevel,
+                StrengthLevel = definition.petStrengthLevel,
+                DefenceLevel = 1,
+                Equip = new EquipmentAggregator.CombinedStats
+                {
+                    attack = definition.accuracyBonus,
+                    strength = definition.damageBonus,
+                    attackSpeedTicks = definition.attackSpeedTicks
+                },
+                Style = CombatStyle.Accurate,
+                DamageType = DamageType.Melee
+            };
+
+            CombatantStats defender;
+            if (target is NpcCombatant npc)
+                defender = npc.GetCombatantStats();
+            else
+                defender = new CombatantStats
+                {
+                    AttackLevel = 1,
+                    StrengthLevel = 1,
+                    DefenceLevel = 1,
+                    Equip = new EquipmentAggregator.CombinedStats(),
+                    Style = CombatStyle.Defensive,
+                    DamageType = target.PreferredDefenceType
+                };
+
+            int attEff = CombatMath.GetEffectiveAttack(attacker.AttackLevel, attacker.Style);
+            int defEff = CombatMath.GetEffectiveDefence(defender.DefenceLevel, defender.Style);
+            int atkRoll = CombatMath.GetAttackRoll(attEff, attacker.Equip.attack);
+            int defBonus = defender.DamageType switch
+            {
+                DamageType.Magic => defender.Equip.magicDef,
+                DamageType.Ranged => defender.Equip.rangeDef,
+                _ => defender.Equip.meleeDef
+            };
+            int defRoll = CombatMath.GetDefenceRoll(defEff, defBonus);
+            float chance = CombatMath.ChanceToHit(atkRoll, defRoll);
+            bool hit = Random.value < chance;
+            animator?.SetTrigger("Attack");
+            if (hit)
+            {
+                int strEff = CombatMath.GetEffectiveStrength(attacker.StrengthLevel, attacker.Style);
+                int maxHit = CombatMath.GetMaxHit(strEff, attacker.Equip.strength);
+                int dmg = CombatMath.RollDamage(maxHit);
+                target.ApplyDamage(dmg, attacker.DamageType, this);
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (attackRoutine != null)
+                StopCoroutine(attackRoutine);
+            currentTarget = null;
+        }
+    }
+}

--- a/Assets/Scripts/Pets/PetDefinition.cs
+++ b/Assets/Scripts/Pets/PetDefinition.cs
@@ -59,6 +59,25 @@ namespace Pets
         [Tooltip("If true, flip left-facing sprites to use for right-facing animations.")]
         public bool useLeftSpritesForRight = false;
 
+        [Header("Combat")]
+        [Tooltip("If true, this pet can participate in combat.")]
+        public bool canFight;
+
+        [Tooltip("Attack level used for combat calculations.")]
+        public int petAttackLevel = 1;
+
+        [Tooltip("Strength level used for combat calculations.")]
+        public int petStrengthLevel = 1;
+
+        [Tooltip("Attack speed in OSRS ticks.")]
+        public int attackSpeedTicks = 4;
+
+        [Tooltip("Additional attack accuracy bonus.")]
+        public int accuracyBonus;
+
+        [Tooltip("Additional strength/damage bonus.")]
+        public int damageBonus;
+
         [Header("UI")]
         [Tooltip("Optional color for drop announcement messages.")]
         public Color messageColor = Color.white;

--- a/Assets/Scripts/Pets/PetDropSystem.cs
+++ b/Assets/Scripts/Pets/PetDropSystem.cs
@@ -15,6 +15,8 @@ namespace Pets
         private static GameObject activePetGO;
         private static PetDefinition activePetDef;
         public static PetDefinition ActivePet => activePetDef;
+        public static GameObject ActivePetObject => activePetGO;
+        public static PetCombatController ActivePetCombat => activePetGO != null ? activePetGO.GetComponent<PetCombatController>() : null;
         private static bool initialized;
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]

--- a/Assets/Scripts/Pets/PetSpawner.cs
+++ b/Assets/Scripts/Pets/PetSpawner.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using UnityEngine.AI;
 
 namespace Pets
 {
@@ -106,6 +107,15 @@ namespace Pets
                 follower.SetPlayer(player);
             var clickable = go.AddComponent<PetClickable>();
             clickable.Init(def);
+
+            if (def.canFight)
+            {
+                var agent = go.AddComponent<NavMeshAgent>();
+                agent.updateRotation = false;
+                agent.updateUpAxis = false;
+                var combat = go.AddComponent<PetCombatController>();
+                combat.definition = def;
+            }
 
             return go;
         }


### PR DESCRIPTION
## Summary
- allow pets to have combat stats and optional attack capabilities
- add pet combat controller with pathfinding and OSRS-style damage logic
- expose pet attack through NPC right-click menu

## Testing
- `dotnet test` *(fails: no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e6827b30832e8c62552e47f6f164