### PR TITLE
Fix pet merge HUD and equipment stats across scenes

### DIFF
--- a/Assets/Scripts/Beastmaster/PetMergeController.cs
+++ b/Assets/Scripts/Beastmaster/PetMergeController.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 using Combat;
 using Pets;
 using UI;
+using EquipmentSystem;
 
 namespace Beastmaster
 {
@@ -23,6 +24,7 @@ namespace Beastmaster
 
         private IBeastmasterService beastmaster;
         private IPetService petService;
+        private EquipmentAggregator.CombinedStats mergedEquipStats;
 
         private bool merged;
         private float durationRemaining;
@@ -34,6 +36,7 @@ namespace Beastmaster
         public bool IsMerged => merged;
         public bool IsOnCooldown => cooldownRemaining > 0f;
         public float CooldownRemaining => cooldownRemaining;
+        public EquipmentAggregator.CombinedStats MergedEquipStats => mergedEquipStats;
         public bool CanMerge
         {
             get
@@ -61,7 +64,7 @@ namespace Beastmaster
             petService = petServiceComponent as IPetService;
 
             if (hudTimer == null)
-                hudTimer = GetComponentInChildren<MergeHudTimer>(true);
+                hudTimer = GetComponentInChildren<MergeHudTimer>(true) ?? FindObjectOfType<MergeHudTimer>();
 
             if (beastmaster == null)
                 Debug.LogWarning("PetMergeController missing IBeastmasterService component.");
@@ -118,6 +121,7 @@ namespace Beastmaster
             visualBinder?.ApplyPetLook(visuals);
             var combat = petService.GetCombatProfile(pet);
             combatBinder?.UseProfile(combat);
+            mergedEquipStats = combat != null ? combat.GetCombatStats().Equip : default;
             hudTimer?.Show(TimeSpan.FromSeconds(durationRemaining));
             SaveState();
             return true;
@@ -132,6 +136,7 @@ namespace Beastmaster
             visualBinder?.RestorePlayerLook();
             combatBinder?.RestorePlayerProfile();
             petService?.ShowActivePet(transform.position);
+            mergedEquipStats = default;
             hudTimer?.Hide();
             SaveState();
         }
@@ -143,6 +148,7 @@ namespace Beastmaster
                 EndMerge();
             cooldownRemaining = 0f;
             durationRemaining = 0f;
+            mergedEquipStats = default;
             hudTimer?.Hide();
             SaveState();
         }
@@ -176,6 +182,7 @@ namespace Beastmaster
                 visualBinder?.ApplyPetLook(visuals);
                 var combat = petService.GetCombatProfile(pet);
                 combatBinder?.UseProfile(combat);
+                mergedEquipStats = combat != null ? combat.GetCombatStats().Equip : default;
                 hudTimer?.Show(TimeSpan.FromSeconds(durationRemaining));
             }
             else

--- a/Assets/Scripts/Equipment/EquipmentAggregator.cs
+++ b/Assets/Scripts/Equipment/EquipmentAggregator.cs
@@ -2,6 +2,7 @@ using System;
 using UnityEngine;
 using Inventory;
 using Items;
+using Beastmaster;
 
 namespace EquipmentSystem
 {
@@ -39,27 +40,41 @@ namespace EquipmentSystem
         public CombinedStats GetCombinedStats()
         {
             CombinedStats result = new CombinedStats { attackSpeedTicks = 4 };
-            if (equipment == null)
-                return result;
-
-            foreach (EquipmentSlot slot in Enum.GetValues(typeof(EquipmentSlot)))
+            if (equipment != null)
             {
-                if (slot == EquipmentSlot.None)
-                    continue;
-                var entry = equipment.GetEquipped(slot);
-                var item = entry.item;
-                if (item == null)
-                    continue;
-                var stats = item.combat;
-                result.attack += stats.Attack;
-                result.strength += stats.Strength;
-                result.range += stats.Range;
-                result.magic += stats.Magic;
-                result.meleeDef += stats.MeleeDefence;
-                result.rangeDef += stats.RangeDefence;
-                result.magicDef += stats.MagicDefence;
-                if (slot == EquipmentSlot.Weapon && stats.AttackSpeedTicks > 0)
-                    result.attackSpeedTicks = stats.AttackSpeedTicks;
+                foreach (EquipmentSlot slot in Enum.GetValues(typeof(EquipmentSlot)))
+                {
+                    if (slot == EquipmentSlot.None)
+                        continue;
+                    var entry = equipment.GetEquipped(slot);
+                    var item = entry.item;
+                    if (item == null)
+                        continue;
+                    var stats = item.combat;
+                    result.attack += stats.Attack;
+                    result.strength += stats.Strength;
+                    result.range += stats.Range;
+                    result.magic += stats.Magic;
+                    result.meleeDef += stats.MeleeDefence;
+                    result.rangeDef += stats.RangeDefence;
+                    result.magicDef += stats.MagicDefence;
+                    if (slot == EquipmentSlot.Weapon && stats.AttackSpeedTicks > 0)
+                        result.attackSpeedTicks = stats.AttackSpeedTicks;
+                }
+            }
+
+            if (PetMergeController.Instance != null && PetMergeController.Instance.IsMerged)
+            {
+                var pet = PetMergeController.Instance.MergedEquipStats;
+                result.attack += pet.attack;
+                result.strength += pet.strength;
+                result.range += pet.range;
+                result.magic += pet.magic;
+                result.meleeDef += pet.meleeDef;
+                result.rangeDef += pet.rangeDef;
+                result.magicDef += pet.magicDef;
+                if (pet.attackSpeedTicks > 0)
+                    result.attackSpeedTicks = pet.attackSpeedTicks;
             }
 
             if (result.attackSpeedTicks <= 0)

--- a/Assets/Scripts/UI/MergeHudTimer.cs
+++ b/Assets/Scripts/UI/MergeHudTimer.cs
@@ -12,21 +12,38 @@ namespace UI
         [SerializeField] private Font font;
         private Text text;
         private Image background;
+        private static MergeHudTimer instance;
 
         private void Awake()
         {
-            var existing = GameObject.Find("MergeHudCanvas");
-            if (existing != null)
-                Destroy(existing);
+            if (instance != null && instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            instance = this;
 
             var canvas = GetComponentInChildren<Canvas>();
             if (canvas == null)
             {
-                var canvasGO = new GameObject("MergeHudCanvas", typeof(Canvas));
-                canvas = canvasGO.GetComponent<Canvas>();
-                canvas.renderMode = RenderMode.ScreenSpaceOverlay;
-                DontDestroyOnLoad(canvasGO);
-                transform.SetParent(canvasGO.transform, false);
+                var existing = GameObject.Find("MergeHudCanvas");
+                if (existing != null)
+                {
+                    canvas = existing.GetComponent<Canvas>();
+                    transform.SetParent(existing.transform, false);
+                }
+                else
+                {
+                    var canvasGO = new GameObject("MergeHudCanvas", typeof(Canvas));
+                    canvas = canvasGO.GetComponent<Canvas>();
+                    canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+                    DontDestroyOnLoad(canvasGO);
+                    transform.SetParent(canvasGO.transform, false);
+                }
+            }
+            else
+            {
+                DontDestroyOnLoad(canvas.gameObject);
             }
             var rectTransform = GetComponent<RectTransform>();
             if (rectTransform == null)

--- a/Assets/Scripts/UI/PetLevelBarContextMenuExtender.cs
+++ b/Assets/Scripts/UI/PetLevelBarContextMenuExtender.cs
@@ -65,7 +65,7 @@ namespace Pets
                 mergeController.EndMerge();
             else
                 mergeController.TryStartMerge();
-            Hide();
+            OnMenuShown();
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure MergeHudTimer persists between scenes and avoid duplicate instances
- propagate pet equipment bonuses when merged and refresh menu button text
- provide merged equipment stats to display bonuses on equipment tab

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a7af950060832e915bf3941e3f03bf