### PR TITLE
Show pet tier names and XP to next level

### DIFF
--- a/Assets/Scripts/NPC/NPCLabel.cs
+++ b/Assets/Scripts/NPC/NPCLabel.cs
@@ -115,7 +115,13 @@ namespace NPC
         {
             if (_tmp == null) return;
             if (_experience)
-                _tmp.text = $"{labelText} Lv {_experience.Level}";
+            {
+                string tier = _experience.TierName;
+                if (string.IsNullOrEmpty(tier))
+                    _tmp.text = $"{labelText} Lv {_experience.Level}";
+                else
+                    _tmp.text = $"{tier} Lv {_experience.Level}";
+            }
             else
                 _tmp.text = labelText;
         }

--- a/Assets/Scripts/Pets/PetDefinition.cs
+++ b/Assets/Scripts/Pets/PetDefinition.cs
@@ -34,6 +34,7 @@ namespace Pets
         {
             public int level;
             public float pixelsPerUnit;
+            public string tierName;
         }
 
         [Tooltip("Evolution tiers that adjust pixels per unit as the pet levels up.")]

--- a/Assets/Scripts/Pets/PetExperience.cs
+++ b/Assets/Scripts/Pets/PetExperience.cs
@@ -10,7 +10,7 @@ namespace Pets
     [DisallowMultipleComponent]
     public class PetExperience : MonoBehaviour
     {
-        public const int MaxLevel = 50;
+        public const int MaxLevel = 99;
 
         public PetDefinition definition;
 
@@ -61,6 +61,14 @@ namespace Pets
 
         public int Level => level;
         public float Xp => xp;
+        public string TierName { get; private set; }
+
+        public int GetXpToNextLevel()
+        {
+            if (level >= MaxLevel)
+                return 0;
+            return LevelXp[level] - Mathf.FloorToInt(xp);
+        }
 
         public void AddXp(float amount)
         {
@@ -106,17 +114,26 @@ namespace Pets
 
         private void UpdateEvolution()
         {
-            if (definition == null || spriteRenderer == null)
+            if (definition == null)
                 return;
+
             float ppu = definition.pixelsPerUnit;
+            string name = string.Empty;
             if (definition.evolutionTiers != null)
             {
                 foreach (var tier in definition.evolutionTiers)
                 {
                     if (level >= tier.level)
+                    {
                         ppu = tier.pixelsPerUnit;
+                        if (!string.IsNullOrEmpty(tier.tierName))
+                            name = tier.tierName;
+                    }
                 }
             }
+            TierName = name;
+            if (spriteRenderer == null)
+                return;
             if (Mathf.Approximately(ppu, currentPpu))
                 return;
             currentPpu = ppu;

--- a/Assets/Scripts/Pets/PetLevelBarHUD.cs
+++ b/Assets/Scripts/Pets/PetLevelBarHUD.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.EventSystems;
 using Player;
 
 namespace Pets
@@ -7,7 +8,7 @@ namespace Pets
     /// <summary>
     /// Displays the pet's level in a golden bar under the player's health bar.
     /// </summary>
-    public class PetLevelBarHUD : MonoBehaviour
+    public class PetLevelBarHUD : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler
     {
         private static PetLevelBarHUD instance;
 
@@ -104,8 +105,34 @@ namespace Pets
 
         private void HandleLevelChanged(int lvl)
         {
-            if (text != null)
-                text.text = $"Lv {lvl}";
+            UpdateLevelText();
+        }
+
+        private void UpdateLevelText()
+        {
+            if (text == null || experience == null)
+                return;
+            string tier = experience.TierName;
+            if (string.IsNullOrEmpty(tier))
+                text.text = $"Lv {experience.Level}";
+            else
+                text.text = $"{tier} Lv {experience.Level}";
+        }
+
+        public void OnPointerEnter(PointerEventData eventData)
+        {
+            if (text == null || experience == null)
+                return;
+            int xp = experience.GetXpToNextLevel();
+            if (xp > 0)
+                text.text = $"{xp} XP till next lvl";
+            else
+                text.text = "Max level";
+        }
+
+        public void OnPointerExit(PointerEventData eventData)
+        {
+            UpdateLevelText();
         }
 
         private void OnDestroy()


### PR DESCRIPTION
## Summary
- allow specifying tier names for pets and track them in `PetExperience`
- display tier name with pet level and show XP remaining when hovering the pet bar
- increase pet max level to 99

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a592fca198832e9d5bb47089b2ddf9