### PR TITLE
Handle pets and minimap across scene transitions

### DIFF
--- a/Assets/Scripts/World/Minimap.cs
+++ b/Assets/Scripts/World/Minimap.cs
@@ -42,6 +42,8 @@ namespace World
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
         private static void CreateInstance()
         {
+            if (instance != null)
+                return;
             var go = new GameObject("Minimap");
             DontDestroyOnLoad(go);
             go.AddComponent<Minimap>();
@@ -54,6 +56,12 @@ namespace World
             CreateUI();
             RegisterExistingMarkers();
             ResetSmallMapZoom();
+        }
+
+        private void OnEnable()
+        {
+            if (mapTexture != null && !mapTexture.IsCreated())
+                mapTexture.Create();
         }
 
         private void CreateCamera()

--- a/Assets/Scripts/World/SceneTransitionManager.cs
+++ b/Assets/Scripts/World/SceneTransitionManager.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.EventSystems;
+using Pets;
 
 namespace World
 {
@@ -16,6 +17,7 @@ namespace World
         private GameObject _cameraToMove;
         private GameObject _inventoryUIToMove;
         private GameObject _eventSystemToMove;
+        private GameObject _petToMove;
         private string _nextSpawnPoint;
 
         private void Awake()
@@ -63,6 +65,13 @@ namespace World
             var ev = EventSystem.current;
             _eventSystemToMove = ev ? ev.gameObject : null;
             if (_eventSystemToMove) DontDestroyOnLoad(_eventSystemToMove);
+
+            var pet = PetDropSystem.ActivePetObject;
+            if (pet != null)
+            {
+                _petToMove = pet;
+                DontDestroyOnLoad(pet);
+            }
 
             SceneManager.sceneLoaded += OnSceneLoaded;
             SceneManager.LoadScene(sceneToLoad);
@@ -124,12 +133,25 @@ namespace World
                 }
             }
 
+            if (_petToMove != null)
+            {
+                if (_playerToMove != null)
+                {
+                    _petToMove.transform.position = _playerToMove.position;
+                    var follower = _petToMove.GetComponent<PetFollower>();
+                    if (follower != null)
+                        follower.SetPlayer(_playerToMove);
+                }
+                SceneManager.MoveGameObjectToScene(_petToMove, scene);
+            }
+
             SceneManager.sceneLoaded -= OnSceneLoaded;
             _playerToMove = null;
             _nextSpawnPoint = null;
             _cameraToMove = null;
             _inventoryUIToMove = null;
             _eventSystemToMove = null;
+            _petToMove = null;
 
             if (ScreenFader.Instance != null)
                 ScreenFader.Instance.StartCoroutine(ScreenFader.Instance.FadeIn());


### PR DESCRIPTION
## Summary
- Persist active pet across scene loads so it follows the player
- Prevent multiple minimap instances and ensure render texture is recreated when returning to a scene

## Testing
- `dotnet test` *(fails: no project or solution file found)*

------
https://chatgpt.com/codex/tasks/task_e_68a797036dd4832eb27e1bd84a1c6de4