### PR TITLE
Disable existing EventSystem during scene load

### DIFF
--- a/Assets/Scripts/World/SceneTransitionManager.cs
+++ b/Assets/Scripts/World/SceneTransitionManager.cs
@@ -74,6 +74,10 @@ namespace World
             }
 
             SceneManager.sceneLoaded += OnSceneLoaded;
+            if (_eventSystemToMove)
+                // Temporarily disable to avoid multiple active EventSystems during load
+                _eventSystemToMove.SetActive(false);
+
             SceneManager.LoadScene(sceneToLoad);
         }
 
@@ -131,6 +135,8 @@ namespace World
                     if (es.gameObject != _eventSystemToMove)
                         Destroy(es.gameObject);
                 }
+                // Reactivate after removing any duplicates
+                _eventSystemToMove.SetActive(true);
             }
 
             if (_petToMove != null)


### PR DESCRIPTION
## Summary
- Temporarily disable carried EventSystem before loading a new scene
- Reactivate it after removing duplicates once the scene has loaded

## Testing
- `dotnet test` *(fails: no project or solution file found)*

------
https://chatgpt.com/codex/tasks/task_e_68a79af8ffc8832e81c05d720a113904