### PR TITLE
Support static attack sprite for pets without Animator

### DIFF
--- a/Assets/Scripts/Pets/PetDefinition.cs
+++ b/Assets/Scripts/Pets/PetDefinition.cs
@@ -28,6 +28,9 @@ namespace Pets
         [Tooltip("Optional animation clips. If set, the pet will play these using an Animator.")]
         public AnimationClip[] animationClips;
 
+        [Tooltip("Sprite used when attacking if no Animator is present.")]
+        public Sprite attackSprite;
+
         [Header("Frame-based Sprites")]
         [Tooltip("Frames for idle animation when facing up.")]
         public Sprite[] idleUp;


### PR DESCRIPTION
## Summary
- allow pets to specify a static attack sprite when no Animator is used
- swap sprites during attacks if Animator component is absent

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f312200c832eabb91c54766babda