### PR TITLE
Ignore minimap clicks for gathering interactions

### DIFF
--- a/Assets/Scripts/Skills/Mining/Core/MinerController.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MinerController.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.EventSystems;
 using Inventory;
 using Player;
 
@@ -36,13 +37,15 @@ namespace Skills.Mining
 
         private void Update()
         {
-            if (Input.GetMouseButtonDown(0))
+            bool pointerOverUI = EventSystem.current != null && EventSystem.current.IsPointerOverGameObject();
+
+            if (Input.GetMouseButtonDown(0) && !pointerOverUI)
             {
                 var rock = GetRockUnderCursor();
                 if (rock != null)
                     TryStartMining(rock);
             }
-            else if (Input.GetMouseButtonDown(1))
+            else if (Input.GetMouseButtonDown(1) && !pointerOverUI)
             {
                 var rock = GetRockUnderCursor();
                 if (rock != null)

--- a/Assets/Scripts/Skills/Woodcutting/Core/WoodcutterController.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Core/WoodcutterController.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.EventSystems;
 using Inventory;
 using Player;
 using Skills.Mining;
@@ -38,9 +39,12 @@ namespace Skills.Woodcutting
         {
             if (Input.GetMouseButtonDown(0))
             {
-                var tree = GetTreeUnderCursor();
-                if (tree != null)
-                    TryStartChopping(tree);
+                if (EventSystem.current == null || !EventSystem.current.IsPointerOverGameObject())
+                {
+                    var tree = GetTreeUnderCursor();
+                    if (tree != null)
+                        TryStartChopping(tree);
+                }
             }
 
             if (Input.GetKeyDown(KeyCode.Escape))


### PR DESCRIPTION
## Summary
- Prevent woodcutting input when pointer is over minimap or other UI
- Block mining and prospecting clicks when pointer overlaps UI elements

## Testing
- `dotnet test` *(fails: MSB1003 Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a78694c218832eaef661cdcab82862