### PR TITLE
Expand quest list buttons width

### DIFF
--- a/Assets/Scripts/Quests/QuestUI.cs
+++ b/Assets/Scripts/Quests/QuestUI.cs
@@ -129,7 +129,7 @@ namespace Quests
             listContent.offsetMin = listContent.offsetMax = Vector2.zero;
             var layout = content.GetComponent<VerticalLayoutGroup>();
             layout.childForceExpandHeight = false;
-            layout.childControlWidth = false;
+            layout.childControlWidth = true;
             layout.childAlignment = TextAnchor.UpperLeft;
             // Add a bit of padding at the top so the first quest is fully visible
             layout.padding = new RectOffset(0, 0, 5, 0);


### PR DESCRIPTION
## Summary
- Ensure quest list layout controls button width so titles span the full list area

## Testing
- `dotnet build` *(fails: MSBUILD: Specify a project or solution file; none found)*

------
https://chatgpt.com/codex/tasks/task_e_68a708037884832e9b9bbf8ff1ab0f43