### PR TITLE
Award Beastmaster XP when pets assist gathering

### DIFF
--- a/Assets/Scripts/Skills/BeastmasterXp.cs
+++ b/Assets/Scripts/Skills/BeastmasterXp.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using Skills;
+using Pets;
 
 /// <summary>
 /// Grants Beastmaster XP to the owning player when their pet deals damage.
@@ -25,6 +26,28 @@ public static class BeastmasterXp
         if (dmgInt <= 0) return;
 
         float xp = dmgInt * 4f; // 4 XP per 1 damage
+        skills.AddXP(SkillType.Beastmaster, xp);
+    }
+
+    /// <summary>
+    /// Grants Beastmaster XP to the owning player when their pet assists them
+    /// in gathering or other non-combat actions.
+    /// Safe to call even if there is no active pet or owner.
+    /// </summary>
+    public static void TryGrantFromPetAssist(float xp)
+    {
+        if (xp <= 0f) return;
+
+        var pet = PetDropSystem.ActivePetObject;
+        if (pet == null) return;
+
+        var follower = pet.GetComponent<PetFollower>();
+        var owner = follower != null ? follower.Player : null;
+        if (owner == null) return;
+
+        var skills = owner.GetComponent<SkillManager>();
+        if (skills == null) return;
+
         skills.AddXP(SkillType.Beastmaster, xp);
     }
 }

--- a/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
@@ -143,6 +143,8 @@ namespace Skills.Mining
                 {
                     oreItems.TryGetValue(ore.Id, out var item);
                     int amount = PetDropSystem.ActivePet?.id == "Rock Golem" ? 2 : 1;
+                    if (amount > 1)
+                        BeastmasterXp.TryGrantFromPetAssist(ore.XpPerOre * (amount - 1));
                     bool added = false;
                     if (item != null && inventory != null)
                         added = inventory.AddItem(item, amount);

--- a/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
@@ -138,6 +138,8 @@ namespace Skills.Woodcutting
                 string logId = currentTree.def.LogItemId;
                 logItems.TryGetValue(logId, out var item);
                 int amount = PetDropSystem.ActivePet?.id == "Beaver" ? 2 : 1;
+                if (amount > 1)
+                    BeastmasterXp.TryGrantFromPetAssist(currentTree.def.XpPerLog * (amount - 1));
                 bool added = false;
                 if (item != null && inventory != null)
                     added = inventory.AddItem(item, amount);


### PR DESCRIPTION
## Summary
- add `TryGrantFromPetAssist` to award Beastmaster XP when a pet helps its owner
- trigger Beastmaster XP when Beaver doubles logs and Rock Golem doubles ore

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a505ca91a8832e826d866dc66dc52e