### PR TITLE
Fix floating text visibility and increase minimap drag speed

### DIFF
--- a/Assets/Scripts/World/Minimap.cs
+++ b/Assets/Scripts/World/Minimap.cs
@@ -235,7 +235,7 @@ namespace World
                 if (IsExpanded && expandedMapRect != null && Input.GetMouseButton(1))
                 {
                     float worldPerPixel = (mapCamera.orthographicSize * 2f) / expandedMapRect.rect.height;
-                    dragOffset += new Vector3(-Input.GetAxis("Mouse X"), -Input.GetAxis("Mouse Y"), 0f) * worldPerPixel;
+                    dragOffset += new Vector3(-Input.GetAxis("Mouse X"), -Input.GetAxis("Mouse Y"), 0f) * worldPerPixel * 10f;
                 }
                 else if (!IsExpanded)
                 {


### PR DESCRIPTION
## Summary
- Render floating feedback text on a ScreenSpaceOverlay canvas so messages appear above world objects
- Multiply minimap right-click drag offset by 10 for faster panning

## Testing
- `dotnet build` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a7878fc7d4832ea8785a0846459095