### PR TITLE
Add directional hit animations for pets

### DIFF
--- a/Assets/Scripts/Pets/PetCombatController.cs
+++ b/Assets/Scripts/Pets/PetCombatController.cs
@@ -153,8 +153,27 @@ namespace Pets
             int defRoll = CombatMath.GetDefenceRoll(defEff, defBonus);
             float chance = CombatMath.ChanceToHit(atkRoll, defRoll);
             bool hit = Random.value < chance;
+
+            int facingDir = 0;
+            Vector2 diff = target.transform.position - transform.position;
+            if (Mathf.Abs(diff.x) > Mathf.Abs(diff.y))
+                facingDir = diff.x < 0f ? 1 : 2;
+            else
+                facingDir = diff.y < 0f ? 0 : 3;
+
+            if (spriteAnimator != null)
+                spriteAnimator.SetFacing(facingDir);
+            else if (spriteRenderer != null)
+                spriteRenderer.flipX = facingDir == 2;
+
             if (animator != null)
                 animator.SetTrigger("Attack");
+            else if (spriteAnimator != null && spriteAnimator.HasHitAnimation(facingDir))
+            {
+                if (spriteSwapRoutine != null)
+                    StopCoroutine(spriteSwapRoutine);
+                spriteSwapRoutine = StartCoroutine(spriteAnimator.PlayHitAnimation(facingDir));
+            }
             else if (spriteRenderer != null && definition != null && definition.attackSprite != null)
             {
                 if (spriteSwapRoutine != null)

--- a/Assets/Scripts/Pets/PetDefinition.cs
+++ b/Assets/Scripts/Pets/PetDefinition.cs
@@ -32,6 +32,18 @@ namespace Pets
         [Tooltip("Sprite used when attacking if no Animator is present.")]
         public Sprite attackSprite;
 
+        [Tooltip("Frames for hit animation when facing up.")]
+        public Sprite[] hitUp;
+
+        [Tooltip("Frames for hit animation when facing down.")]
+        public Sprite[] hitDown;
+
+        [Tooltip("Frames for hit animation when facing left.")]
+        public Sprite[] hitLeft;
+
+        [Tooltip("Frames for hit animation when facing right.")]
+        public Sprite[] hitRight;
+
         [Header("Frame-based Sprites")]
         [Tooltip("Frames for idle animation when facing up.")]
         public Sprite[] idleUp;
@@ -57,10 +69,10 @@ namespace Pets
         [Tooltip("Frames for walking animation when facing right.")]
         public Sprite[] walkRight;
 
-        [Tooltip("If true, flip right-facing sprites to use for left-facing animations.")]
+        [Tooltip("If true, flip right-facing sprites to use for left-facing animations (idle/walk/hit).")] 
         public bool useRightSpritesForLeft = true;
 
-        [Tooltip("If true, flip left-facing sprites to use for right-facing animations.")]
+        [Tooltip("If true, flip left-facing sprites to use for right-facing animations (idle/walk/hit).")] 
         public bool useLeftSpritesForRight = false;
 
         [Header("Combat")]

--- a/Assets/Scripts/Pets/PetSpawner.cs
+++ b/Assets/Scripts/Pets/PetSpawner.cs
@@ -47,7 +47,11 @@ namespace Pets
                 (def.idleLeft != null && def.idleLeft.Length > 0) ||
                 (def.walkLeft != null && def.walkLeft.Length > 0) ||
                 (def.idleRight != null && def.idleRight.Length > 0) ||
-                (def.walkRight != null && def.walkRight.Length > 0);
+                (def.walkRight != null && def.walkRight.Length > 0) ||
+                (def.hitUp != null && def.hitUp.Length > 0) ||
+                (def.hitDown != null && def.hitDown.Length > 0) ||
+                (def.hitLeft != null && def.hitLeft.Length > 0) ||
+                (def.hitRight != null && def.hitRight.Length > 0);
 
             if (hasFrameSprites && (def.animationClips == null || def.animationClips.Length == 0))
             {
@@ -61,6 +65,10 @@ namespace Pets
                 spriteAnim.walkLeft = def.walkLeft;
                 spriteAnim.idleRight = def.idleRight;
                 spriteAnim.walkRight = def.walkRight;
+                spriteAnim.hitUp = def.hitUp;
+                spriteAnim.hitDown = def.hitDown;
+                spriteAnim.hitLeft = def.hitLeft;
+                spriteAnim.hitRight = def.hitRight;
                 spriteAnim.useFlipXForLeft = def.useRightSpritesForLeft;
                 spriteAnim.useFlipXForRight = def.useLeftSpritesForRight;
             }


### PR DESCRIPTION
## Summary
- Support directional hit animations for pets with up/down/left/right frames and flipping options
- Spawn pets with hit animations and play them during combat
- Orient pets during attacks and trigger hit animation coroutine

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a51413cd78832ebac3526da64204f0