### PR TITLE
Resolve npc variable conflict in PetCombatController

### DIFF
--- a/Assets/Scripts/Pets/PetCombatController.cs
+++ b/Assets/Scripts/Pets/PetCombatController.cs
@@ -142,8 +142,9 @@ namespace Pets
                     attacker.StrengthLevel = Mathf.RoundToInt(attacker.StrengthLevel * (1f + definition.strengthLevelPerBeastmasterLevel * beastmasterLevel));
             }
 
+            var npc = target as NpcCombatant;
             CombatantStats defender;
-            if (target is NpcCombatant npc)
+            if (npc != null)
                 defender = npc.GetCombatantStats();
             else
                 defender = new CombatantStats
@@ -203,7 +204,7 @@ namespace Pets
                     maxHit = Mathf.RoundToInt(maxHit * (1f + definition.maxHitPerBeastmasterLevel * beastmasterLevel));
                 int dmg = CombatMath.RollDamage(maxHit);
                 target.ApplyDamage(dmg, attacker.DamageType, this);
-                if (target is NpcCombatant npc)
+                if (npc != null)
                 {
                     var npcAttack = npc.GetComponent<NpcAttackController>();
                     npcAttack?.BeginAttacking(this);


### PR DESCRIPTION
## Summary
- Avoid duplicate npc variable declarations in `PetCombatController` by reusing a single `npc` reference
- Use the shared `npc` reference when triggering NPC counterattacks

## Testing
- `dotnet build` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68a74a138a1c832eab21bdadc06c615e