### PR TITLE
Fix quest list title clipping

### DIFF
--- a/Assets/Scripts/Quests/QuestUI.cs
+++ b/Assets/Scripts/Quests/QuestUI.cs
@@ -130,6 +130,8 @@ namespace Quests
             var layout = content.GetComponent<VerticalLayoutGroup>();
             layout.childForceExpandHeight = false;
             layout.childAlignment = TextAnchor.UpperLeft;
+            // Add a bit of padding at the top so the first quest is fully visible
+            layout.padding = new RectOffset(0, 0, 5, 0);
 
             var scroll = listGO.GetComponent<ScrollRect>();
             scroll.viewport = vpRect;


### PR DESCRIPTION
## Summary
- add top padding to quest list layout so first quest title isn't cut off

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ec09541c832ebf506884fe75f1d2