### PR TITLE
Shorten pet post-combat attack delay

### DIFF
--- a/Assets/Scripts/Pets/PetCombatController.cs
+++ b/Assets/Scripts/Pets/PetCombatController.cs
@@ -78,7 +78,10 @@ namespace Pets
                 if (dist <= CombatMath.MELEE_RANGE)
                 {
                     ResolveAttack(currentTarget);
-                    yield return new WaitForSeconds(definition.attackSpeedTicks * CombatMath.TICK_SECONDS);
+                    int waitTicks = definition.attackSpeedTicks;
+                    if (currentTarget == null || !currentTarget.IsAlive)
+                        waitTicks = Mathf.Min(waitTicks, 2);
+                    yield return new WaitForSeconds(waitTicks * CombatMath.TICK_SECONDS);
                 }
                 else if (dist > CombatMath.MELEE_RANGE * 5f)
                 {


### PR DESCRIPTION
## Summary
- Reduce pet attack routine wait to 2 ticks after their target dies so they return to idle faster

## Testing
- `dotnet test` (fails: MSBUILD : error MSB1003: Specify a project or solution file)`

------
https://chatgpt.com/codex/tasks/task_e_68a556bde28c832e8b00bb93a32e0283