### PR TITLE
Ensure pet follows player after loading saved scene

### DIFF
--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -284,6 +284,15 @@ namespace Player
             if (SceneManager.GetActiveScene().name == data.scene)
             {
                 ApplySavedPosition();
+
+                var pet = PetDropSystem.ActivePetObject;
+                if (pet != null)
+                {
+                    pet.transform.position = transform.position;
+                    var follower = pet.GetComponent<PetFollower>();
+                    if (follower != null)
+                        follower.SetPlayer(transform);
+                }
             }
             else
             {


### PR DESCRIPTION
## Summary
- Reposition the active pet and reassign its follower when loading a saved position in the same scene

## Testing
- `dotnet test` *(fails: project or solution file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b8c9995c832eba4961b6e7f40429