### PR TITLE
Add pet guard mode with right-click menu

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -4,6 +4,7 @@ using EquipmentSystem;
 using Skills;
 using Player;
 using NPC;
+using Pets;
 
 namespace Combat
 {
@@ -62,6 +63,11 @@ namespace Combat
                 npcAttack.BeginAttacking(playerTarget);
             }
             attackRoutine = StartCoroutine(AttackRoutine(target));
+            if (PetDropSystem.GuardModeEnabled)
+            {
+                var pet = PetDropSystem.ActivePetCombat;
+                pet?.CommandAttack(target);
+            }
             return true;
         }
 

--- a/Assets/Scripts/NPC/NPCInteractable.cs
+++ b/Assets/Scripts/NPC/NPCInteractable.cs
@@ -26,7 +26,7 @@ namespace NPC
         {
             if (Input.GetMouseButtonDown(1))
             {
-                if (PetDropSystem.ActivePetCombat != null && GetComponent<CombatTarget>() != null)
+                if (!PetDropSystem.GuardModeEnabled && PetDropSystem.ActivePetCombat != null && GetComponent<CombatTarget>() != null)
                 {
                     AttackWithPet();
                     return;

--- a/Assets/Scripts/Pets/PetDropSystem.cs
+++ b/Assets/Scripts/Pets/PetDropSystem.cs
@@ -18,6 +18,7 @@ namespace Pets
         public static PetDefinition ActivePet => activePetDef;
         public static GameObject ActivePetObject => activePetGO;
         public static PetCombatController ActivePetCombat => activePetGO != null ? activePetGO.GetComponent<PetCombatController>() : null;
+        public static bool GuardModeEnabled { get; set; }
         private static bool initialized;
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]

--- a/Assets/Scripts/Pets/PetLevelBarHUD.cs
+++ b/Assets/Scripts/Pets/PetLevelBarHUD.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.EventSystems;
+using System.Collections;
 using Player;
 
 namespace Pets
@@ -8,12 +9,13 @@ namespace Pets
     /// <summary>
     /// Displays the pet's level in a golden bar under the player's health bar.
     /// </summary>
-    public class PetLevelBarHUD : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler
+    public class PetLevelBarHUD : MonoBehaviour, IPointerClickHandler
     {
         private static PetLevelBarHUD instance;
 
         private PetExperience experience;
         private Text text;
+        private Coroutine xpRoutine;
 
         /// <summary>
         /// Create the pet level bar under the existing health bar.
@@ -119,20 +121,33 @@ namespace Pets
                 text.text = $"{tier} Lv {experience.Level}";
         }
 
-        public void OnPointerEnter(PointerEventData eventData)
+        public void ShowXpToNextLevel()
         {
-            if (text == null || experience == null)
-                return;
-            int xp = experience.GetXpToNextLevel();
-            if (xp > 0)
-                text.text = $"{xp} XP till next lvl";
-            else
-                text.text = "Max level";
+            if (xpRoutine != null)
+                StopCoroutine(xpRoutine);
+            xpRoutine = StartCoroutine(ShowXpRoutine());
         }
 
-        public void OnPointerExit(PointerEventData eventData)
+        private IEnumerator ShowXpRoutine()
         {
+            if (text == null || experience == null)
+                yield break;
+            int xp = experience.GetXpToNextLevel();
+            text.text = xp > 0 ? $"{xp} XP till next lvl" : "Max level";
+            yield return new WaitForSeconds(2f);
             UpdateLevelText();
+            xpRoutine = null;
+        }
+
+        public void ToggleGuardMode()
+        {
+            PetDropSystem.GuardModeEnabled = !PetDropSystem.GuardModeEnabled;
+        }
+
+        public void OnPointerClick(PointerEventData eventData)
+        {
+            if (eventData.button == PointerEventData.InputButton.Right)
+                PetLevelBarMenu.Show(this, eventData.position);
         }
 
         private void OnDestroy()

--- a/Assets/Scripts/Pets/PetLevelBarMenu.cs
+++ b/Assets/Scripts/Pets/PetLevelBarMenu.cs
@@ -1,0 +1,108 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Pets
+{
+    /// <summary>
+    /// Simple context menu for the pet level bar.
+    /// </summary>
+    public class PetLevelBarMenu : MonoBehaviour
+    {
+        private Button xpButton;
+        private Button guardButton;
+        private Text guardText;
+        private PetLevelBarHUD current;
+
+        private static PetLevelBarMenu instance;
+        private static Canvas menuCanvas;
+
+        public static void Show(PetLevelBarHUD hud, Vector2 position)
+        {
+            if (instance == null)
+                CreateInstance();
+            instance.current = hud;
+            instance.guardText.text = PetDropSystem.GuardModeEnabled ? "Guard Mode: On" : "Guard Mode: Off";
+            instance.transform.position = position;
+            instance.gameObject.SetActive(true);
+        }
+
+        private static void CreateInstance()
+        {
+            var canvasGO = new GameObject("PetBarMenuCanvas", typeof(Canvas), typeof(CanvasScaler), typeof(GraphicRaycaster));
+            menuCanvas = canvasGO.GetComponent<Canvas>();
+            menuCanvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            Object.DontDestroyOnLoad(canvasGO);
+
+            var menuGO = new GameObject("PetLevelBarMenu", typeof(Image), typeof(PetLevelBarMenu), typeof(VerticalLayoutGroup), typeof(ContentSizeFitter));
+            menuGO.transform.SetParent(canvasGO.transform, false);
+            var img = menuGO.GetComponent<Image>();
+            img.color = new Color(0f, 0f, 0f, 0.8f);
+
+            var layout = menuGO.GetComponent<VerticalLayoutGroup>();
+            layout.childControlHeight = layout.childControlWidth = true;
+            layout.childForceExpandHeight = layout.childForceExpandWidth = true;
+            var fitter = menuGO.GetComponent<ContentSizeFitter>();
+            fitter.horizontalFit = ContentSizeFitter.FitMode.PreferredSize;
+            fitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+
+            instance = menuGO.GetComponent<PetLevelBarMenu>();
+            instance.xpButton = CreateButton(menuGO.transform, "XP Till Next Level");
+            instance.xpButton.onClick.AddListener(() =>
+            {
+                instance.current?.ShowXpToNextLevel();
+                instance.Hide();
+            });
+
+            instance.guardButton = CreateButton(menuGO.transform, "Guard Mode");
+            instance.guardText = instance.guardButton.GetComponentInChildren<Text>();
+            instance.guardButton.onClick.AddListener(() =>
+            {
+                instance.current?.ToggleGuardMode();
+                instance.Hide();
+            });
+
+            menuGO.SetActive(false);
+        }
+
+        private static Button CreateButton(Transform parent, string label)
+        {
+            var go = new GameObject(label, typeof(Image), typeof(Button), typeof(LayoutElement));
+            go.transform.SetParent(parent, false);
+            var img = go.GetComponent<Image>();
+            img.color = new Color(0.2f, 0.2f, 0.2f, 1f);
+            var le = go.GetComponent<LayoutElement>();
+            le.preferredHeight = 24f;
+            le.preferredWidth = 160f;
+            var btn = go.GetComponent<Button>();
+
+            var textGO = new GameObject("Text", typeof(Text));
+            textGO.transform.SetParent(go.transform, false);
+            var txt = textGO.GetComponent<Text>();
+            txt.text = label;
+            txt.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            txt.alignment = TextAnchor.MiddleCenter;
+            txt.color = Color.white;
+            var rect = txt.rectTransform;
+            rect.anchorMin = Vector2.zero;
+            rect.anchorMax = Vector2.one;
+            rect.offsetMin = rect.offsetMax = Vector2.zero;
+            return btn;
+        }
+
+        public void Hide()
+        {
+            gameObject.SetActive(false);
+            current = null;
+        }
+
+        private void Update()
+        {
+            if (gameObject.activeSelf && Input.GetMouseButtonDown(0))
+            {
+                var rect = GetComponent<RectTransform>();
+                if (!RectTransformUtility.RectangleContainsScreenPoint(rect, Input.mousePosition, menuCanvas != null ? menuCanvas.worldCamera : null))
+                    Hide();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `GuardModeEnabled` flag so pets can auto-attack when enabled
- Replace pet level bar hover with right-click menu including XP and guard toggle
- Integrate guard mode into combat and NPC interactions

## Testing
- `dotnet build` *(fails: project or solution file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a596ade870832e94c6cccb2e02fab5