### PR TITLE
Fix pet XP persistence

### DIFF
--- a/Assets/Scripts/Pets/PetExperience.cs
+++ b/Assets/Scripts/Pets/PetExperience.cs
@@ -30,8 +30,13 @@ namespace Pets
             spriteRenderer = GetComponent<SpriteRenderer>() ?? GetComponentInChildren<SpriteRenderer>();
             if (spriteRenderer != null && spriteRenderer.sprite != null)
                 spritePpu = spriteRenderer.sprite.pixelsPerUnit;
+        }
+
+        private void Start()
+        {
             Load();
             UpdateEvolution();
+            OnLevelChanged?.Invoke(level);
         }
 
         private void OnDisable()
@@ -79,8 +84,8 @@ namespace Pets
             if (newLevel != level)
             {
                 level = Mathf.Clamp(newLevel, 1, MaxLevel);
-                OnLevelChanged?.Invoke(level);
                 UpdateEvolution();
+                OnLevelChanged?.Invoke(level);
             }
         }
 


### PR DESCRIPTION
## Summary
- Load pet XP in Start after definition is assigned and fire level-change event
- Ensure evolution updates before raising level-change event

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a05609d4832ebfbb2b40f1a33ae6