### PR TITLE
Ensure tree stump retains collider after depletion

### DIFF
--- a/Assets/Scripts/Skills/Woodcutting/Core/TreeNode.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Core/TreeNode.cs
@@ -16,6 +16,10 @@ namespace Skills.Woodcutting
         [SerializeField] private Sprite aliveSprite;
         [SerializeField] private Sprite depletedSprite;
 
+        [Header("Colliders")]
+        [SerializeField] private Collider2D stumpCollider;
+        private Collider2D col;
+
         public bool IsDepleted { get; private set; }
         public bool IsBusy { get; set; }
 
@@ -28,6 +32,9 @@ namespace Skills.Woodcutting
         {
             if (sr == null)
                 sr = GetComponent<SpriteRenderer>();
+            col = GetComponent<Collider2D>();
+            if (stumpCollider)
+                stumpCollider.enabled = false;
             if (def != null)
             {
                 if (aliveSprite == null) aliveSprite = def.AliveSprite;
@@ -81,8 +88,11 @@ namespace Skills.Woodcutting
         {
             IsDepleted = true;
             respawnAt = Time.timeAsDouble + def.RespawnSeconds;
-            var col = GetComponent<Collider2D>();
-            if (col) col.enabled = false;
+            if (stumpCollider)
+            {
+                if (col) col.enabled = false;
+                stumpCollider.enabled = true;
+            }
             if (sr && depletedSprite) sr.sprite = depletedSprite;
             IsBusy = false;
             OnTreeDepleted?.Invoke(this, def != null ? def.RespawnSeconds : 0f);
@@ -91,8 +101,15 @@ namespace Skills.Woodcutting
         private void Respawn()
         {
             IsDepleted = false;
-            var col = GetComponent<Collider2D>();
-            if (col) col.enabled = true;
+            if (stumpCollider)
+            {
+                stumpCollider.enabled = false;
+                if (col) col.enabled = true;
+            }
+            else if (col)
+            {
+                col.enabled = true;
+            }
             if (sr && aliveSprite) sr.sprite = aliveSprite;
             OnTreeRespawned?.Invoke(this);
         }


### PR DESCRIPTION
## Summary
- Preserve a collider when a tree is depleted
- Add optional stump collider to swap with tree collider
- Restore colliders when the tree respawns

## Testing
- `dotnet test` *(fails: specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a7520c76fc832e90e8ec0d27b07aed