### PR TITLE
Ensure quest list buttons span full width

### DIFF
--- a/Assets/Scripts/Quests/QuestUI.cs
+++ b/Assets/Scripts/Quests/QuestUI.cs
@@ -129,6 +129,7 @@ namespace Quests
             listContent.offsetMin = listContent.offsetMax = Vector2.zero;
             var layout = content.GetComponent<VerticalLayoutGroup>();
             layout.childForceExpandHeight = false;
+            layout.childControlWidth = false;
             layout.childAlignment = TextAnchor.UpperLeft;
             // Add a bit of padding at the top so the first quest is fully visible
             layout.padding = new RectOffset(0, 0, 5, 0);


### PR DESCRIPTION
## Summary
- Allow quest list items to stretch fully by disabling layout width control

## Testing
- `dotnet test` *(fails: project or solution file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f8ea5dbc832e87351cb07fc6e54a