### PR TITLE
Enable dialogue overrides for NPCs

### DIFF
--- a/Assets/Scripts/NPC/ElderRowanNPC.cs
+++ b/Assets/Scripts/NPC/ElderRowanNPC.cs
@@ -10,7 +10,7 @@ namespace NPC
     {
         public ElderRowanDialogueData dialogueData;
 
-        public new void Talk()
+        public override void Talk()
         {
             var qm = QuestManager.Instance;
             int node = 0;

--- a/Assets/Scripts/NPC/NPCInteractable.cs
+++ b/Assets/Scripts/NPC/NPCInteractable.cs
@@ -56,7 +56,7 @@ namespace NPC
             }
         }
 
-        public void Talk()
+        public virtual void Talk()
         {
             Debug.Log($"{name} has nothing to say yet.");
         }


### PR DESCRIPTION
## Summary
- Allow NPCs to override dialogue by making `NpcInteractable.Talk` virtual
- Ensure Elder Rowan starts the correct dialogue node instead of the fallback message

## Testing
- `dotnet test` *(fails: current directory does not contain a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a64b186934832e87cce4040131faca