### PR TITLE
Grant Beaver and Rock Golem pets double resource yields

### DIFF
--- a/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using Inventory;
 using Util;
 using Skills.Mining;
+using Pets;
 
 namespace Skills.Mining
 {
@@ -141,9 +142,10 @@ namespace Skills.Mining
                 if (ore != null)
                 {
                     oreItems.TryGetValue(ore.Id, out var item);
+                    int amount = PetDropSystem.ActivePet?.id == "Rock Golem" ? 2 : 1;
                     bool added = false;
                     if (item != null && inventory != null)
-                        added = inventory.AddItem(item);
+                        added = inventory.AddItem(item, amount);
 
                     Transform anchorTransform = floatingTextAnchor != null
                         ? floatingTextAnchor
@@ -157,10 +159,10 @@ namespace Skills.Mining
                         return;
                     }
 
-                    xp += ore.XpPerOre;
-                    FloatingText.Show($"+1 {ore.DisplayName}", anchorPos);
-                    StartCoroutine(ShowXpGainDelayed(ore.XpPerOre, anchorTransform));
-                    OnOreGained?.Invoke(ore.Id, 1);
+                    xp += ore.XpPerOre * amount;
+                    FloatingText.Show($"+{amount} {ore.DisplayName}", anchorPos);
+                    StartCoroutine(ShowXpGainDelayed(ore.XpPerOre * amount, anchorTransform));
+                    OnOreGained?.Invoke(ore.Id, amount);
 
                     int newLevel = xpTable.GetLevel(xp);
                     if (newLevel > level)

--- a/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using Inventory;
 using Util;
 using Skills.Mining; // reuse XP table
+using Pets;
 
 namespace Skills.Woodcutting
 {
@@ -136,9 +137,10 @@ namespace Skills.Woodcutting
             {
                 string logId = currentTree.def.LogItemId;
                 logItems.TryGetValue(logId, out var item);
+                int amount = PetDropSystem.ActivePet?.id == "Beaver" ? 2 : 1;
                 bool added = false;
                 if (item != null && inventory != null)
-                    added = inventory.AddItem(item);
+                    added = inventory.AddItem(item, amount);
 
                 Transform anchorTransform = floatingTextAnchor != null ? floatingTextAnchor : transform;
                 Vector3 anchorPos = anchorTransform.position;
@@ -150,11 +152,11 @@ namespace Skills.Woodcutting
                     return;
                 }
 
-                xp += currentTree.def.XpPerLog;
+                xp += currentTree.def.XpPerLog * amount;
                 string logName = item != null ? item.itemName : currentTree.def.DisplayName;
-                FloatingText.Show($"+1 {logName}", anchorPos);
-                StartCoroutine(ShowXpGainDelayed(currentTree.def.XpPerLog, anchorTransform));
-                OnLogGained?.Invoke(logId, 1);
+                FloatingText.Show($"+{amount} {logName}", anchorPos);
+                StartCoroutine(ShowXpGainDelayed(currentTree.def.XpPerLog * amount, anchorTransform));
+                OnLogGained?.Invoke(logId, amount);
 
                 int newLevel = xpTable.GetLevel(xp);
                 if (newLevel > level)


### PR DESCRIPTION
## Summary
- Woodcutting now awards two logs per chop when the Beaver pet is active
- Mining now grants two ore per successful swing when the Rock Golem pet is active

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fa2c7ec0832e84c4ef4f17d8bc96