### PR TITLE
Preserve quest log during scene transitions

### DIFF
--- a/Assets/Scripts/Quests/QuestUI.cs
+++ b/Assets/Scripts/Quests/QuestUI.cs
@@ -37,6 +37,7 @@ namespace Quests
             gameObject.AddComponent<GraphicRaycaster>();
 
             BuildLayout();
+            DontDestroyOnLoad(gameObject);
             canvas.enabled = false;
             playerMover = FindObjectOfType<PlayerMover>();
         }

--- a/Assets/Scripts/World/SceneTransitionManager.cs
+++ b/Assets/Scripts/World/SceneTransitionManager.cs
@@ -16,6 +16,7 @@ namespace World
         private Transform _playerToMove;
         private GameObject _cameraToMove;
         private GameObject _inventoryUIToMove;
+        private GameObject _questUIToMove;
         private GameObject _eventSystemToMove;
         private GameObject _petToMove;
         private string _nextSpawnPoint;
@@ -61,6 +62,9 @@ namespace World
 
             _inventoryUIToMove = GameObject.Find("InventoryUI");
             if (_inventoryUIToMove) DontDestroyOnLoad(_inventoryUIToMove);
+
+            _questUIToMove = GameObject.Find("QuestUI");
+            if (_questUIToMove) DontDestroyOnLoad(_questUIToMove);
 
             var ev = EventSystem.current;
             _eventSystemToMove = ev ? ev.gameObject : null;
@@ -126,6 +130,17 @@ namespace World
                 }
             }
 
+            if (_questUIToMove != null)
+            {
+                SceneManager.MoveGameObjectToScene(_questUIToMove, scene);
+                var canvases = GameObject.FindObjectsOfType<Canvas>();
+                foreach (var cv in canvases)
+                {
+                    if (cv.gameObject != _questUIToMove && cv.gameObject.name == _questUIToMove.name)
+                        Destroy(cv.gameObject);
+                }
+            }
+
             if (_eventSystemToMove != null)
             {
                 SceneManager.MoveGameObjectToScene(_eventSystemToMove, scene);
@@ -157,6 +172,7 @@ namespace World
             _nextSpawnPoint = null;
             _cameraToMove = null;
             _inventoryUIToMove = null;
+            _questUIToMove = null;
             _eventSystemToMove = null;
             _petToMove = null;
 


### PR DESCRIPTION
## Summary
- Keep `QuestUI` across scene loads with `DontDestroyOnLoad`
- Move existing `QuestUI` during scene transitions and prune duplicates

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a0bbbdf4832ea791a754a36b089e