### PR TITLE
Fix quest UI duplication on close

### DIFF
--- a/Assets/Scripts/Quests/QuestUI.cs
+++ b/Assets/Scripts/Quests/QuestUI.cs
@@ -41,7 +41,14 @@ namespace Quests
             if (Input.GetKeyDown(KeyCode.Q))
             {
                 canvas.enabled = !canvas.enabled;
-                if (canvas.enabled) Refresh();
+                if (canvas.enabled)
+                {
+                    Refresh();
+                }
+                else
+                {
+                    Clear();
+                }
             }
         }
 
@@ -138,8 +145,7 @@ namespace Quests
 
         private void Refresh()
         {
-            foreach (Transform child in listContent)
-                Destroy(child.gameObject);
+            ClearList();
 
             var allQuests = QuestManager.Instance.GetActiveQuests().Concat(QuestManager.Instance.GetAvailableQuests());
             foreach (var quest in allQuests)
@@ -158,6 +164,20 @@ namespace Quests
                 SelectQuest(allQuests.First());
             else if (selected != null)
                 SelectQuest(selected);
+        }
+
+        private void Clear()
+        {
+            ClearList();
+            selected = null;
+            titleText.text = descriptionText.text = stepsText.text = rewardsText.text = string.Empty;
+        }
+
+        private void ClearList()
+        {
+            if (listContent == null) return;
+            foreach (Transform child in listContent)
+                Destroy(child.gameObject);
         }
 
         private void SelectQuest(QuestDefinition quest)


### PR DESCRIPTION
## Summary
- clear quest list and selections when closing quest UI
- ensure quest details refresh without duplicating entries

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e01b5ae4832ea6ce7ca3c829c099