### PR TITLE
Fix minimap turning grey after scene load

### DIFF
--- a/Assets/Scripts/World/Minimap.cs
+++ b/Assets/Scripts/World/Minimap.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.SceneManagement;
 using System.Collections.Generic;
 using Skills;
 using BankSystem;
@@ -62,6 +63,12 @@ namespace World
         {
             if (mapTexture != null && !mapTexture.IsCreated())
                 mapTexture.Create();
+            SceneManager.sceneLoaded += HandleSceneLoaded;
+        }
+
+        private void OnDisable()
+        {
+            SceneManager.sceneLoaded -= HandleSceneLoaded;
         }
 
         private void CreateCamera()
@@ -227,6 +234,33 @@ namespace World
                     markers.Add(marker);
                 CreateIcons(marker);
             }
+        }
+
+        private void HandleSceneLoaded(Scene scene, LoadSceneMode mode)
+        {
+            if (mapTexture != null && !mapTexture.IsCreated())
+                mapTexture.Create();
+
+            if (mapCamera != null)
+                mapCamera.targetTexture = mapTexture;
+
+            if (smallMapRect != null)
+            {
+                var raw = smallMapRect.GetComponent<RawImage>();
+                if (raw != null)
+                    raw.texture = mapTexture;
+            }
+
+            if (expandedMapRect != null)
+            {
+                var raw = expandedMapRect.GetComponent<RawImage>();
+                if (raw != null)
+                    raw.texture = mapTexture;
+            }
+
+            RegisterExistingMarkers();
+            ResetSmallMapZoom();
+            dragOffset = Vector3.zero;
         }
 
         private void LateUpdate()


### PR DESCRIPTION
## Summary
- Reinitialize minimap render texture on scene load and rebind to camera/UI
- Reset zoom and markers when a new scene loads

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a7aabc9e10832ea8cc0b7a1829119a