### PR TITLE
Add quest and dialogue systems with starter quest

### DIFF
--- a/Assets/Scripts/Dialogue.meta
+++ b/Assets/Scripts/Dialogue.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3b6bc63f28d54e89aad6c618c7d4376c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Dialogue/DialogueData.cs
+++ b/Assets/Scripts/Dialogue/DialogueData.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using UnityEngine;
+using Quests;
+
+namespace Dialogue
+{
+    /// <summary>
+    /// Scriptable object holding dialogue nodes for an NPC.
+    /// </summary>
+    [CreateAssetMenu(menuName = "Dialogue/Dialogue Data")]
+    public class DialogueData : ScriptableObject
+    {
+        public string NpcName;
+        public List<DialogueNode> Nodes = new List<DialogueNode>();
+    }
+
+    [System.Serializable]
+    public class DialogueNode
+    {
+        [TextArea]
+        public string Text;
+        public List<DialogueOption> Options = new List<DialogueOption>();
+    }
+
+    [System.Serializable]
+    public class DialogueOption
+    {
+        public string Text;
+        public int NextNode = -1;
+        public DialogueAction Action;
+        public string QuestID;
+        public string RequiredQuestID;
+        public QuestState RequiredState = QuestState.None;
+    }
+
+    public enum DialogueAction
+    {
+        None,
+        StartQuest,
+        CompleteQuest
+    }
+
+    public enum QuestState
+    {
+        None,
+        NotStarted,
+        Active,
+        Completed
+    }
+}

--- a/Assets/Scripts/Dialogue/DialogueData.cs.meta
+++ b/Assets/Scripts/Dialogue/DialogueData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 37111aa34c5c4a74accaa4d9c74d3b4a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Dialogue/DialogueManager.cs
+++ b/Assets/Scripts/Dialogue/DialogueManager.cs
@@ -1,0 +1,98 @@
+using UnityEngine;
+using Quests;
+
+namespace Dialogue
+{
+    /// <summary>
+    /// Controls dialogue flow and applies option actions.
+    /// </summary>
+    public class DialogueManager : MonoBehaviour
+    {
+        public static DialogueManager Instance { get; private set; }
+
+        private DialogueData currentData;
+        private int currentIndex;
+        private DialogueUI ui;
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+
+            ui = gameObject.AddComponent<DialogueUI>();
+        }
+
+        /// <summary>
+        /// Starts a dialogue sequence.
+        /// </summary>
+        public void StartDialogue(DialogueData data, int startNode = 0)
+        {
+            if (data == null || data.Nodes.Count == 0)
+                return;
+            currentData = data;
+            currentIndex = Mathf.Clamp(startNode, 0, data.Nodes.Count - 1);
+            ShowNode();
+        }
+
+        private void ShowNode()
+        {
+            var node = currentData.Nodes[currentIndex];
+            ui.Show(currentData.NpcName, node, OnOption);
+        }
+
+        private void OnOption(int optionIndex)
+        {
+            var node = currentData.Nodes[currentIndex];
+            if (optionIndex < 0 || optionIndex >= node.Options.Count)
+                return;
+            var opt = node.Options[optionIndex];
+            if (!CheckCondition(opt)) return;
+
+            ApplyAction(opt);
+
+            if (opt.NextNode < 0 || opt.NextNode >= currentData.Nodes.Count)
+            {
+                ui.Hide();
+                currentData = null;
+            }
+            else
+            {
+                currentIndex = opt.NextNode;
+                ShowNode();
+            }
+        }
+
+        private bool CheckCondition(DialogueOption opt)
+        {
+            if (string.IsNullOrEmpty(opt.RequiredQuestID) || opt.RequiredState == QuestState.None)
+                return true;
+            var qm = QuestManager.Instance;
+            return opt.RequiredState switch
+            {
+                QuestState.NotStarted => !qm.IsQuestActive(opt.RequiredQuestID) && !qm.IsQuestCompleted(opt.RequiredQuestID),
+                QuestState.Active => qm.IsQuestActive(opt.RequiredQuestID),
+                QuestState.Completed => qm.IsQuestCompleted(opt.RequiredQuestID),
+                _ => true
+            };
+        }
+
+        private void ApplyAction(DialogueOption opt)
+        {
+            var qm = QuestManager.Instance;
+            switch (opt.Action)
+            {
+                case DialogueAction.StartQuest:
+                    qm.AddQuest(opt.QuestID);
+                    break;
+                case DialogueAction.CompleteQuest:
+                    qm.CompleteQuest(opt.QuestID);
+                    break;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Dialogue/DialogueManager.cs.meta
+++ b/Assets/Scripts/Dialogue/DialogueManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 385067e1ae9b4e56888001d3cf5132b1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Dialogue/DialogueUI.cs
+++ b/Assets/Scripts/Dialogue/DialogueUI.cs
@@ -1,0 +1,97 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Dialogue
+{
+    /// <summary>
+    /// Constructs dialogue UI elements and exposes a simple API for updating them.
+    /// </summary>
+    public class DialogueUI : MonoBehaviour
+    {
+        private Text nameText;
+        private Text bodyText;
+        private RectTransform optionsParent;
+
+        private void Awake()
+        {
+            name = "DialogueUI";
+            var canvas = gameObject.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            gameObject.AddComponent<CanvasScaler>().uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+            gameObject.AddComponent<GraphicRaycaster>();
+            Build();
+            gameObject.SetActive(false);
+        }
+
+        private void Build()
+        {
+            var panel = new GameObject("Panel", typeof(Image));
+            var panelRect = panel.GetComponent<RectTransform>();
+            panelRect.SetParent(transform, false);
+            panelRect.anchorMin = new Vector2(0.1f, 0.1f);
+            panelRect.anchorMax = new Vector2(0.9f, 0.3f);
+            panelRect.offsetMin = panelRect.offsetMax = Vector2.zero;
+
+            nameText = CreateText("Name", panelRect, new Vector2(0f, 1f), new Vector2(1f, 1f), new Vector2(0, -10));
+            nameText.fontStyle = FontStyle.Bold;
+            bodyText = CreateText("Body", panelRect, new Vector2(0f, 0.4f), new Vector2(1f, 1f), new Vector2(0, -40));
+
+            var options = new GameObject("Options", typeof(RectTransform), typeof(VerticalLayoutGroup));
+            optionsParent = options.GetComponent<RectTransform>();
+            optionsParent.SetParent(panelRect, false);
+            optionsParent.anchorMin = new Vector2(0f, 0f);
+            optionsParent.anchorMax = new Vector2(1f, 0.4f);
+            optionsParent.offsetMin = optionsParent.offsetMax = Vector2.zero;
+            var layout = options.GetComponent<VerticalLayoutGroup>();
+            layout.childControlHeight = true;
+            layout.childForceExpandHeight = false;
+            layout.childAlignment = TextAnchor.UpperLeft;
+        }
+
+        private Text CreateText(string name, RectTransform parent, Vector2 anchorMin, Vector2 anchorMax, Vector2 offset)
+        {
+            var go = new GameObject(name, typeof(Text));
+            var rect = go.GetComponent<RectTransform>();
+            rect.SetParent(parent, false);
+            rect.anchorMin = anchorMin;
+            rect.anchorMax = anchorMax;
+            rect.offsetMin = rect.offsetMax = offset;
+            var txt = go.GetComponent<Text>();
+            txt.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+            txt.alignment = TextAnchor.UpperLeft;
+            txt.horizontalOverflow = HorizontalWrapMode.Wrap;
+            txt.verticalOverflow = VerticalWrapMode.Overflow;
+            txt.color = Color.white;
+            return txt;
+        }
+
+        /// <summary>
+        /// Populates the dialogue UI with new content and displays it.
+        /// </summary>
+        public void Show(string npcName, DialogueNode node, System.Action<int> onOption)
+        {
+            gameObject.SetActive(true);
+            nameText.text = npcName;
+            bodyText.text = node.Text;
+
+            foreach (Transform child in optionsParent)
+                Destroy(child.gameObject);
+
+            for (int i = 0; i < node.Options.Count; i++)
+            {
+                var opt = node.Options[i];
+                var btnGO = new GameObject($"Option{i}", typeof(Image), typeof(Button));
+                var rect = btnGO.GetComponent<RectTransform>();
+                rect.SetParent(optionsParent, false);
+                rect.sizeDelta = new Vector2(0, 30f);
+                var txt = CreateText("Text", rect, Vector2.zero, Vector2.one, Vector2.zero);
+                txt.text = opt.Text;
+                txt.alignment = TextAnchor.MiddleLeft;
+                int index = i;
+                btnGO.GetComponent<Button>().onClick.AddListener(() => onOption(index));
+            }
+        }
+
+        public void Hide() => gameObject.SetActive(false);
+    }
+}

--- a/Assets/Scripts/Dialogue/DialogueUI.cs.meta
+++ b/Assets/Scripts/Dialogue/DialogueUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 409e956dbc7a4b99be711eec1c10274c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Dialogue/ElderRowanDialogueData.cs
+++ b/Assets/Scripts/Dialogue/ElderRowanDialogueData.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using UnityEngine;
+using Quests;
+
+namespace Dialogue
+{
+    /// <summary>
+    /// Dialogue tree for Elder Rowan.
+    /// </summary>
+    [CreateAssetMenu(menuName = "Dialogue/Elder Rowan")]
+    public class ElderRowanDialogueData : DialogueData
+    {
+        private void OnEnable()
+        {
+            NpcName = "Elder Rowan";
+            if (Nodes != null && Nodes.Count > 0) return;
+
+            Nodes = new List<DialogueNode>();
+
+            // 0: initial offer
+            Nodes.Add(new DialogueNode
+            {
+                Text = "Greetings, traveler. If you want to survive here, you must learn the basics. Chop some logs and mine some ore. Do you accept?",
+                Options = new List<DialogueOption>
+                {
+                    new DialogueOption
+                    {
+                        Text = "Accept",
+                        Action = DialogueAction.StartQuest,
+                        QuestID = "ToolsOfSurvival",
+                        NextNode = -1,
+                        RequiredQuestID = "ToolsOfSurvival",
+                        RequiredState = QuestState.NotStarted
+                    },
+                    new DialogueOption
+                    {
+                        Text = "Decline",
+                        NextNode = -1,
+                        RequiredQuestID = "ToolsOfSurvival",
+                        RequiredState = QuestState.NotStarted
+                    }
+                }
+            });
+
+            // 1: quest active
+            Nodes.Add(new DialogueNode
+            {
+                Text = "Keep at it, traveler. Chop 3 logs and mine 3 ores, then return to me.",
+                Options = new List<DialogueOption>
+                {
+                    new DialogueOption { Text = "Continue", NextNode = -1, RequiredQuestID = "ToolsOfSurvival", RequiredState = QuestState.Active }
+                }
+            });
+
+            // 2: quest ready to turn in
+            Nodes.Add(new DialogueNode
+            {
+                Text = "Excellent work! You’ve proven yourself capable.",
+                Options = new List<DialogueOption>
+                {
+                    new DialogueOption
+                    {
+                        Text = "Thanks",
+                        Action = DialogueAction.CompleteQuest,
+                        QuestID = "ToolsOfSurvival",
+                        NextNode = -1,
+                        RequiredQuestID = "ToolsOfSurvival",
+                        RequiredState = QuestState.Active
+                    }
+                }
+            });
+
+            // 3: quest completed
+            Nodes.Add(new DialogueNode
+            {
+                Text = "You’ve mastered the basics. Violetstown is safer with you here.",
+                Options = new List<DialogueOption>
+                {
+                    new DialogueOption { Text = "Farewell", NextNode = -1, RequiredQuestID = "ToolsOfSurvival", RequiredState = QuestState.Completed }
+                }
+            });
+        }
+    }
+}

--- a/Assets/Scripts/Dialogue/ElderRowanDialogueData.cs.meta
+++ b/Assets/Scripts/Dialogue/ElderRowanDialogueData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3d8fe1987deb41aaaf3eec00a9c482a0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/NPC/ElderRowanNPC.cs
+++ b/Assets/Scripts/NPC/ElderRowanNPC.cs
@@ -1,0 +1,27 @@
+using Dialogue;
+using Quests;
+
+namespace NPC
+{
+    /// <summary>
+    /// Elder Rowan specific behaviour integrating quests and dialogue.
+    /// </summary>
+    public class ElderRowanNPC : NpcInteractable
+    {
+        public ElderRowanDialogueData dialogueData;
+
+        public new void Talk()
+        {
+            var qm = QuestManager.Instance;
+            int node = 0;
+            if (qm != null)
+            {
+                if (qm.IsQuestCompleted("ToolsOfSurvival"))
+                    node = 3;
+                else if (qm.IsQuestActive("ToolsOfSurvival"))
+                    node = qm.IsQuestReadyToTurnIn("ToolsOfSurvival") ? 2 : 1;
+            }
+            DialogueManager.Instance.StartDialogue(dialogueData, node);
+        }
+    }
+}

--- a/Assets/Scripts/NPC/ElderRowanNPC.cs.meta
+++ b/Assets/Scripts/NPC/ElderRowanNPC.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1afc247c0dd94a03b52098890604016c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Quests.meta
+++ b/Assets/Scripts/Quests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8696fab037be464ba7e0fe48907d39d6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Quests/QuestDefinition.cs
+++ b/Assets/Scripts/Quests/QuestDefinition.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Quests
+{
+    /// <summary>
+    /// Data asset describing a quest and its steps.
+    /// </summary>
+    [CreateAssetMenu(menuName = "Quests/Quest Definition")]
+    public class QuestDefinition : ScriptableObject
+    {
+        [Tooltip("Unique identifier for this quest.")]
+        public string QuestID;
+
+        [Tooltip("Displayed title of the quest.")]
+        public string Title;
+
+        [Tooltip("Description shown in the quest log.")]
+        [TextArea]
+        public string Description;
+
+        [Tooltip("Ordered steps that comprise the quest.")]
+        public List<QuestStep> Steps = new List<QuestStep>();
+
+        [Tooltip("Text describing rewards granted on completion.")]
+        [TextArea]
+        public string Rewards;
+    }
+}

--- a/Assets/Scripts/Quests/QuestDefinition.cs.meta
+++ b/Assets/Scripts/Quests/QuestDefinition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2f92b6a21b144d8686a1e1795eb7d5f6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -1,0 +1,126 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace Quests
+{
+    /// <summary>
+    /// Manages the player's quests and notifies listeners when they change.
+    /// </summary>
+    public class QuestManager : MonoBehaviour
+    {
+        public static QuestManager Instance { get; private set; }
+
+        [Tooltip("Invoked whenever the quest list or progress changes.")]
+        public UnityEvent QuestsUpdated;
+
+        private readonly Dictionary<string, QuestDefinition> available = new Dictionary<string, QuestDefinition>();
+        private readonly Dictionary<string, QuestDefinition> active = new Dictionary<string, QuestDefinition>();
+        private readonly Dictionary<string, QuestDefinition> completed = new Dictionary<string, QuestDefinition>();
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+
+            if (QuestsUpdated == null)
+                QuestsUpdated = new UnityEvent();
+        }
+
+        /// <summary>
+        /// Registers a quest as available to the player.
+        /// </summary>
+        public void RegisterQuest(QuestDefinition quest)
+        {
+            if (quest == null || available.ContainsKey(quest.QuestID) || active.ContainsKey(quest.QuestID) || completed.ContainsKey(quest.QuestID))
+                return;
+            available[quest.QuestID] = quest;
+            QuestsUpdated.Invoke();
+        }
+
+        /// <summary>
+        /// Moves an available quest to the active list.
+        /// </summary>
+        public void AddQuest(string questID)
+        {
+            if (!available.TryGetValue(questID, out var def))
+                return;
+            var instance = Instantiate(def);
+            // Ensure step states reset
+            foreach (var step in instance.Steps)
+                step.IsComplete = false;
+            active[questID] = instance;
+            available.Remove(questID);
+            QuestsUpdated.Invoke();
+        }
+
+        /// <summary>
+        /// Marks a quest step complete and checks for quest completion.
+        /// </summary>
+        public void UpdateStep(string questID, string stepID)
+        {
+            if (!active.TryGetValue(questID, out var quest))
+                return;
+            var step = quest.Steps.Find(s => s.StepID == stepID);
+            if (step == null || step.IsComplete)
+                return;
+            step.IsComplete = true;
+            if (quest.Steps.TrueForAll(s => s.IsComplete))
+            {
+                CompleteQuest(questID);
+            }
+            else
+            {
+                QuestsUpdated.Invoke();
+            }
+        }
+
+        /// <summary>
+        /// Finalizes a quest and moves it to the completed list.
+        /// </summary>
+        public void CompleteQuest(string questID)
+        {
+            if (!active.TryGetValue(questID, out var quest))
+                return;
+            active.Remove(questID);
+            completed[questID] = quest;
+            QuestsUpdated.Invoke();
+        }
+
+        public IEnumerable<QuestDefinition> GetActiveQuests() => active.Values;
+        public IEnumerable<QuestDefinition> GetCompletedQuests() => completed.Values;
+        public IEnumerable<QuestDefinition> GetAvailableQuests() => available.Values;
+
+        public bool IsQuestActive(string questID) => active.ContainsKey(questID);
+        public bool IsQuestCompleted(string questID) => completed.ContainsKey(questID);
+
+        /// <summary>
+        /// Returns true if all steps except possibly a return step are completed.
+        /// </summary>
+        public bool IsQuestReadyToTurnIn(string questID)
+        {
+            if (!active.TryGetValue(questID, out var quest))
+                return false;
+            foreach (var step in quest.Steps)
+            {
+                if (!step.IsComplete)
+                    return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Retrieves a quest definition from the active list.
+        /// </summary>
+        public QuestDefinition GetQuest(string questID)
+        {
+            active.TryGetValue(questID, out var quest);
+            return quest;
+        }
+    }
+}

--- a/Assets/Scripts/Quests/QuestManager.cs.meta
+++ b/Assets/Scripts/Quests/QuestManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2c4ecae6cbe94cc8b079ce3f7401394a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Quests/QuestStep.cs
+++ b/Assets/Scripts/Quests/QuestStep.cs
@@ -1,0 +1,22 @@
+using System;
+using UnityEngine;
+
+namespace Quests
+{
+    /// <summary>
+    /// Represents a single step within a quest.
+    /// </summary>
+    [Serializable]
+    public class QuestStep
+    {
+        [Tooltip("Unique identifier for this step.")]
+        public string StepID;
+
+        [Tooltip("Description displayed to the player.")]
+        [TextArea]
+        public string StepDescription;
+
+        [Tooltip("True when the step has been completed.")]
+        public bool IsComplete;
+    }
+}

--- a/Assets/Scripts/Quests/QuestStep.cs.meta
+++ b/Assets/Scripts/Quests/QuestStep.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dc1c70c925f24f7b9ec332ab649536fe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Quests/QuestUI.cs
+++ b/Assets/Scripts/Quests/QuestUI.cs
@@ -1,0 +1,168 @@
+using System.Linq;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Quests
+{
+    /// <summary>
+    /// Simple quest log UI built entirely in code.
+    /// </summary>
+    public class QuestUI : MonoBehaviour
+    {
+        private RectTransform listContent;
+        private Text titleText;
+        private Text descriptionText;
+        private Text stepsText;
+        private Text rewardsText;
+        private QuestDefinition selected;
+
+        private void Awake()
+        {
+            name = "QuestUI";
+            var canvas = gameObject.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            gameObject.AddComponent<CanvasScaler>().uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+            gameObject.AddComponent<GraphicRaycaster>();
+
+            BuildLayout();
+            gameObject.SetActive(false);
+        }
+
+        private void Start()
+        {
+            if (QuestManager.Instance != null)
+                QuestManager.Instance.QuestsUpdated.AddListener(Refresh);
+        }
+
+        private void Update()
+        {
+            if (Input.GetKeyDown(KeyCode.Q))
+            {
+                gameObject.SetActive(!gameObject.activeSelf);
+                if (gameObject.activeSelf) Refresh();
+            }
+        }
+
+        private void BuildLayout()
+        {
+            var bg = new GameObject("Background", typeof(Image));
+            var bgRect = bg.GetComponent<RectTransform>();
+            bgRect.SetParent(transform, false);
+            bgRect.anchorMin = Vector2.zero;
+            bgRect.anchorMax = Vector2.one;
+            bgRect.offsetMin = Vector2.zero;
+            bgRect.offsetMax = Vector2.zero;
+
+            // Left quest list
+            var listGO = new GameObject("QuestList", typeof(Image), typeof(ScrollRect));
+            var listRect = listGO.GetComponent<RectTransform>();
+            listRect.SetParent(bgRect, false);
+            listRect.anchorMin = new Vector2(0f, 0f);
+            listRect.anchorMax = new Vector2(0.35f, 1f);
+            listRect.offsetMin = new Vector2(10f, 10f);
+            listRect.offsetMax = new Vector2(-10f, -10f);
+
+            var viewport = new GameObject("Viewport", typeof(RectTransform), typeof(Mask), typeof(Image));
+            viewport.transform.SetParent(listGO.transform, false);
+            var vpRect = viewport.GetComponent<RectTransform>();
+            vpRect.anchorMin = Vector2.zero;
+            vpRect.anchorMax = Vector2.one;
+            vpRect.offsetMin = Vector2.zero;
+            vpRect.offsetMax = Vector2.zero;
+            viewport.GetComponent<Image>().color = new Color(0, 0, 0, 0.2f);
+
+            var content = new GameObject("Content", typeof(RectTransform), typeof(VerticalLayoutGroup));
+            listContent = content.GetComponent<RectTransform>();
+            listContent.SetParent(viewport.transform, false);
+            var layout = content.GetComponent<VerticalLayoutGroup>();
+            layout.childForceExpandHeight = false;
+            layout.childAlignment = TextAnchor.UpperLeft;
+
+            var scroll = listGO.GetComponent<ScrollRect>();
+            scroll.viewport = vpRect;
+            scroll.content = listContent;
+
+            // Right details panel
+            var details = new GameObject("Details", typeof(Image));
+            var detRect = details.GetComponent<RectTransform>();
+            detRect.SetParent(bgRect, false);
+            detRect.anchorMin = new Vector2(0.35f, 0f);
+            detRect.anchorMax = new Vector2(1f, 1f);
+            detRect.offsetMin = new Vector2(10f, 10f);
+            detRect.offsetMax = new Vector2(-40f, -10f);
+
+            titleText = CreateText("Title", detRect, new Vector2(0f, 1f), new Vector2(1f, 1f), new Vector2(0, -10));
+            titleText.fontStyle = FontStyle.Bold;
+            descriptionText = CreateText("Description", detRect, new Vector2(0f, 0.7f), new Vector2(1f, 1f), new Vector2(0, -40));
+            stepsText = CreateText("Steps", detRect, new Vector2(0f, 0.3f), new Vector2(1f, 0.7f), Vector2.zero);
+            rewardsText = CreateText("Rewards", detRect, new Vector2(0f, 0f), new Vector2(1f, 0.3f), new Vector2(0, 10));
+
+            // Close button
+            var closeBtnGO = new GameObject("Close", typeof(Image), typeof(Button));
+            var closeRect = closeBtnGO.GetComponent<RectTransform>();
+            closeRect.SetParent(bgRect, false);
+            closeRect.anchorMin = new Vector2(1f, 1f);
+            closeRect.anchorMax = new Vector2(1f, 1f);
+            closeRect.sizeDelta = new Vector2(30f, 30f);
+            closeRect.anchoredPosition = new Vector2(-15f, -15f);
+            var closeText = CreateText("X", closeRect, Vector2.zero, Vector2.one, Vector2.zero);
+            closeText.alignment = TextAnchor.MiddleCenter;
+            closeBtnGO.GetComponent<Button>().onClick.AddListener(() => gameObject.SetActive(false));
+        }
+
+        private Text CreateText(string name, RectTransform parent, Vector2 anchorMin, Vector2 anchorMax, Vector2 offset)
+        {
+            var go = new GameObject(name, typeof(Text));
+            var rect = go.GetComponent<RectTransform>();
+            rect.SetParent(parent, false);
+            rect.anchorMin = anchorMin;
+            rect.anchorMax = anchorMax;
+            rect.offsetMin = rect.offsetMax = offset;
+            var txt = go.GetComponent<Text>();
+            txt.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+            txt.alignment = TextAnchor.UpperLeft;
+            txt.horizontalOverflow = HorizontalWrapMode.Wrap;
+            txt.verticalOverflow = VerticalWrapMode.Overflow;
+            txt.color = Color.white;
+            return txt;
+        }
+
+        private void Refresh()
+        {
+            foreach (Transform child in listContent)
+                Destroy(child.gameObject);
+
+            var allQuests = QuestManager.Instance.GetActiveQuests().Concat(QuestManager.Instance.GetAvailableQuests());
+            foreach (var quest in allQuests)
+            {
+                var btnGO = new GameObject(quest.Title, typeof(Button));
+                var btnRect = btnGO.GetComponent<RectTransform>();
+                btnRect.SetParent(listContent, false);
+                btnRect.sizeDelta = new Vector2(0, 30f);
+                var txt = CreateText("Text", btnRect, Vector2.zero, Vector2.one, Vector2.zero);
+                txt.text = quest.Title;
+                txt.alignment = TextAnchor.MiddleLeft;
+                btnGO.GetComponent<Button>().onClick.AddListener(() => SelectQuest(quest));
+            }
+
+            if (selected == null && allQuests.Any())
+                SelectQuest(allQuests.First());
+            else if (selected != null)
+                SelectQuest(selected);
+        }
+
+        private void SelectQuest(QuestDefinition quest)
+        {
+            selected = quest;
+            if (quest == null)
+            {
+                titleText.text = descriptionText.text = stepsText.text = rewardsText.text = string.Empty;
+                return;
+            }
+            titleText.text = quest.Title;
+            descriptionText.text = quest.Description;
+            stepsText.text = string.Join("\n", quest.Steps.Select(s => $"{(s.IsComplete ? "[\u2714]" : "[ ]")} {s.StepDescription}"));
+            rewardsText.text = quest.Rewards;
+        }
+    }
+}

--- a/Assets/Scripts/Quests/QuestUI.cs.meta
+++ b/Assets/Scripts/Quests/QuestUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8da186e16d194a74a1b74dcf26280d6b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Quests/ToolsOfSurvivalQuest.cs
+++ b/Assets/Scripts/Quests/ToolsOfSurvivalQuest.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Quests
+{
+    /// <summary>
+    /// Preconfigured quest used as a starting example.
+    /// </summary>
+    [CreateAssetMenu(menuName = "Quests/Tools Of Survival")]
+    public class ToolsOfSurvivalQuest : QuestDefinition
+    {
+        private void OnEnable()
+        {
+            QuestID = "ToolsOfSurvival";
+            Title = "Tools of Survival";
+            Description = "Elder Rowan has tasked you with gathering basic resources.";
+            Rewards = "Small Woodcutting XP\nSmall Mining XP\n100 Coins";
+
+            if (Steps == null || Steps.Count == 0)
+            {
+                Steps = new List<QuestStep>
+                {
+                    new QuestStep { StepID = "ChopLogs", StepDescription = "Chop 3 logs" },
+                    new QuestStep { StepID = "MineOres", StepDescription = "Mine 3 ores" },
+                    new QuestStep { StepID = "ReturnToRowan", StepDescription = "Return to Elder Rowan" }
+                };
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Quests/ToolsOfSurvivalQuest.cs.meta
+++ b/Assets/Scripts/Quests/ToolsOfSurvivalQuest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3a015a47ae66499896f77657aa2ffbc6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Implement quest backend with definitions, steps, and manager
- Build code-generated quest log UI toggled with Q
- Add reusable dialogue system with Elder Rowan example

## Testing
- `mcs Assets/Scripts/Quests/QuestManager.cs` *(fails: UnityEngine reference missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a63d728d38832ea3755e4f2a6065a9