### PR TITLE
Sync player with pet attack animations

### DIFF
--- a/Assets/Scripts/Beastmaster/MergedPetAttackAnimator.cs
+++ b/Assets/Scripts/Beastmaster/MergedPetAttackAnimator.cs
@@ -1,0 +1,86 @@
+using UnityEngine;
+using Combat;
+using Pets;
+using Player;
+
+namespace Beastmaster
+{
+    /// <summary>
+    /// Plays pet attack animations when the player attacks while merged with a pet.
+    /// </summary>
+    public class MergedPetAttackAnimator : MonoBehaviour
+    {
+        [SerializeField] private CombatController combat;
+        [SerializeField] private PlayerMover mover;
+        [SerializeField] private Animator animator;
+        [SerializeField] private PetSpriteAnimator spriteAnimator;
+
+        private void Awake()
+        {
+            if (combat == null)
+                combat = GetComponent<CombatController>() ?? GetComponentInParent<CombatController>();
+            if (mover == null)
+                mover = GetComponent<PlayerMover>() ?? GetComponentInChildren<PlayerMover>();
+            if (animator == null)
+                animator = GetComponent<Animator>() ?? GetComponentInChildren<Animator>();
+            if (spriteAnimator == null)
+                spriteAnimator = GetComponent<PetSpriteAnimator>();
+            if (spriteAnimator == null)
+                spriteAnimator = gameObject.AddComponent<PetSpriteAnimator>();
+        }
+
+        private void OnEnable()
+        {
+            if (combat != null)
+                combat.OnAttackStart += HandleAttack;
+        }
+
+        private void OnDisable()
+        {
+            if (combat != null)
+                combat.OnAttackStart -= HandleAttack;
+        }
+
+        public void ApplyPetLook(PetVisualProfile profile)
+        {
+            if (profile == null || spriteAnimator == null)
+                return;
+            if (spriteAnimator.spriteRenderer == null)
+                spriteAnimator.spriteRenderer = GetComponent<SpriteRenderer>() ?? GetComponentInChildren<SpriteRenderer>();
+            spriteAnimator.hitDown = profile.hitDown;
+            spriteAnimator.hitLeft = profile.hitLeft;
+            spriteAnimator.hitRight = profile.hitRight;
+            spriteAnimator.hitUp = profile.hitUp;
+            spriteAnimator.useFlipXForLeft = profile.useFlipXForLeft;
+            spriteAnimator.useFlipXForRight = profile.useFlipXForRight;
+        }
+
+        public void ClearPetLook()
+        {
+            if (spriteAnimator == null)
+                return;
+            spriteAnimator.hitDown = null;
+            spriteAnimator.hitLeft = null;
+            spriteAnimator.hitRight = null;
+            spriteAnimator.hitUp = null;
+        }
+
+        private void HandleAttack()
+        {
+            int dir = mover != null ? mover.FacingDir : 0;
+            if (animator != null && animator.runtimeAnimatorController != null)
+                animator.SetTrigger("Attack");
+            if (spriteAnimator != null && spriteAnimator.HasHitAnimation(dir))
+                StartCoroutine(PlayHit(dir));
+        }
+
+        private System.Collections.IEnumerator PlayHit(int dir)
+        {
+            if (mover != null)
+                mover.freezeSprite = true;
+            yield return StartCoroutine(spriteAnimator.PlayHitAnimation(dir));
+            if (mover != null)
+                mover.freezeSprite = false;
+        }
+    }
+}

--- a/Assets/Scripts/Beastmaster/PlayerVisualBinder.cs
+++ b/Assets/Scripts/Beastmaster/PlayerVisualBinder.cs
@@ -12,6 +12,7 @@ namespace Beastmaster
         [SerializeField] private SpriteRenderer spriteRenderer;
         [SerializeField] private Animator animator;
         [SerializeField] private PlayerMover playerMover;
+        [SerializeField] private MergedPetAttackAnimator attackAnimator;
 
         private RuntimeAnimatorController originalController;
         private Sprite originalSprite;
@@ -35,6 +36,10 @@ namespace Beastmaster
                 playerMover = GetComponent<PlayerMover>();
             if (playerMover == null)
                 playerMover = GetComponentInChildren<PlayerMover>();
+            if (attackAnimator == null)
+                attackAnimator = GetComponent<MergedPetAttackAnimator>();
+            if (attackAnimator == null)
+                attackAnimator = gameObject.AddComponent<MergedPetAttackAnimator>();
             if (spriteRenderer != null)
                 originalSprite = spriteRenderer.sprite;
             if (animator != null)
@@ -69,20 +74,35 @@ namespace Beastmaster
                 spriteRenderer.sprite = profile.baseSprite;
             if (playerMover != null)
             {
-                if (profile.idleDown != null) playerMover.idleDown = profile.idleDown;
-                if (profile.idleLeft != null) playerMover.idleLeft = profile.idleLeft;
-                if (profile.idleRight != null) playerMover.idleRight = profile.idleRight;
-                if (profile.idleUp != null) playerMover.idleUp = profile.idleUp;
-                if (profile.walkDown != null) playerMover.walkDown = profile.walkDown;
-                if (profile.walkLeft != null) playerMover.walkLeft = profile.walkLeft;
-                if (profile.walkRight != null) playerMover.walkRight = profile.walkRight;
-                if (profile.walkUp != null) playerMover.walkUp = profile.walkUp;
-                playerMover.useFlipXForLeft = profile.useFlipXForLeft;
-                playerMover.useFlipXForRight = profile.useFlipXForRight;
+                if (profile.controller == null)
+                {
+                    if (profile.idleDown != null) playerMover.idleDown = profile.idleDown;
+                    if (profile.idleLeft != null) playerMover.idleLeft = profile.idleLeft;
+                    if (profile.idleRight != null) playerMover.idleRight = profile.idleRight;
+                    if (profile.idleUp != null) playerMover.idleUp = profile.idleUp;
+                    if (profile.walkDown != null) playerMover.walkDown = profile.walkDown;
+                    if (profile.walkLeft != null) playerMover.walkLeft = profile.walkLeft;
+                    if (profile.walkRight != null) playerMover.walkRight = profile.walkRight;
+                    if (profile.walkUp != null) playerMover.walkUp = profile.walkUp;
+                    playerMover.useFlipXForLeft = profile.useFlipXForLeft;
+                    playerMover.useFlipXForRight = profile.useFlipXForRight;
+                }
+                else
+                {
+                    playerMover.idleDown = null;
+                    playerMover.idleLeft = null;
+                    playerMover.idleRight = null;
+                    playerMover.idleUp = null;
+                    playerMover.walkDown = null;
+                    playerMover.walkLeft = null;
+                    playerMover.walkRight = null;
+                    playerMover.walkUp = null;
+                }
             }
             transform.localScale = profile.localScale;
             if (spriteRenderer != null)
                 spriteRenderer.flipX = false;
+            attackAnimator?.ApplyPetLook(profile);
         }
 
         /// <summary>
@@ -111,6 +131,7 @@ namespace Beastmaster
                 playerMover.useFlipXForLeft = origUseFlipXForLeft;
                 playerMover.useFlipXForRight = origUseFlipXForRight;
             }
+            attackAnimator?.ClearPetLook();
         }
     }
 }

--- a/Assets/Scripts/Pets/IPetService.cs
+++ b/Assets/Scripts/Pets/IPetService.cs
@@ -23,6 +23,10 @@ namespace Pets
         public Sprite walkLeft;
         public Sprite walkRight;
         public Sprite walkUp;
+        public Sprite[] hitDown;
+        public Sprite[] hitLeft;
+        public Sprite[] hitRight;
+        public Sprite[] hitUp;
         public bool useFlipXForLeft;
         public bool useFlipXForRight;
         public Vector3 localScale = Vector3.one;

--- a/Assets/Scripts/Pets/PetServiceAdapter.cs
+++ b/Assets/Scripts/Pets/PetServiceAdapter.cs
@@ -63,6 +63,10 @@ namespace Pets
                     if (psa.walkLeft != null && psa.walkLeft.Length > 0) profile.walkLeft = psa.walkLeft[0];
                     if (psa.walkRight != null && psa.walkRight.Length > 0) profile.walkRight = psa.walkRight[0];
                     if (psa.walkUp != null && psa.walkUp.Length > 0) profile.walkUp = psa.walkUp[0];
+                    if (psa.hitDown != null && psa.hitDown.Length > 0) profile.hitDown = psa.hitDown;
+                    if (psa.hitLeft != null && psa.hitLeft.Length > 0) profile.hitLeft = psa.hitLeft;
+                    if (psa.hitRight != null && psa.hitRight.Length > 0) profile.hitRight = psa.hitRight;
+                    if (psa.hitUp != null && psa.hitUp.Length > 0) profile.hitUp = psa.hitUp;
                     profile.useFlipXForLeft = psa.useFlipXForLeft;
                     profile.useFlipXForRight = psa.useFlipXForRight;
                 }

--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -21,6 +21,9 @@ namespace Player
         [HideInInspector]
         public bool CanDrop = true;
 
+        [HideInInspector]
+        public bool freezeSprite = false;
+
         [Header("(Optional) Direct Sprite Override")]
         [Tooltip("If assigned, these sprites will be applied directly each frame based on Dir/IsMoving. Leave null to rely on Animator clips.")]
         public Sprite idleDown, idleLeft, idleRight, idleUp;
@@ -222,7 +225,7 @@ namespace Player
                         break;
                 }
             }
-            if (desired != null)
+            if (desired != null && !freezeSprite)
             {
                 if (sr.flipX != flip)
                     sr.flipX = flip;


### PR DESCRIPTION
## Summary
- allow PlayerMover to freeze sprite updates while attacks play
- include pet attack frames in merge visual data and wiring
- trigger pet-style attack animations when merged player fights

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c886cb4c832ea39508f61fcd29e0