### PR TITLE
Prevent reload loops during scene transitions

### DIFF
--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -4,6 +4,7 @@ using UnityEngine.InputSystem;
 using UnityEngine.SceneManagement;
 using System;
 using Core.Save;
+using World;
 
 namespace Player
 {
@@ -257,7 +258,7 @@ namespace Player
             SavePosition();
         }
 
-        private void SavePosition()
+        public void SavePosition()
         {
             Vector3 pos = transform.position;
             var data = new PositionData
@@ -276,15 +277,11 @@ namespace Player
             if (data == null)
                 return;
 
-            if (SceneManager.GetActiveScene().name != data.scene)
-            {
-                SceneManager.sceneLoaded += OnSceneLoaded;
-                SceneManager.LoadScene(data.scene);
-            }
-            else
-            {
-                ApplySavedPosition();
-            }
+            if (SceneTransitionManager.IsTransitioning || SceneManager.GetActiveScene().name == data.scene)
+                return;
+
+            SceneManager.sceneLoaded += OnSceneLoaded;
+            SceneManager.LoadScene(data.scene);
         }
 
         private void OnSceneLoaded(Scene scene, LoadSceneMode mode)

--- a/Assets/Scripts/World/SceneTransitionManager.cs
+++ b/Assets/Scripts/World/SceneTransitionManager.cs
@@ -12,6 +12,7 @@ namespace World
     public class SceneTransitionManager : MonoBehaviour
     {
         public static SceneTransitionManager Instance;
+        public static bool IsTransitioning;
 
         private Transform _playerToMove;
         private GameObject _cameraToMove;
@@ -82,6 +83,7 @@ namespace World
                 // Temporarily disable to avoid multiple active EventSystems during load
                 _eventSystemToMove.SetActive(false);
 
+            IsTransitioning = true;
             SceneManager.LoadScene(sceneToLoad);
         }
 
@@ -106,6 +108,10 @@ namespace World
                     if (p != _playerToMove.gameObject)
                         Destroy(p);
                 }
+
+                var playerMover = _playerToMove.GetComponent<Player.PlayerMover>();
+                if (playerMover != null)
+                    playerMover.SavePosition();
             }
 
             if (_cameraToMove != null)
@@ -178,6 +184,8 @@ namespace World
 
             if (ScreenFader.Instance != null)
                 ScreenFader.Instance.StartCoroutine(ScreenFader.Instance.FadeIn());
+
+            IsTransitioning = false;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Expose `PlayerMover.SavePosition` so other systems can record the player position
- Track transition state and save player position when a new scene finishes loading
- Skip automatic scene loads if already transitioning or already in the saved scene

## Testing
- `dotnet test` *(fails: specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a73ca0e4832eb54fc7cd8b548d51