### PR TITLE
Ensure merge timer anchors to top center

### DIFF
--- a/Assets/Scripts/UI/MergeHudTimer.cs
+++ b/Assets/Scripts/UI/MergeHudTimer.cs
@@ -22,6 +22,14 @@ namespace UI
                 DontDestroyOnLoad(canvasGO);
                 transform.SetParent(canvasGO.transform, false);
             }
+            var rectTransform = GetComponent<RectTransform>();
+            if (rectTransform == null)
+                rectTransform = gameObject.AddComponent<RectTransform>();
+            rectTransform.anchorMin = new Vector2(0.5f, 1f);
+            rectTransform.anchorMax = new Vector2(0.5f, 1f);
+            rectTransform.pivot = new Vector2(0.5f, 1f);
+            rectTransform.anchoredPosition = Vector2.zero;
+
             text = GetComponentInChildren<Text>();
             if (text == null)
             {
@@ -29,13 +37,13 @@ namespace UI
                 textGO.transform.SetParent(transform, false);
                 text = textGO.GetComponent<Text>();
                 text.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
-                text.alignment = TextAnchor.UpperCenter;
-                var rect = text.rectTransform;
-                rect.anchorMin = new Vector2(0.5f, 1f);
-                rect.anchorMax = new Vector2(0.5f, 1f);
-                rect.pivot = new Vector2(0.5f, 1f);
-                rect.anchoredPosition = new Vector2(0f, -10f);
             }
+            text.alignment = TextAnchor.UpperCenter;
+            var rect = text.rectTransform;
+            rect.anchorMin = new Vector2(0.5f, 1f);
+            rect.anchorMax = new Vector2(0.5f, 1f);
+            rect.pivot = new Vector2(0.5f, 1f);
+            rect.anchoredPosition = new Vector2(0f, -10f);
             Hide();
         }
 


### PR DESCRIPTION
## Summary
- fix missing RectTransform for merge HUD timer
- anchor merge timer UI to top center so countdown appears during pet merges

## Testing
- `dotnet test` *(fails: MSB1003 project or solution file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5cf5b8aec832e92f53b8ab2de5e10