### PR TITLE
Sync player size & flips when merging with pets

### DIFF
--- a/Assets/Scripts/Beastmaster/PlayerVisualBinder.cs
+++ b/Assets/Scripts/Beastmaster/PlayerVisualBinder.cs
@@ -17,6 +17,9 @@ namespace Beastmaster
         private Sprite originalSprite;
         private Sprite origIdleDown, origIdleLeft, origIdleRight, origIdleUp;
         private Sprite origWalkDown, origWalkLeft, origWalkRight, origWalkUp;
+        private Vector3 origScale;
+        private bool origFlipX;
+        private bool origUseFlipXForLeft, origUseFlipXForRight;
 
         private void Awake()
         {
@@ -46,7 +49,11 @@ namespace Beastmaster
                 origWalkLeft = playerMover.walkLeft;
                 origWalkRight = playerMover.walkRight;
                 origWalkUp = playerMover.walkUp;
+                origUseFlipXForLeft = playerMover.useFlipXForLeft;
+                origUseFlipXForRight = playerMover.useFlipXForRight;
             }
+            origScale = transform.localScale;
+            origFlipX = spriteRenderer != null && spriteRenderer.flipX;
         }
 
         /// <summary>
@@ -70,7 +77,12 @@ namespace Beastmaster
                 if (profile.walkLeft != null) playerMover.walkLeft = profile.walkLeft;
                 if (profile.walkRight != null) playerMover.walkRight = profile.walkRight;
                 if (profile.walkUp != null) playerMover.walkUp = profile.walkUp;
+                playerMover.useFlipXForLeft = profile.useFlipXForLeft;
+                playerMover.useFlipXForRight = profile.useFlipXForRight;
             }
+            transform.localScale = profile.localScale;
+            if (spriteRenderer != null)
+                spriteRenderer.flipX = false;
         }
 
         /// <summary>
@@ -81,7 +93,11 @@ namespace Beastmaster
             if (animator != null)
                 animator.runtimeAnimatorController = originalController;
             if (spriteRenderer != null)
+            {
                 spriteRenderer.sprite = originalSprite;
+                spriteRenderer.flipX = origFlipX;
+            }
+            transform.localScale = origScale;
             if (playerMover != null)
             {
                 playerMover.idleDown = origIdleDown;
@@ -92,6 +108,8 @@ namespace Beastmaster
                 playerMover.walkLeft = origWalkLeft;
                 playerMover.walkRight = origWalkRight;
                 playerMover.walkUp = origWalkUp;
+                playerMover.useFlipXForLeft = origUseFlipXForLeft;
+                playerMover.useFlipXForRight = origUseFlipXForRight;
             }
         }
     }

--- a/Assets/Scripts/Pets/IPetService.cs
+++ b/Assets/Scripts/Pets/IPetService.cs
@@ -23,6 +23,9 @@ namespace Pets
         public Sprite walkLeft;
         public Sprite walkRight;
         public Sprite walkUp;
+        public bool useFlipXForLeft;
+        public bool useFlipXForRight;
+        public Vector3 localScale = Vector3.one;
     }
 
     /// <summary>

--- a/Assets/Scripts/Pets/PetServiceAdapter.cs
+++ b/Assets/Scripts/Pets/PetServiceAdapter.cs
@@ -45,6 +45,7 @@ namespace Pets
             var profile = new PetVisualProfile();
             if (pet != null)
             {
+                profile.localScale = pet.transform.localScale;
                 var anim = pet.GetComponent<Animator>();
                 if (anim != null)
                     profile.controller = anim.runtimeAnimatorController;
@@ -62,6 +63,8 @@ namespace Pets
                     if (psa.walkLeft != null && psa.walkLeft.Length > 0) profile.walkLeft = psa.walkLeft[0];
                     if (psa.walkRight != null && psa.walkRight.Length > 0) profile.walkRight = psa.walkRight[0];
                     if (psa.walkUp != null && psa.walkUp.Length > 0) profile.walkUp = psa.walkUp[0];
+                    profile.useFlipXForLeft = psa.useFlipXForLeft;
+                    profile.useFlipXForRight = psa.useFlipXForRight;
                 }
             }
             return profile;

--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -25,6 +25,10 @@ namespace Player
         [Tooltip("If assigned, these sprites will be applied directly each frame based on Dir/IsMoving. Leave null to rely on Animator clips.")]
         public Sprite idleDown, idleLeft, idleRight, idleUp;
         public Sprite walkDown, walkLeft, walkRight, walkUp;
+        [Tooltip("If true, flip right-facing sprites for left-facing movement/idle.")]
+        public bool useFlipXForLeft;
+        [Tooltip("If true, flip left-facing sprites for right-facing movement/idle.")]
+        public bool useFlipXForRight;
 
         private Rigidbody2D rb;
         private Animator anim;
@@ -149,28 +153,82 @@ namespace Player
 
             // --- OPTIONAL: Direct sprite override (solves your 'stuck on IdleDown_0' instantly) ---
             Sprite desired = null;
+            bool flip = false;
             if (isMoving)
             {
                 switch (facingDir)
                 {
-                    case 0: desired = walkDown  ? walkDown  : idleDown;  break;
-                    case 1: desired = walkLeft  ? walkLeft  : idleLeft;  break;
-                    case 2: desired = walkRight ? walkRight : idleRight; break;
-                    case 3: desired = walkUp    ? walkUp    : idleUp;    break;
+                    case 0:
+                        desired = walkDown ? walkDown : idleDown;
+                        break;
+                    case 1:
+                        if (useFlipXForLeft)
+                        {
+                            desired = walkRight ? walkRight : idleRight;
+                            flip = true;
+                        }
+                        else
+                        {
+                            desired = walkLeft ? walkLeft : idleLeft;
+                        }
+                        break;
+                    case 2:
+                        if (useFlipXForRight)
+                        {
+                            desired = walkLeft ? walkLeft : idleLeft;
+                            flip = true;
+                        }
+                        else
+                        {
+                            desired = walkRight ? walkRight : idleRight;
+                        }
+                        break;
+                    case 3:
+                        desired = walkUp ? walkUp : idleUp;
+                        break;
                 }
             }
             else
             {
                 switch (facingDir)
                 {
-                    case 0: desired = idleDown;  break;
-                    case 1: desired = idleLeft;  break;
-                    case 2: desired = idleRight; break;
-                    case 3: desired = idleUp;    break;
+                    case 0:
+                        desired = idleDown;
+                        break;
+                    case 1:
+                        if (useFlipXForLeft)
+                        {
+                            desired = idleRight ? idleRight : walkRight;
+                            flip = true;
+                        }
+                        else
+                        {
+                            desired = idleLeft;
+                        }
+                        break;
+                    case 2:
+                        if (useFlipXForRight)
+                        {
+                            desired = idleLeft ? idleLeft : walkLeft;
+                            flip = true;
+                        }
+                        else
+                        {
+                            desired = idleRight;
+                        }
+                        break;
+                    case 3:
+                        desired = idleUp;
+                        break;
                 }
             }
-            if (desired != null && sr.sprite != desired)
-                sr.sprite = desired;
+            if (desired != null)
+            {
+                if (sr.flipX != flip)
+                    sr.flipX = flip;
+                if (sr.sprite != desired)
+                    sr.sprite = desired;
+            }
             // --------------------------------------------------------------------------------------
         }
 


### PR DESCRIPTION
## Summary
- let merged players flip sprites when pets only provide one lateral direction
- match player scale to the active pet's scale during merge

## Testing
- `dotnet test` *(fails: current directory does not contain a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c61ef224832eb023f0109504ea41