### PR TITLE
Persist pet when loading saved scene

### DIFF
--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -5,6 +5,7 @@ using UnityEngine.SceneManagement;
 using System;
 using Core.Save;
 using World;
+using Pets;
 
 namespace Player
 {
@@ -38,6 +39,7 @@ namespace Player
         private Animator anim;
         private SpriteRenderer sr;
         private Inventory.Inventory inventory;
+        private GameObject petToMove;
 
         [Serializable]
         private class PositionData
@@ -286,6 +288,12 @@ namespace Player
             else
             {
                 SceneManager.sceneLoaded += OnSceneLoaded;
+                var pet = PetDropSystem.ActivePetObject;
+                if (pet != null)
+                {
+                    petToMove = pet;
+                    DontDestroyOnLoad(pet);
+                }
                 SceneManager.LoadScene(data.scene);
             }
         }
@@ -296,6 +304,15 @@ namespace Player
             if (data != null && scene.name == data.scene)
             {
                 ApplySavedPosition();
+                if (petToMove != null)
+                {
+                    petToMove.transform.position = transform.position;
+                    var follower = petToMove.GetComponent<PetFollower>();
+                    if (follower != null)
+                        follower.SetPlayer(transform);
+                    SceneManager.MoveGameObjectToScene(petToMove, scene);
+                    petToMove = null;
+                }
                 SceneManager.sceneLoaded -= OnSceneLoaded;
             }
         }


### PR DESCRIPTION
## Summary
- preserve active pet across startup scene loads by carrying it to the saved scene

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b3d3dd6c832e8e6bfcd99af5ce3c