### PR TITLE
fix: ensure dialogue UI built before showing

### DIFF
--- a/Assets/Scripts/Dialogue/DialogueUI.cs
+++ b/Assets/Scripts/Dialogue/DialogueUI.cs
@@ -74,6 +74,12 @@ namespace Dialogue
         /// </summary>
         public void Show(string npcName, DialogueNode node, System.Action<int> onOption)
         {
+            // Ensure UI elements are built before use in case initialization
+            // has not yet occurred (e.g., when DialogueManager adds this
+            // component at runtime and Show is called immediately).
+            if (nameText == null || bodyText == null || optionsParent == null)
+                Build();
+
             gameObject.SetActive(true);
             nameText.text = npcName;
             bodyText.text = node.Text;


### PR DESCRIPTION
## Summary
- ensure dialogue UI elements are built before use to prevent null reference errors

## Testing
- `dotnet test` *(fails: MSBUILD error, no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a64e4de534832e933c62d20557b72d