### PR TITLE
Add interaction trigger collider for woodcutting trees

### DIFF
--- a/Assets/Prefabs/Woodcutting Trees/Oak Woodcutting Tree - Level 15.prefab
+++ b/Assets/Prefabs/Woodcutting Trees/Oak Woodcutting Tree - Level 15.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 8236091862416192098}
   - component: {fileID: 1957610996786731413}
   - component: {fileID: 8560682867254658415}
+  - component: {fileID: 3244907390266376697}
   - component: {fileID: 6070147374573012547}
   - component: {fileID: 5826013684839782429}
   - component: {fileID: 1334518141455398624}
@@ -156,6 +157,52 @@ CapsuleCollider2D:
   m_Offset: {x: 0, y: -1}
   m_Size: {x: 3, y: 2}
   m_Direction: 1
+--- !u!61 &3244907390266376697
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5912612152994619936}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
 --- !u!114 &6070147374573012547
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Woodcutting Trees/Willow Woodcutting Tree - Level 30.prefab
+++ b/Assets/Prefabs/Woodcutting Trees/Willow Woodcutting Tree - Level 30.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: 1262169029336756179}
   - component: {fileID: 2288543091511179613}
   - component: {fileID: -405956003792355250}
+  - component: {fileID: 6325066802276008278}
   m_Layer: 0
   m_Name: Willow Woodcutting Tree - Level 30
   m_TagString: Untagged
@@ -185,3 +186,49 @@ CapsuleCollider2D:
   m_Offset: {x: 0, y: -1}
   m_Size: {x: 2, y: 2}
   m_Direction: 0
+--- !u!61 &6325066802276008278
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8019037619377101243}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0

--- a/Assets/Prefabs/Woodcutting Trees/Woodcutting Tree - Level 1.prefab
+++ b/Assets/Prefabs/Woodcutting Trees/Woodcutting Tree - Level 1.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 640502800502164102}
   - component: {fileID: -4868585429389313886}
   - component: {fileID: 4706168499053634714}
+  - component: {fileID: 9217099583063519757}
   m_Layer: 7
   m_Name: Woodcutting Tree - Level 1
   m_TagString: Untagged
@@ -156,3 +157,49 @@ CircleCollider2D:
   m_CompositeOrder: 0
   m_Offset: {x: 0.1, y: -0.8}
   m_Radius: 0.38
+--- !u!61 &9217099583063519757
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 670287344996780806}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0

--- a/Assets/Scripts/Skills/Woodcutting/Core/TreeNode.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Core/TreeNode.cs
@@ -19,6 +19,7 @@ namespace Skills.Woodcutting
         [Header("Colliders")]
         [SerializeField] private Collider2D stumpCollider;
         private Collider2D col;
+        private BoxCollider2D interactionCollider;
 
         public bool IsDepleted { get; private set; }
         public bool IsBusy { get; set; }
@@ -40,6 +41,25 @@ namespace Skills.Woodcutting
                 if (aliveSprite == null) aliveSprite = def.AliveSprite;
                 if (depletedSprite == null) depletedSprite = def.DepletedSprite;
                 if (sr != null && aliveSprite != null) sr.sprite = aliveSprite;
+            }
+
+            var boxColliders = GetComponents<BoxCollider2D>();
+            foreach (var bc in boxColliders)
+            {
+                if (bc != col)
+                {
+                    interactionCollider = bc;
+                    break;
+                }
+            }
+            if (interactionCollider == null)
+                interactionCollider = gameObject.AddComponent<BoxCollider2D>();
+            interactionCollider.isTrigger = true;
+            if (sr != null && sr.sprite != null)
+            {
+                var bounds = sr.sprite.bounds;
+                interactionCollider.size = bounds.size;
+                interactionCollider.offset = bounds.center;
             }
         }
 


### PR DESCRIPTION
## Summary
- add interaction trigger collider to TreeNode and size it to the sprite
- update woodcutting tree prefabs with new trigger colliders

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a859ecb27c832e89200a707e3e3022