### PR TITLE
Prevent duplicated HUD and equipment UI on scene changes

### DIFF
--- a/Assets/Scripts/Inventory/Equipment.cs
+++ b/Assets/Scripts/Inventory/Equipment.cs
@@ -467,6 +467,10 @@ namespace Inventory
 
         private void CreateUI()
         {
+            var existing = GameObject.Find("EquipmentUI");
+            if (existing != null)
+                Destroy(existing);
+
             uiRoot = new GameObject("EquipmentUI", typeof(Canvas), typeof(CanvasScaler), typeof(GraphicRaycaster));
             uiRoot.transform.SetParent(null, false);
             DontDestroyOnLoad(uiRoot);

--- a/Assets/Scripts/UI/MergeHudTimer.cs
+++ b/Assets/Scripts/UI/MergeHudTimer.cs
@@ -15,6 +15,10 @@ namespace UI
 
         private void Awake()
         {
+            var existing = GameObject.Find("MergeHudCanvas");
+            if (existing != null)
+                Destroy(existing);
+
             var canvas = GetComponentInChildren<Canvas>();
             if (canvas == null)
             {


### PR DESCRIPTION
## Summary
- avoid leftover MergeHudCanvas when scenes change
- destroy any existing EquipmentUI before creating a new instance

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a99afd40832eb2e2a00739dbd72d