### PR TITLE
Add pet experience and evolution system

### DIFF
--- a/Assets/Scripts/Pets/PetCombatController.cs
+++ b/Assets/Scripts/Pets/PetCombatController.cs
@@ -115,6 +115,12 @@ namespace Pets
                 Style = CombatStyle.Accurate,
                 DamageType = DamageType.Melee
             };
+            var exp = GetComponent<PetExperience>();
+            float statMult = exp != null ? PetExperience.GetStatMultiplier(exp.Level) : 1f;
+            attacker.AttackLevel = Mathf.RoundToInt(attacker.AttackLevel * statMult);
+            attacker.StrengthLevel = Mathf.RoundToInt(attacker.StrengthLevel * statMult);
+            attacker.Equip.attack = Mathf.RoundToInt(attacker.Equip.attack * statMult);
+            attacker.Equip.strength = Mathf.RoundToInt(attacker.Equip.strength * statMult);
 
             // scale stats based on the owner's Beastmaster level
             var owner = follower != null ? follower.Player : null;

--- a/Assets/Scripts/Pets/PetDefinition.cs
+++ b/Assets/Scripts/Pets/PetDefinition.cs
@@ -29,6 +29,16 @@ namespace Pets
         [Tooltip("Pixels per unit used to scale this pet's sprites.")]
         public float pixelsPerUnit = 64f;
 
+        [System.Serializable]
+        public struct EvolutionTier
+        {
+            public int level;
+            public float pixelsPerUnit;
+        }
+
+        [Tooltip("Evolution tiers that adjust pixels per unit as the pet levels up.")]
+        public EvolutionTier[] evolutionTiers;
+
         [Tooltip("Optional animation clips. If set, the pet will play these using an Animator.")]
         public AnimationClip[] animationClips;
 

--- a/Assets/Scripts/Pets/PetExperience.cs
+++ b/Assets/Scripts/Pets/PetExperience.cs
@@ -1,0 +1,145 @@
+using System;
+using UnityEngine;
+using Core.Save;
+
+namespace Pets
+{
+    /// <summary>
+    /// Tracks XP and level for an active pet and handles stat scaling/evolution.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class PetExperience : MonoBehaviour
+    {
+        public const int MaxLevel = 50;
+
+        public PetDefinition definition;
+
+        [SerializeField] private float xp;
+        [SerializeField] private int level = 1;
+
+        private SpriteRenderer spriteRenderer;
+        private float currentPpu;
+        private float spritePpu = 64f;
+
+        public event Action<int> OnLevelChanged;
+
+        private static readonly int[] LevelXp = GenerateXpTable(MaxLevel);
+
+        private void Awake()
+        {
+            spriteRenderer = GetComponent<SpriteRenderer>() ?? GetComponentInChildren<SpriteRenderer>();
+            if (spriteRenderer != null && spriteRenderer.sprite != null)
+                spritePpu = spriteRenderer.sprite.pixelsPerUnit;
+            Load();
+            UpdateEvolution();
+        }
+
+        private void OnDisable()
+        {
+            Save();
+        }
+
+        private void OnApplicationQuit()
+        {
+            Save();
+        }
+
+        private void Load()
+        {
+            if (definition == null) return;
+            xp = SaveManager.Load<float>(XpKey(definition.id));
+            level = GetLevel(xp);
+        }
+
+        private void Save()
+        {
+            if (definition == null) return;
+            SaveManager.Save(XpKey(definition.id), xp);
+        }
+
+        private static string XpKey(string id) => $"petxp_{id}";
+
+        public int Level => level;
+        public float Xp => xp;
+
+        public void AddXp(float amount)
+        {
+            if (amount <= 0f || level >= MaxLevel)
+                return;
+            xp += amount;
+            int newLevel = GetLevel(xp);
+            if (newLevel != level)
+            {
+                level = Mathf.Clamp(newLevel, 1, MaxLevel);
+                OnLevelChanged?.Invoke(level);
+                UpdateEvolution();
+            }
+        }
+
+        private static int GetLevel(float xp)
+        {
+            int xpInt = Mathf.FloorToInt(xp);
+            for (int i = LevelXp.Length - 1; i >= 0; i--)
+            {
+                if (xpInt >= LevelXp[i])
+                    return i + 1;
+            }
+            return 1;
+        }
+
+        private static int[] GenerateXpTable(int maxLevel)
+        {
+            int[] xp = new int[maxLevel];
+            int points = 0;
+            for (int level = 1; level <= maxLevel; level++)
+            {
+                if (level == 1)
+                {
+                    xp[0] = 0;
+                    continue;
+                }
+                points += Mathf.FloorToInt(level + 300f * Mathf.Pow(2f, level / 7f));
+                xp[level - 1] = points / 4;
+            }
+            return xp;
+        }
+
+        private void UpdateEvolution()
+        {
+            if (definition == null || spriteRenderer == null)
+                return;
+            float ppu = definition.pixelsPerUnit;
+            if (definition.evolutionTiers != null)
+            {
+                foreach (var tier in definition.evolutionTiers)
+                {
+                    if (level >= tier.level)
+                        ppu = tier.pixelsPerUnit;
+                }
+            }
+            if (Mathf.Approximately(ppu, currentPpu))
+                return;
+            currentPpu = ppu;
+            float scale = spritePpu / ppu;
+            transform.localScale = new Vector3(scale, scale, 1f);
+        }
+
+        public static void AddPetXp(float xp)
+        {
+            if (xp <= 0f) return;
+            var pet = PetDropSystem.ActivePetObject;
+            if (pet == null) return;
+            var exp = pet.GetComponent<PetExperience>();
+            if (exp == null) return;
+            exp.AddXp(xp);
+        }
+
+        public static float GetStatMultiplier(int level)
+        {
+            if (level >= 50) return 1f;
+            if (level >= 25) return 0.75f;
+            return 0.5f;
+        }
+    }
+}
+

--- a/Assets/Scripts/Pets/PetLevelHUD.cs
+++ b/Assets/Scripts/Pets/PetLevelHUD.cs
@@ -1,0 +1,61 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Pets
+{
+    /// <summary>
+    /// Displays the pet's current level above its head.
+    /// </summary>
+    [RequireComponent(typeof(PetExperience))]
+    public class PetLevelHUD : MonoBehaviour
+    {
+        private PetExperience experience;
+        private Canvas canvas;
+        private Text text;
+
+        private void Awake()
+        {
+            experience = GetComponent<PetExperience>();
+            experience.OnLevelChanged += HandleLevelChanged;
+            CreateHud();
+            HandleLevelChanged(experience.Level);
+        }
+
+        private void CreateHud()
+        {
+            var go = new GameObject("PetLevelHUD", typeof(Canvas), typeof(CanvasScaler), typeof(GraphicRaycaster));
+            canvas = go.GetComponent<Canvas>();
+            canvas.renderMode = RenderMode.WorldSpace;
+            canvas.transform.SetParent(transform, false);
+            canvas.transform.localPosition = new Vector3(0f, 1.5f, 0f);
+            canvas.transform.localRotation = Quaternion.identity;
+            canvas.GetComponent<RectTransform>().sizeDelta = new Vector2(1f, 0.3f);
+
+            var textGO = new GameObject("Text", typeof(Text));
+            textGO.transform.SetParent(canvas.transform, false);
+            text = textGO.GetComponent<Text>();
+            text.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            text.alignment = TextAnchor.MiddleCenter;
+            text.color = Color.white;
+            text.fontSize = 14;
+            var rect = text.rectTransform;
+            rect.anchorMin = Vector2.zero;
+            rect.anchorMax = Vector2.one;
+            rect.offsetMin = Vector2.zero;
+            rect.offsetMax = Vector2.zero;
+        }
+
+        private void HandleLevelChanged(int lvl)
+        {
+            if (text != null)
+                text.text = $"Lv {lvl}";
+        }
+
+        private void OnDestroy()
+        {
+            if (experience != null)
+                experience.OnLevelChanged -= HandleLevelChanged;
+        }
+    }
+}
+

--- a/Assets/Scripts/Pets/PetSpawner.cs
+++ b/Assets/Scripts/Pets/PetSpawner.cs
@@ -124,6 +124,10 @@ namespace Pets
             var clickable = go.AddComponent<PetClickable>();
             clickable.Init(def);
 
+            var exp = go.AddComponent<PetExperience>();
+            exp.definition = def;
+            go.AddComponent<PetLevelHUD>();
+
             if (def.canFight)
             {
                 var agent = go.AddComponent<NavMeshAgent>();

--- a/Assets/Scripts/Skills/BeastmasterXp.cs
+++ b/Assets/Scripts/Skills/BeastmasterXp.cs
@@ -11,6 +11,11 @@ public static class BeastmasterXp
 {
     public static void TryGrantFromPetDamage(GameObject ownerPlayer, float damage)
     {
+        int dmgInt = Mathf.Max(0, Mathf.FloorToInt(damage));
+        if (dmgInt <= 0) return;
+
+        PetExperience.AddPetXp(dmgInt * 12f);
+
         if (ownerPlayer == null) return;
 
         var skills = ownerPlayer.GetComponent<SkillManager>();
@@ -21,9 +26,6 @@ public static class BeastmasterXp
             // if (skillsAlt == null) return; else { /* adapt call below to skillsAlt */ }
             return;
         }
-
-        int dmgInt = Mathf.Max(0, Mathf.FloorToInt(damage));
-        if (dmgInt <= 0) return;
 
         float xp = dmgInt * 4f; // 4 XP per 1 damage
         skills.AddXP(SkillType.Beastmaster, xp);
@@ -49,5 +51,6 @@ public static class BeastmasterXp
         if (skills == null) return;
 
         skills.AddXP(SkillType.Beastmaster, xp);
+        PetExperience.AddPetXp(xp * 3f);
     }
 }


### PR DESCRIPTION
## Summary
- Track per-pet XP, levels, and evolution with new `PetExperience` component
- Display pet level above pets and auto-scale based on evolution tiers
- Grant pet XP from Beastmaster hooks and scale combat stats by level

## Testing
- `dotnet build` *(fails: project or solution file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a57ce719d0832e839ec994698426bf