### PR TITLE
Preserve minimap camera during scene transitions

### DIFF
--- a/Assets/Scripts/World/SceneTransitionManager.cs
+++ b/Assets/Scripts/World/SceneTransitionManager.cs
@@ -120,8 +120,13 @@ namespace World
                 var cameras = GameObject.FindObjectsOfType<Camera>();
                 foreach (var c in cameras)
                 {
-                    if (c.gameObject != _cameraToMove)
+                    var isMinimapCam = c.GetComponentInParent<Minimap>() != null;
+                    Debug.Log($"[SceneTransition] Found camera {c.name}, isMinimap={isMinimapCam}");
+                    if (c.gameObject != _cameraToMove && !isMinimapCam)
+                    {
+                        Debug.Log($"[SceneTransition] Destroying camera {c.name}");
                         Destroy(c.gameObject);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- Skip destroying the minimap camera when clearing extra cameras after a scene load
- Add debug logs to trace camera handling during transitions

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68a7add559e8832ea4513385f846ce25