### PR TITLE
Fix missing RectTransform error in QuestUI

### DIFF
--- a/Assets/Scripts/Quests/QuestUI.cs
+++ b/Assets/Scripts/Quests/QuestUI.cs
@@ -150,7 +150,7 @@ namespace Quests
             var allQuests = QuestManager.Instance.GetActiveQuests().Concat(QuestManager.Instance.GetAvailableQuests());
             foreach (var quest in allQuests)
             {
-                var btnGO = new GameObject(quest.Title, typeof(Button));
+                var btnGO = new GameObject(quest.Title, typeof(RectTransform), typeof(Image), typeof(Button));
                 var btnRect = btnGO.GetComponent<RectTransform>();
                 btnRect.SetParent(listContent, false);
                 btnRect.sizeDelta = new Vector2(0, 30f);


### PR DESCRIPTION
## Summary
- Ensure quest list buttons include RectTransform and Image components to prevent MissingComponentException

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e454af78832e8cdea53b5ae79f08