### PR TITLE
Add pixels-per-unit scaling option for pets

### DIFF
--- a/Assets/Scripts/Pets/PetDefinition.cs
+++ b/Assets/Scripts/Pets/PetDefinition.cs
@@ -26,6 +26,9 @@ namespace Pets
         [Tooltip("Idle sprite if no animation clips are provided.")]
         public Sprite sprite;
 
+        [Tooltip("Pixels per unit used to scale this pet's sprites.")]
+        public float pixelsPerUnit = 64f;
+
         [Tooltip("Optional animation clips. If set, the pet will play these using an Animator.")]
         public AnimationClip[] animationClips;
 

--- a/Assets/Scripts/Pets/PetSpawner.cs
+++ b/Assets/Scripts/Pets/PetSpawner.cs
@@ -39,6 +39,14 @@ namespace Pets
             if (sr.sprite != null && sr.sprite.texture != null)
                 sr.sprite.texture.filterMode = FilterMode.Point;
 
+            // Scale based on desired pixels per unit
+            if (def.pixelsPerUnit > 0f)
+            {
+                float spritePPU = sr.sprite != null ? sr.sprite.pixelsPerUnit : 64f;
+                float scale = spritePPU / def.pixelsPerUnit;
+                go.transform.localScale = new Vector3(scale, scale, 1f);
+            }
+
             bool hasFrameSprites =
                 (def.idleUp != null && def.idleUp.Length > 0) ||
                 (def.walkUp != null && def.walkUp.Length > 0) ||


### PR DESCRIPTION
## Summary
- allow specifying desired pixels-per-unit for a pet
- scale spawned pet sprites based on the definition's PPU

## Testing
- `dotnet test` *(fails: MSB1003 no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a579d74e08832eab6663cbde890f87