### PR TITLE
Prevent pet attack spamming and add max hit tester

### DIFF
--- a/Assets/Scripts/Pets/PetCombatController.cs
+++ b/Assets/Scripts/Pets/PetCombatController.cs
@@ -48,6 +48,10 @@ namespace Pets
             if (!CanFight || target == null || !target.IsAlive)
                 return;
 
+            // Prevent restarting the attack routine when already attacking the same target.
+            if (currentTarget == target && attackRoutine != null)
+                return;
+
             currentTarget = target;
             if (attackRoutine != null)
                 StopCoroutine(attackRoutine);

--- a/Assets/Scripts/Pets/PetDefinition.cs
+++ b/Assets/Scripts/Pets/PetDefinition.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using Inventory;
+using Combat;
 
 namespace Pets
 {
@@ -93,5 +94,37 @@ namespace Pets
         [Header("UI")]
         [Tooltip("Optional color for drop announcement messages.")]
         public Color messageColor = Color.white;
+
+#if UNITY_EDITOR
+        [Header("Debugging")]
+        [Tooltip("Beastmaster level used when testing max hit via context menu.")]
+        public int debugBeastmasterLevel = 1;
+
+        [ContextMenu("Test Max Hit")]
+        private void TestMaxHit()
+        {
+            int max = GetMaxHit(debugBeastmasterLevel);
+            Debug.Log($"{displayName} max hit at level {debugBeastmasterLevel}: {max}");
+        }
+#endif
+
+        /// <summary>
+        /// Calculate the maximum hit this pet can deal for a given Beastmaster level.
+        /// </summary>
+        /// <param name="beastmasterLevel">Owner's Beastmaster skill level.</param>
+        public int GetMaxHit(int beastmasterLevel)
+        {
+            int strength = petStrengthLevel;
+            if (strengthLevelPerBeastmasterLevel != 0f)
+                strength = Mathf.RoundToInt(strength * (1f + strengthLevelPerBeastmasterLevel * beastmasterLevel));
+
+            int effectiveStrength = CombatMath.GetEffectiveStrength(strength, CombatStyle.Accurate);
+            int maxHit = CombatMath.GetMaxHit(effectiveStrength, damageBonus);
+
+            if (maxHitPerBeastmasterLevel != 0f)
+                maxHit = Mathf.RoundToInt(maxHit * (1f + maxHitPerBeastmasterLevel * beastmasterLevel));
+
+            return maxHit;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- avoid restarting pet attack routine when repeatedly commanding attack on same NPC
- add debug utility on PetDefinition for calculating pet max hit at a given Beastmaster level

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a50e4d25b0832ea73ab8dfff9b5fa3