### PR TITLE
Stop player movement when opening minimap

### DIFF
--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -240,6 +240,18 @@ namespace Player
             rb.linearVelocity = moveDir * moveSpeed;
         }
 
+        /// <summary>
+        /// Immediately halts any current movement and updates animation state.
+        /// </summary>
+        public void StopMovement()
+        {
+            moveDir = Vector2.zero;
+            if (rb != null)
+                rb.linearVelocity = Vector2.zero;
+            if (anim != null)
+                anim.SetBool("IsMoving", false);
+        }
+
         void OnApplicationQuit()
         {
             SavePosition();

--- a/Assets/Scripts/World/Minimap.cs
+++ b/Assets/Scripts/World/Minimap.cs
@@ -305,7 +305,11 @@ namespace World
             var playerObj = target != null ? target.gameObject : GameObject.FindGameObjectWithTag("Player");
             var mover = playerObj != null ? playerObj.GetComponent<PlayerMover>() : null;
             if (mover != null)
+            {
+                if (opening)
+                    mover.StopMovement();
                 mover.enabled = !opening;
+            }
         }
 
         public bool IsExpanded => expandedRoot != null && expandedRoot.activeSelf;


### PR DESCRIPTION
## Summary
- halt Rigidbody motion when minimap expands
- ensure minimap disables PlayerMover component after stopping

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a74934b908832ea0e339f88cad88e2