### PR TITLE
Scale pet combat by Beastmaster skill

### DIFF
--- a/Assets/Scripts/Pets/PetCombatController.cs
+++ b/Assets/Scripts/Pets/PetCombatController.cs
@@ -109,6 +109,20 @@ namespace Pets
                 DamageType = DamageType.Melee
             };
 
+            // scale stats based on the owner's Beastmaster level
+            var owner = follower != null ? follower.Player : null;
+            int beastmasterLevel = 1;
+            if (owner != null && owner.TryGetComponent<SkillManager>(out var skills))
+                beastmasterLevel = skills.GetLevel(SkillType.Beastmaster);
+
+            if (definition != null)
+            {
+                if (definition.attackLevelPerBeastmasterLevel != 0f)
+                    attacker.AttackLevel = Mathf.RoundToInt(attacker.AttackLevel * (1f + definition.attackLevelPerBeastmasterLevel * beastmasterLevel));
+                if (definition.strengthLevelPerBeastmasterLevel != 0f)
+                    attacker.StrengthLevel = Mathf.RoundToInt(attacker.StrengthLevel * (1f + definition.strengthLevelPerBeastmasterLevel * beastmasterLevel));
+            }
+
             CombatantStats defender;
             if (target is NpcCombatant npc)
                 defender = npc.GetCombatantStats();
@@ -147,9 +161,10 @@ namespace Pets
             {
                 int strEff = CombatMath.GetEffectiveStrength(attacker.StrengthLevel, attacker.Style);
                 int maxHit = CombatMath.GetMaxHit(strEff, attacker.Equip.strength);
+                if (definition != null && definition.maxHitPerBeastmasterLevel != 0f)
+                    maxHit = Mathf.RoundToInt(maxHit * (1f + definition.maxHitPerBeastmasterLevel * beastmasterLevel));
                 int dmg = CombatMath.RollDamage(maxHit);
                 target.ApplyDamage(dmg, attacker.DamageType, this);
-                var owner = follower != null ? follower.Player : null;
                 BeastmasterXp.TryGrantFromPetDamage(owner != null ? owner.gameObject : null, dmg);
             }
         }

--- a/Assets/Scripts/Pets/PetDefinition.cs
+++ b/Assets/Scripts/Pets/PetDefinition.cs
@@ -81,6 +81,15 @@ namespace Pets
         [Tooltip("Additional strength/damage bonus.")]
         public int damageBonus;
 
+        [Tooltip("Attack level multiplier applied per Beastmaster level (e.g. 0.05 for +5% per level).")]
+        public float attackLevelPerBeastmasterLevel;
+
+        [Tooltip("Strength level multiplier applied per Beastmaster level (e.g. 0.05 for +5% per level).")]
+        public float strengthLevelPerBeastmasterLevel;
+
+        [Tooltip("Max hit multiplier applied per Beastmaster level (e.g. 0.05 for +5% per level).")]
+        public float maxHitPerBeastmasterLevel;
+
         [Header("UI")]
         [Tooltip("Optional color for drop announcement messages.")]
         public Color messageColor = Color.white;


### PR DESCRIPTION
## Summary
- scale pet attack, strength and damage using the owner's Beastmaster level
- add Beastmaster scaling fields to `PetDefinition`

## Testing
- `dotnet test` *(fails: MSB1003 Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a506e04e10832eb32a25d1dd0a2678