### PR TITLE
Handle sprite-based visuals when merging with pets

### DIFF
--- a/Assets/Scripts/Beastmaster/PlayerVisualBinder.cs
+++ b/Assets/Scripts/Beastmaster/PlayerVisualBinder.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using Pets;
+using Player;
 
 namespace Beastmaster
 {
@@ -10,9 +11,12 @@ namespace Beastmaster
     {
         [SerializeField] private SpriteRenderer spriteRenderer;
         [SerializeField] private Animator animator;
+        [SerializeField] private PlayerMover playerMover;
 
         private RuntimeAnimatorController originalController;
         private Sprite originalSprite;
+        private Sprite origIdleDown, origIdleLeft, origIdleRight, origIdleUp;
+        private Sprite origWalkDown, origWalkLeft, origWalkRight, origWalkUp;
 
         private void Awake()
         {
@@ -24,10 +28,25 @@ namespace Beastmaster
                 animator = GetComponent<Animator>();
             if (animator == null)
                 animator = GetComponentInChildren<Animator>();
+            if (playerMover == null)
+                playerMover = GetComponent<PlayerMover>();
+            if (playerMover == null)
+                playerMover = GetComponentInChildren<PlayerMover>();
             if (spriteRenderer != null)
                 originalSprite = spriteRenderer.sprite;
             if (animator != null)
                 originalController = animator.runtimeAnimatorController;
+            if (playerMover != null)
+            {
+                origIdleDown = playerMover.idleDown;
+                origIdleLeft = playerMover.idleLeft;
+                origIdleRight = playerMover.idleRight;
+                origIdleUp = playerMover.idleUp;
+                origWalkDown = playerMover.walkDown;
+                origWalkLeft = playerMover.walkLeft;
+                origWalkRight = playerMover.walkRight;
+                origWalkUp = playerMover.walkUp;
+            }
         }
 
         /// <summary>
@@ -41,6 +60,17 @@ namespace Beastmaster
                 animator.runtimeAnimatorController = profile.controller;
             if (spriteRenderer != null && profile.baseSprite != null)
                 spriteRenderer.sprite = profile.baseSprite;
+            if (playerMover != null)
+            {
+                if (profile.idleDown != null) playerMover.idleDown = profile.idleDown;
+                if (profile.idleLeft != null) playerMover.idleLeft = profile.idleLeft;
+                if (profile.idleRight != null) playerMover.idleRight = profile.idleRight;
+                if (profile.idleUp != null) playerMover.idleUp = profile.idleUp;
+                if (profile.walkDown != null) playerMover.walkDown = profile.walkDown;
+                if (profile.walkLeft != null) playerMover.walkLeft = profile.walkLeft;
+                if (profile.walkRight != null) playerMover.walkRight = profile.walkRight;
+                if (profile.walkUp != null) playerMover.walkUp = profile.walkUp;
+            }
         }
 
         /// <summary>
@@ -52,6 +82,17 @@ namespace Beastmaster
                 animator.runtimeAnimatorController = originalController;
             if (spriteRenderer != null)
                 spriteRenderer.sprite = originalSprite;
+            if (playerMover != null)
+            {
+                playerMover.idleDown = origIdleDown;
+                playerMover.idleLeft = origIdleLeft;
+                playerMover.idleRight = origIdleRight;
+                playerMover.idleUp = origIdleUp;
+                playerMover.walkDown = origWalkDown;
+                playerMover.walkLeft = origWalkLeft;
+                playerMover.walkRight = origWalkRight;
+                playerMover.walkUp = origWalkUp;
+            }
         }
     }
 }

--- a/Assets/Scripts/Pets/IPetService.cs
+++ b/Assets/Scripts/Pets/IPetService.cs
@@ -15,6 +15,14 @@ namespace Pets
     {
         public RuntimeAnimatorController controller;
         public Sprite baseSprite;
+        public Sprite idleDown;
+        public Sprite idleLeft;
+        public Sprite idleRight;
+        public Sprite idleUp;
+        public Sprite walkDown;
+        public Sprite walkLeft;
+        public Sprite walkRight;
+        public Sprite walkUp;
     }
 
     /// <summary>

--- a/Assets/Scripts/Pets/PetServiceAdapter.cs
+++ b/Assets/Scripts/Pets/PetServiceAdapter.cs
@@ -51,6 +51,18 @@ namespace Pets
                 var sr = pet.GetComponent<SpriteRenderer>();
                 if (sr != null)
                     profile.baseSprite = sr.sprite;
+                var psa = pet.GetComponent<PetSpriteAnimator>();
+                if (psa != null)
+                {
+                    if (psa.idleDown != null && psa.idleDown.Length > 0) profile.idleDown = psa.idleDown[0];
+                    if (psa.idleLeft != null && psa.idleLeft.Length > 0) profile.idleLeft = psa.idleLeft[0];
+                    if (psa.idleRight != null && psa.idleRight.Length > 0) profile.idleRight = psa.idleRight[0];
+                    if (psa.idleUp != null && psa.idleUp.Length > 0) profile.idleUp = psa.idleUp[0];
+                    if (psa.walkDown != null && psa.walkDown.Length > 0) profile.walkDown = psa.walkDown[0];
+                    if (psa.walkLeft != null && psa.walkLeft.Length > 0) profile.walkLeft = psa.walkLeft[0];
+                    if (psa.walkRight != null && psa.walkRight.Length > 0) profile.walkRight = psa.walkRight[0];
+                    if (psa.walkUp != null && psa.walkUp.Length > 0) profile.walkUp = psa.walkUp[0];
+                }
             }
             return profile;
         }


### PR DESCRIPTION
## Summary
- capture base and directional sprites from pets without animators
- apply those sprites to the player mover when merging
- restore original player sprites after merge ends

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c1822354832e8a254505fa158d8d