### PR TITLE
Hook Tools of Survival quest to resource gathering

### DIFF
--- a/Assets/Scripts/NPC/ElderRowanNPC.cs
+++ b/Assets/Scripts/NPC/ElderRowanNPC.cs
@@ -16,6 +16,16 @@ namespace NPC
             int node = 0;
             if (qm != null)
             {
+                if (qm.IsQuestActive("ToolsOfSurvival"))
+                {
+                    var quest = qm.GetQuest("ToolsOfSurvival");
+                    bool logsDone = quest?.Steps.Find(s => s.StepID == "ChopLogs")?.IsComplete == true;
+                    bool oresDone = quest?.Steps.Find(s => s.StepID == "MineOres")?.IsComplete == true;
+                    bool returnDone = quest?.Steps.Find(s => s.StepID == "ReturnToRowan")?.IsComplete == true;
+                    if (logsDone && oresDone && !returnDone)
+                        qm.UpdateStep("ToolsOfSurvival", "ReturnToRowan");
+                }
+
                 if (qm.IsQuestCompleted("ToolsOfSurvival"))
                     node = 3;
                 else if (qm.IsQuestActive("ToolsOfSurvival"))

--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -60,7 +60,7 @@ namespace Quests
         }
 
         /// <summary>
-        /// Marks a quest step complete and checks for quest completion.
+        /// Marks a quest step complete.
         /// </summary>
         public void UpdateStep(string questID, string stepID)
         {
@@ -70,14 +70,7 @@ namespace Quests
             if (step == null || step.IsComplete)
                 return;
             step.IsComplete = true;
-            if (quest.Steps.TrueForAll(s => s.IsComplete))
-            {
-                CompleteQuest(questID);
-            }
-            else
-            {
-                QuestsUpdated.Invoke();
-            }
+            QuestsUpdated.Invoke();
         }
 
         /// <summary>

--- a/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
@@ -5,6 +5,7 @@ using Inventory;
 using Util;
 using Skills.Mining;
 using Pets;
+using Quests;
 
 namespace Skills.Mining
 {
@@ -29,6 +30,7 @@ namespace Skills.Mining
         private int swingProgress;
 
         private Dictionary<string, ItemData> oreItems;
+        private int questOreCount;
 
         public event System.Action<MineableRock> OnStartMining;
         public event System.Action OnStopMining;
@@ -165,6 +167,18 @@ namespace Skills.Mining
                     FloatingText.Show($"+{amount} {ore.DisplayName}", anchorPos);
                     StartCoroutine(ShowXpGainDelayed(ore.XpPerOre * amount, anchorTransform));
                     OnOreGained?.Invoke(ore.Id, amount);
+
+                    if (QuestManager.Instance != null && QuestManager.Instance.IsQuestActive("ToolsOfSurvival"))
+                    {
+                        var quest = QuestManager.Instance.GetQuest("ToolsOfSurvival");
+                        var step = quest?.Steps.Find(s => s.StepID == "MineOres");
+                        if (step != null && !step.IsComplete)
+                        {
+                            questOreCount += amount;
+                            if (questOreCount >= 3)
+                                QuestManager.Instance.UpdateStep("ToolsOfSurvival", "MineOres");
+                        }
+                    }
 
                     int newLevel = xpTable.GetLevel(xp);
                     if (newLevel > level)

--- a/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
@@ -5,6 +5,7 @@ using Inventory;
 using Util;
 using Skills.Mining; // reuse XP table
 using Pets;
+using Quests;
 
 namespace Skills.Woodcutting
 {
@@ -30,6 +31,7 @@ namespace Skills.Woodcutting
         private int currentIntervalTicks;
 
         private Dictionary<string, ItemData> logItems;
+        private int questLogCount;
 
         public event System.Action<TreeNode> OnStartChopping;
         public event System.Action OnStopChopping;
@@ -159,6 +161,18 @@ namespace Skills.Woodcutting
                 FloatingText.Show($"+{amount} {logName}", anchorPos);
                 StartCoroutine(ShowXpGainDelayed(currentTree.def.XpPerLog * amount, anchorTransform));
                 OnLogGained?.Invoke(logId, amount);
+
+                if (QuestManager.Instance != null && QuestManager.Instance.IsQuestActive("ToolsOfSurvival"))
+                {
+                    var quest = QuestManager.Instance.GetQuest("ToolsOfSurvival");
+                    var step = quest?.Steps.Find(s => s.StepID == "ChopLogs");
+                    if (step != null && !step.IsComplete)
+                    {
+                        questLogCount += amount;
+                        if (questLogCount >= 3)
+                            QuestManager.Instance.UpdateStep("ToolsOfSurvival", "ChopLogs");
+                    }
+                }
 
                 int newLevel = xpTable.GetLevel(xp);
                 if (newLevel > level)


### PR DESCRIPTION
## Summary
- update woodcutting and mining skills to progress Tools of Survival quest after collecting resources
- mark ReturnToRowan step when speaking with Elder Rowan and delay quest completion to dialogue
- remove automatic quest completion on step update

## Testing
- `dotnet test` *(fails: project or solution file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6432226a4832ebdc344081722653b