### PR TITLE
fix: load saved player position

### DIFF
--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -276,12 +276,18 @@ namespace Player
             var data = SaveManager.Load<PositionData>(PositionKey);
             if (data == null)
                 return;
-
-            if (SceneTransitionManager.IsTransitioning || SceneManager.GetActiveScene().name == data.scene)
+            if (SceneTransitionManager.IsTransitioning)
                 return;
 
-            SceneManager.sceneLoaded += OnSceneLoaded;
-            SceneManager.LoadScene(data.scene);
+            if (SceneManager.GetActiveScene().name == data.scene)
+            {
+                ApplySavedPosition();
+            }
+            else
+            {
+                SceneManager.sceneLoaded += OnSceneLoaded;
+                SceneManager.LoadScene(data.scene);
+            }
         }
 
         private void OnSceneLoaded(Scene scene, LoadSceneMode mode)


### PR DESCRIPTION
## Summary
- ensure player spawns at saved location when reloading game in same scene

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b1c7b838832ea4cf96c4ecd8d94a