### PR TITLE
Fix quest selection closure for quest details

### DIFF
--- a/Assets/Scripts/Quests/QuestUI.cs
+++ b/Assets/Scripts/Quests/QuestUI.cs
@@ -210,7 +210,13 @@ namespace Quests
                     txt.color = Color.yellow;
                 else
                     txt.color = Color.red;
-                btnGO.GetComponent<Button>().onClick.AddListener(() => SelectQuest(quest));
+                // Capture the quest in a local variable to ensure the correct
+                // quest is referenced when the button is clicked. Without this,
+                // all buttons could end up referencing the final quest in the
+                // loop, preventing the correct details from appearing when
+                // selecting a quest.
+                var capturedQuest = quest;
+                btnGO.GetComponent<Button>().onClick.AddListener(() => SelectQuest(capturedQuest));
             }
 
             if (selected != null)


### PR DESCRIPTION
## Summary
- Ensure each quest button captures its own quest so selecting a quest shows the correct details

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f4639ad8832e900ad0db4dd41cd9