### PR TITLE
Switch to LegacyRuntime font and correct floating text position

### DIFF
--- a/Assets/Scripts/Bank/BankUI.cs
+++ b/Assets/Scripts/Bank/BankUI.cs
@@ -76,7 +76,7 @@ namespace BankSystem
             }
             catch (ArgumentException)
             {
-                defaultFont = Resources.GetBuiltinResource<Font>("Arial.ttf");
+                defaultFont = null;
             }
 
             CreateUI();

--- a/Assets/Scripts/Inventory/Equipment.cs
+++ b/Assets/Scripts/Inventory/Equipment.cs
@@ -528,8 +528,7 @@ namespace Inventory
             }
             catch (ArgumentException)
             {
-                try { defaultFont = Resources.GetBuiltinResource<Font>("Arial.ttf"); }
-                catch (ArgumentException) { }
+                defaultFont = null;
             }
 
             for (int i = 0; i < 15; i++)

--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -68,11 +68,11 @@ namespace Inventory
         public Vector2 windowSize = new Vector2(83f, 375f);
 
         [Header("Tooltip")]
-        [Tooltip("Optional: custom font for the tooltip item name. Uses Arial if null.")]
+        [Tooltip("Optional: custom font for the tooltip item name. Uses LegacyRuntime if null.")]
         public Font tooltipNameFont;
         [Tooltip("Color for the tooltip item name text.")]
         public Color tooltipNameColor = Color.white;
-        [Tooltip("Optional: custom font for the tooltip description. Uses Arial if null.")]
+        [Tooltip("Optional: custom font for the tooltip description. Uses LegacyRuntime if null.")]
         public Font tooltipDescriptionFont;
         [Tooltip("Color for the tooltip description text.")]
         public Color tooltipDescriptionColor = Color.white;
@@ -163,28 +163,15 @@ namespace Inventory
             // Ensure at least one slot and cache the builtin font once
             size = Mathf.Max(1, size);
 
-            // Unity 2022+ renamed the builtin Arial font. Attempt to load the new
-            // name first and fall back for older Unity versions to avoid
-            // runtime exceptions that would prevent the UI from being created.
+            // Unity uses a builtin font named "LegacyRuntime" for runtime UI. Attempt
+            // to load it once so all UI elements have a consistent default.
             try
             {
                 defaultFont = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
             }
             catch (System.ArgumentException)
             {
-                // ignored: will fall back below
-            }
-
-            if (defaultFont == null)
-            {
-                try
-                {
-                    defaultFont = Resources.GetBuiltinResource<Font>("Arial.ttf");
-                }
-                catch (System.ArgumentException)
-                {
-                    defaultFont = null;
-                }
+                defaultFont = null;
             }
 
             items = new InventoryEntry[size];

--- a/Assets/Scripts/Shop/ShopUI.cs
+++ b/Assets/Scripts/Shop/ShopUI.cs
@@ -196,7 +196,7 @@ namespace ShopSystem
             GameObject closeTextGO = new GameObject("Text", typeof(Text));
             closeTextGO.transform.SetParent(closeButtonGO.transform, false);
             var closeText = closeTextGO.GetComponent<Text>();
-            closeText.font = priceFont != null ? priceFont : Resources.GetBuiltinResource<Font>("Arial.ttf");
+            closeText.font = priceFont != null ? priceFont : Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
             closeText.text = "X";
             closeText.alignment = TextAnchor.MiddleCenter;
             closeText.color = Color.white;
@@ -249,7 +249,7 @@ namespace ShopSystem
                 GameObject priceGO = new GameObject("Price", typeof(Text));
                 priceGO.transform.SetParent(slot.transform, false);
                 var priceText = priceGO.GetComponent<Text>();
-                priceText.font = priceFont != null ? priceFont : Resources.GetBuiltinResource<Font>("Arial.ttf");
+                priceText.font = priceFont != null ? priceFont : Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
                 priceText.alignment = TextAnchor.LowerLeft;
                 priceText.color = priceColor;
                 priceText.raycastTarget = false;
@@ -276,7 +276,7 @@ namespace ShopSystem
             GameObject nameGO = new GameObject("Name", typeof(Text));
             nameGO.transform.SetParent(window.transform, false);
             shopNameText = nameGO.GetComponent<Text>();
-            shopNameText.font = priceFont != null ? priceFont : Resources.GetBuiltinResource<Font>("Arial.ttf");
+            shopNameText.font = priceFont != null ? priceFont : Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
             shopNameText.color = priceColor;
             shopNameText.alignment = TextAnchor.MiddleLeft;
             shopNameText.text = string.Empty;
@@ -291,7 +291,7 @@ namespace ShopSystem
             GameObject tooltipGO = new GameObject("Tooltip", typeof(Text));
             tooltipGO.transform.SetParent(window.transform, false);
             tooltipText = tooltipGO.GetComponent<Text>();
-            tooltipText.font = priceFont != null ? priceFont : Resources.GetBuiltinResource<Font>("Arial.ttf");
+            tooltipText.font = priceFont != null ? priceFont : Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
             tooltipText.color = priceColor;
             tooltipText.alignment = TextAnchor.MiddleLeft;
             tooltipText.text = string.Empty;

--- a/Assets/Scripts/Skills/Mining/UI/FloatingText.cs
+++ b/Assets/Scripts/Skills/Mining/UI/FloatingText.cs
@@ -45,7 +45,7 @@ namespace Skills.Mining
             activeInstance.worldPosition = position;
             if (activeInstance.mainCamera == null)
                 activeInstance.mainCamera = Camera.main;
-            activeInstance.rectTransform.anchoredPosition = activeInstance.mainCamera.WorldToScreenPoint(position);
+            activeInstance.rectTransform.position = activeInstance.mainCamera.WorldToScreenPoint(position);
             activeInstance.uiText.text = message;
             activeInstance.uiText.color = color ?? Color.white;
             float finalSize = size ?? activeInstance.textSize;
@@ -64,7 +64,7 @@ namespace Skills.Mining
             if (mainCamera == null)
                 mainCamera = Camera.main;
             if (rectTransform != null && mainCamera != null)
-                rectTransform.anchoredPosition = mainCamera.WorldToScreenPoint(worldPosition);
+                rectTransform.position = mainCamera.WorldToScreenPoint(worldPosition);
 
             remainingLifetime -= Time.deltaTime;
             if (remainingLifetime <= 0f)


### PR DESCRIPTION
## Summary
- replace remaining Arial font references with LegacyRuntime builtin font
- use screen-space position so floating mining text appears above clicked objects

## Testing
- `dotnet test` *(fails: project or solution file not found)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a78a2ba588832eb1f1aa7339cbbd6f