### PR TITLE
Lock UI interactions while quest menu is open

### DIFF
--- a/Assets/Scripts/Bank/BankUI.cs
+++ b/Assets/Scripts/Bank/BankUI.cs
@@ -5,6 +5,7 @@ using UnityEngine.EventSystems;
 using Inventory;
 using Core.Save;
 using Skills;
+using Quests;
 
 namespace BankSystem
 {
@@ -486,6 +487,9 @@ namespace BankSystem
         public void Open()
         {
             if (Beastmaster.PetMergeController.Instance != null && Beastmaster.PetMergeController.Instance.IsMerged)
+                return;
+            var quest = FindObjectOfType<QuestUI>();
+            if (quest != null && quest.IsOpen)
                 return;
             if (playerInventory == null)
                 playerInventory = FindObjectOfType<Inventory.Inventory>();

--- a/Assets/Scripts/Inventory/Equipment.cs
+++ b/Assets/Scripts/Inventory/Equipment.cs
@@ -12,6 +12,7 @@ using Combat;
 #if ENABLE_INPUT_SYSTEM
 using UnityEngine.InputSystem;
 #endif
+using Quests;
 
 namespace Inventory
 {
@@ -158,6 +159,13 @@ namespace Inventory
 #else
             bool toggle = Input.GetKeyDown(KeyCode.E);
 #endif
+            var quest = Object.FindObjectOfType<QuestUI>();
+            if (quest != null && quest.IsOpen)
+            {
+                if (uiRoot != null && uiRoot.activeSelf)
+                    uiRoot.SetActive(false);
+                return;
+            }
             if (toggle && uiRoot != null)
             {
                 bool opening = !uiRoot.activeSelf;

--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -11,6 +11,7 @@ using ShopSystem;
 using Player;
 using Skills;
 using Pets;
+using Quests;
 
 namespace Inventory
 {
@@ -986,6 +987,14 @@ namespace Inventory
 #else
             bool toggle = Input.GetKeyDown(KeyCode.I);
 #endif
+
+            var quest = Object.FindObjectOfType<QuestUI>();
+            if (quest != null && quest.IsOpen)
+            {
+                if (uiRoot != null && uiRoot.activeSelf)
+                    uiRoot.SetActive(false);
+                return;
+            }
             if (currentShop != null)
             {
                 if (uiRoot != null && !uiRoot.activeSelf)

--- a/Assets/Scripts/Quests/QuestUI.cs
+++ b/Assets/Scripts/Quests/QuestUI.cs
@@ -1,6 +1,11 @@
 using System.Linq;
 using UnityEngine;
 using UnityEngine.UI;
+using Inventory;
+using Player;
+using Skills;
+using ShopSystem;
+using BankSystem;
 
 namespace Quests
 {
@@ -17,6 +22,9 @@ namespace Quests
         private QuestDefinition selected;
 
         private Canvas canvas;
+        private PlayerMover playerMover;
+
+        public bool IsOpen => canvas != null && canvas.enabled;
 
         private void Awake()
         {
@@ -28,6 +36,7 @@ namespace Quests
 
             BuildLayout();
             canvas.enabled = false;
+            playerMover = FindObjectOfType<PlayerMover>();
         }
 
         private void Start()
@@ -40,14 +49,40 @@ namespace Quests
         {
             if (Input.GetKeyDown(KeyCode.Q))
             {
-                canvas.enabled = !canvas.enabled;
+                bool opening = !canvas.enabled;
+                if (opening)
+                {
+                    var inv = FindObjectOfType<Inventory.Inventory>();
+                    if (inv != null && inv.IsOpen)
+                        inv.CloseUI();
+                    var eq = FindObjectOfType<Inventory.Equipment>();
+                    if (eq != null && eq.IsOpen)
+                        eq.CloseUI();
+                    var skills = SkillsUI.Instance;
+                    if (skills != null && skills.IsOpen)
+                        skills.Close();
+                    var shop = ShopUI.Instance;
+                    if (shop != null && shop.IsOpen)
+                        shop.Close();
+                    var bank = BankUI.Instance;
+                    if (bank != null && bank.IsOpen)
+                        bank.Close();
+                }
+
+                canvas.enabled = opening;
                 if (canvas.enabled)
                 {
                     Refresh();
+                    if (playerMover == null)
+                        playerMover = FindObjectOfType<PlayerMover>();
+                    if (playerMover != null)
+                        playerMover.enabled = false;
                 }
                 else
                 {
                     Clear();
+                    if (playerMover != null)
+                        playerMover.enabled = true;
                 }
             }
         }

--- a/Assets/Scripts/Shop/ShopUI.cs
+++ b/Assets/Scripts/Shop/ShopUI.cs
@@ -5,6 +5,7 @@ using Inventory;
 using Player;
 using Skills;
 using NPC;
+using Quests;
 
 namespace ShopSystem
 {
@@ -85,6 +86,9 @@ namespace ShopSystem
         public void Open(Shop shop, NpcRandomMovement npcMovement = null)
         {
             if (shop == null) return;
+            var quest = FindObjectOfType<QuestUI>();
+            if (quest != null && quest.IsOpen)
+                return;
             currentShop = shop;
             Refresh();
             var skills = SkillsUI.Instance;

--- a/Assets/Scripts/Skills/SkillsUI.cs
+++ b/Assets/Scripts/Skills/SkillsUI.cs
@@ -3,6 +3,7 @@ using UnityEngine.UI;
 using ShopSystem;
 using Inventory;
 using Player;
+using Quests;
 
 namespace Skills
 {
@@ -89,6 +90,13 @@ namespace Skills
 
         private void Update()
         {
+            var quest = FindObjectOfType<QuestUI>();
+            if (quest != null && quest.IsOpen)
+            {
+                if (uiRoot != null && uiRoot.activeSelf)
+                    uiRoot.SetActive(false);
+                return;
+            }
             if (Input.GetKeyDown(KeyCode.O))
             {
                 var shop = ShopUI.Instance;


### PR DESCRIPTION
## Summary
- Close inventory, equipment, skills, shop, and bank UIs when opening quest menu
- Block other interfaces from opening while quest menu is active
- Freeze player movement when quest UI is shown and restore it on close

## Testing
- `dotnet test` *(fails: The current working directory does not contain a project or solution file.)*


------
https://chatgpt.com/codex/tasks/task_e_68a6ea454a14832eb770836c0c023561