### PR TITLE
Fix quest menu toggle not opening with Q

### DIFF
--- a/Assets/Scripts/Quests/QuestUI.cs
+++ b/Assets/Scripts/Quests/QuestUI.cs
@@ -16,16 +16,18 @@ namespace Quests
         private Text rewardsText;
         private QuestDefinition selected;
 
+        private Canvas canvas;
+
         private void Awake()
         {
             name = "QuestUI";
-            var canvas = gameObject.AddComponent<Canvas>();
+            canvas = gameObject.AddComponent<Canvas>();
             canvas.renderMode = RenderMode.ScreenSpaceOverlay;
             gameObject.AddComponent<CanvasScaler>().uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
             gameObject.AddComponent<GraphicRaycaster>();
 
             BuildLayout();
-            gameObject.SetActive(false);
+            canvas.enabled = false;
         }
 
         private void Start()
@@ -38,8 +40,8 @@ namespace Quests
         {
             if (Input.GetKeyDown(KeyCode.Q))
             {
-                gameObject.SetActive(!gameObject.activeSelf);
-                if (gameObject.activeSelf) Refresh();
+                canvas.enabled = !canvas.enabled;
+                if (canvas.enabled) Refresh();
             }
         }
 
@@ -114,7 +116,7 @@ namespace Quests
             var closeText = CreateText("X", closeRect, Vector2.zero, Vector2.one, Vector2.zero);
             closeText.alignment = TextAnchor.MiddleCenter;
             closeBtnGO.GetComponent<Image>().color = Color.clear;
-            closeBtnGO.GetComponent<Button>().onClick.AddListener(() => gameObject.SetActive(false));
+            closeBtnGO.GetComponent<Button>().onClick.AddListener(() => canvas.enabled = false);
         }
 
         private Text CreateText(string name, RectTransform parent, Vector2 anchorMin, Vector2 anchorMax, Vector2 offset)


### PR DESCRIPTION
## Summary
- Ensure QuestUI stays active so Update can listen for the Q key
- Toggle the quest log by enabling/disabling the canvas instead of the GameObject
- Fix close button to disable the canvas

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a6dc828a30832eb17beb81a30ef682