### PR TITLE
feat: allow per-tree woodcutting ranges

### DIFF
--- a/Assets/Scripts/Skills/Woodcutting/Core/WoodcutterController.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Core/WoodcutterController.cs
@@ -57,10 +57,16 @@ namespace Skills.Woodcutting
             {
                 if (playerMover != null && playerMover.IsMoving)
                     woodcuttingSkill.StopChopping();
-                else if (Vector3.Distance(transform.position, woodcuttingSkill.CurrentTree.transform.position) > cancelDistance)
-                    woodcuttingSkill.StopChopping();
-                else if (woodcuttingSkill.CurrentTree.IsDepleted)
-                    woodcuttingSkill.StopChopping();
+                else
+                {
+                    float cancelDist = woodcuttingSkill.CurrentTree != null && woodcuttingSkill.CurrentTree.def != null
+                        ? woodcuttingSkill.CurrentTree.def.CancelDistance
+                        : cancelDistance;
+                    if (Vector3.Distance(transform.position, woodcuttingSkill.CurrentTree.transform.position) > cancelDist)
+                        woodcuttingSkill.StopChopping();
+                    else if (woodcuttingSkill.CurrentTree.IsDepleted)
+                        woodcuttingSkill.StopChopping();
+                }
             }
         }
 
@@ -81,7 +87,8 @@ namespace Skills.Woodcutting
                 return;
 
             float dist = Vector3.Distance(transform.position, tree.transform.position);
-            if (dist > interactRange)
+            float range = tree.def != null ? tree.def.InteractRange : interactRange;
+            if (dist > range)
                 return;
 
             var axe = axeSelector.GetBestAxe();

--- a/Assets/Scripts/Skills/Woodcutting/Data/TreeDefinition.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Data/TreeDefinition.cs
@@ -26,6 +26,10 @@ namespace Skills.Woodcutting
         [Header("Chop Timing")]
         [SerializeField] private int chopIntervalTicks = 4;
 
+        [Header("Ranges")]
+        [SerializeField] private float interactRange = 1.5f;
+        [SerializeField] private float cancelDistance = 3f;
+
         [Header("Visuals")]
         [SerializeField] private Sprite aliveSprite;
         [SerializeField] private Sprite depletedSprite;
@@ -39,6 +43,8 @@ namespace Skills.Woodcutting
         public int DepleteRollInverse => depleteRollInverse;
         public int RespawnSeconds => respawnSeconds;
         public int ChopIntervalTicks => chopIntervalTicks;
+        public float InteractRange => interactRange;
+        public float CancelDistance => cancelDistance;
         public Sprite AliveSprite => aliveSprite;
         public Sprite DepletedSprite => depletedSprite;
     }


### PR DESCRIPTION
## Summary
- add interaction and cancel range fields to tree definitions
- use tree-specific ranges when starting and cancelling woodcutting

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a85fb66720832eb4d722aff1bbc772