### PR TITLE
Prevent dropping pets while merged

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -618,6 +618,12 @@ namespace Inventory
             // Cache the item before modifying the slot so we can check for pets.
             var droppedItem = entry.item;
 
+            // Prevent dropping or swapping pets while merged with a pet.
+            var pet = PetDropSystem.FindPetByItem(droppedItem);
+            if (pet != null && Beastmaster.PetMergeController.Instance != null &&
+                Beastmaster.PetMergeController.Instance.IsMerged)
+                return;
+
             int remove = Mathf.Clamp(quantity, 1, entry.count);
             entry.count -= remove;
             if (entry.count <= 0)
@@ -628,7 +634,6 @@ namespace Inventory
             OnInventoryChanged?.Invoke();
 
             // Attempt to spawn a pet for this item if one exists.
-            var pet = PetDropSystem.FindPetByItem(droppedItem);
             if (pet != null)
             {
                 // If a different pet is already active, return its pickup item to the inventory


### PR DESCRIPTION
## Summary
- prevent dropping or swapping pets when the player is merged with a pet

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a5cd8ca03c832eb016284246c72813