### PR TITLE
feat: set quest log backgrounds to custom color

### DIFF
--- a/Assets/Scripts/Quests/QuestUI.cs
+++ b/Assets/Scripts/Quests/QuestUI.cs
@@ -83,7 +83,7 @@ namespace Quests
             vpRect.anchorMax = Vector2.one;
             vpRect.offsetMin = Vector2.zero;
             vpRect.offsetMax = Vector2.zero;
-            viewport.GetComponent<Image>().color = new Color(0, 0, 0, 0.2f);
+            viewport.GetComponent<Image>().color = new Color32(0x26, 0x26, 0x26, 0xF2);
 
             var content = new GameObject("Content", typeof(RectTransform), typeof(VerticalLayoutGroup));
             listContent = content.GetComponent<RectTransform>();
@@ -104,7 +104,7 @@ namespace Quests
             detRect.anchorMax = new Vector2(1f, 1f);
             detRect.offsetMin = new Vector2(10f, 10f);
             detRect.offsetMax = new Vector2(-40f, -10f);
-            details.GetComponent<Image>().color = Color.clear;
+            details.GetComponent<Image>().color = new Color32(0x26, 0x26, 0x26, 0xF2);
 
             titleText = CreateText("Title", detRect, new Vector2(0f, 1f), new Vector2(1f, 1f), new Vector2(0, -10));
             titleText.fontStyle = FontStyle.Bold;


### PR DESCRIPTION
## Summary
- use #262626 with alpha 242 for the quest list panel background
- use same color for the quest details panel background

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e1b6aad8832ebe9f3da0f3f1034c