### PR TITLE
Fix duplicate EventSystems during scene transition

### DIFF
--- a/Assets/Scripts/World/SceneTransitionManager.cs
+++ b/Assets/Scripts/World/SceneTransitionManager.cs
@@ -129,7 +129,8 @@ namespace World
             if (_eventSystemToMove != null)
             {
                 SceneManager.MoveGameObjectToScene(_eventSystemToMove, scene);
-                var systems = GameObject.FindObjectsOfType<EventSystem>();
+                // Remove any additional EventSystems, even if they are disabled
+                var systems = GameObject.FindObjectsOfType<EventSystem>(true);
                 foreach (var es in systems)
                 {
                     if (es.gameObject != _eventSystemToMove)


### PR DESCRIPTION
## Summary
- ensure duplicate EventSystems are removed on scene load

## Testing
- `dotnet test` (fails: no project or solution file)


------
https://chatgpt.com/codex/tasks/task_e_68a79e97dde0832e9b0770d72090a768