### PR TITLE
Enable direct pet attack on right-click

### DIFF
--- a/Assets/Scripts/NPC/NPCInteractable.cs
+++ b/Assets/Scripts/NPC/NPCInteractable.cs
@@ -26,6 +26,12 @@ namespace NPC
         {
             if (Input.GetMouseButtonDown(1))
             {
+                if (PetDropSystem.ActivePetCombat != null && GetComponent<CombatTarget>() != null)
+                {
+                    AttackWithPet();
+                    return;
+                }
+
                 if (menuInstance == null)
                 {
                     var canvasGO = new GameObject("ContextMenuCanvas", typeof(Canvas), typeof(CanvasScaler),

--- a/Assets/Scripts/NPC/RightClickMenu.cs
+++ b/Assets/Scripts/NPC/RightClickMenu.cs
@@ -1,7 +1,5 @@
 using UnityEngine;
 using UnityEngine.UI;
-using Pets;
-using Combat;
 
 namespace NPC
 {
@@ -13,7 +11,6 @@ namespace NPC
         public Button talkButton;
         public Button shopButton;
         public Button examineButton;
-        public Button petAttackButton;
 
         private NpcInteractable current;
 
@@ -26,16 +23,12 @@ namespace NPC
                 shopButton.onClick.AddListener(() => { current?.OpenShop(); Hide(); });
             if (examineButton != null)
                 examineButton.onClick.AddListener(() => { current?.Examine(); Hide(); });
-            if (petAttackButton != null)
-                petAttackButton.onClick.AddListener(() => { current?.AttackWithPet(); Hide(); });
         }
 
         public void Show(NpcInteractable npc, Vector2 position)
         {
             current = npc;
             transform.position = position;
-            if (petAttackButton != null)
-                petAttackButton.gameObject.SetActive(PetDropSystem.ActivePetCombat != null && npc.GetComponent<CombatTarget>() != null);
             gameObject.SetActive(true);
         }
 


### PR DESCRIPTION
## Summary
- enable pets to attack combat NPCs directly when right-clicked
- simplify NPC right-click menu by removing pet attack option

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*


------
https://chatgpt.com/codex/tasks/task_e_68a4ef13ed78832e9caab1ba9400dff3