### PR TITLE
Add merge timer reset button to debug menu

### DIFF
--- a/Assets/Scripts/Beastmaster/PetMergeController.cs
+++ b/Assets/Scripts/Beastmaster/PetMergeController.cs
@@ -131,6 +131,17 @@ namespace Beastmaster
             SaveState();
         }
 
+        /// <summary>Reset merge and cooldown timers to zero.</summary>
+        public void ResetMergeTimer()
+        {
+            if (merged)
+                EndMerge();
+            cooldownRemaining = 0f;
+            durationRemaining = 0f;
+            hudTimer?.Hide();
+            SaveState();
+        }
+
         private void OnDisable()
         {
             SaveState();

--- a/Assets/Scripts/Skills/SkillsDebugMenu.cs
+++ b/Assets/Scripts/Skills/SkillsDebugMenu.cs
@@ -169,6 +169,11 @@ namespace Skills
                 RefreshFields();
             }
 
+            if (GUILayout.Button("Reset Merge Timer"))
+            {
+                PetMergeController.Instance?.ResetMergeTimer();
+            }
+
             GUILayout.EndScrollView();
 
             GUILayout.EndArea();


### PR DESCRIPTION
## Summary
- Add method to PetMergeController to reset merge and cooldown timers
- Expose reset action in F2 skills debug menu

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c32f1d50832e83f37888c3e18e8d