### PR TITLE
Move pet sorting order to LateUpdate

### DIFF
--- a/Assets/Scripts/Pets/PetFollower.cs
+++ b/Assets/Scripts/Pets/PetFollower.cs
@@ -168,22 +168,26 @@ namespace Pets
                     sprite.flipX = newPos.x > player.position.x;
             }
 
-            if (sprite != null)
+        }
+
+        private void LateUpdate()
+        {
+            if (spriteDepth != null || sprite == null)
+                return;
+
+            int baseOrder = Mathf.RoundToInt(-transform.position.y * 100f) + depthOffset;
+            if (player != null)
             {
-                int baseOrder = Mathf.RoundToInt(-transform.position.y * 100f) + (spriteDepth != null ? spriteDepth.offset : 0);
-                if (player != null)
+                int playerOrder = Mathf.RoundToInt(-player.position.y * 100f) + (playerDepth != null ? playerDepth.offset : 0);
+                if (playerMover != null)
                 {
-                    int playerOrder = Mathf.RoundToInt(-player.position.y * 100f) + (playerDepth != null ? playerDepth.offset : 0);
-                    if (playerMover != null)
-                    {
-                        if (playerMover.FacingDir == 3 && transform.position.y < player.position.y)
-                            baseOrder = playerOrder - 1;
-                        else if (playerMover.FacingDir == 0 && transform.position.y > player.position.y)
-                            baseOrder = playerOrder - 1;
-                    }
+                    if (playerMover.FacingDir == 3 && transform.position.y < player.position.y)
+                        baseOrder = playerOrder - 1;
+                    else if (playerMover.FacingDir == 0 && transform.position.y > player.position.y)
+                        baseOrder = playerOrder - 1;
                 }
-                sprite.sortingOrder = baseOrder;
             }
+            sprite.sortingOrder = baseOrder;
         }
 
     }

--- a/Assets/Scripts/Pets/PetSpawner.cs
+++ b/Assets/Scripts/Pets/PetSpawner.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using UnityEngine.AI;
+using Util;
 
 namespace Pets
 {
@@ -23,6 +24,7 @@ namespace Pets
             go.transform.position = position;
 
             var sr = go.AddComponent<SpriteRenderer>();
+            go.AddComponent<SpriteDepth>();
             sr.sortingLayerName = "Characters";
             sr.sprite = def.sprite;
             if (sr.sprite == null)


### PR DESCRIPTION
## Summary
- Update pet follower to set sprite sorting order during `LateUpdate`
- Add `SpriteDepth` component when spawning pets for automatic depth handling

## Testing
- `dotnet test` *(fails: MSB1003 project/solution file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7709f7f4c832eae8e1c4d6c391bdb