### PR TITLE
Add pet storage inventories

### DIFF
--- a/Assets/Scripts/Pets/PetClickable.cs
+++ b/Assets/Scripts/Pets/PetClickable.cs
@@ -10,10 +10,12 @@ namespace Pets
     public class PetClickable : MonoBehaviour
     {
         private PetDefinition definition;
+        private PetStorage storage;
 
-        public void Init(PetDefinition def)
+        public void Init(PetDefinition def, PetStorage petStorage)
         {
             definition = def;
+            storage = petStorage;
         }
 
         private void Awake()
@@ -24,17 +26,24 @@ namespace Pets
 
         private void Update()
         {
-            if (Input.GetMouseButtonDown(0))
+            bool left = Input.GetMouseButtonDown(0);
+            bool right = Input.GetMouseButtonDown(1);
+            if (!left && !right)
+                return;
+
+            Vector3 world = Camera.main.ScreenToWorldPoint(Input.mousePosition);
+            Vector2 p = new Vector2(world.x, world.y);
+            var hit = Physics2D.OverlapPoint(p);
+            if (hit != null && hit.gameObject == gameObject)
             {
-                Vector3 world = Camera.main.ScreenToWorldPoint(Input.mousePosition);
-                Vector2 p = new Vector2(world.x, world.y);
-                var hit = Physics2D.OverlapPoint(p);
-                if (hit != null && hit.gameObject == gameObject)
-                    OnClicked();
+                if (left)
+                    OnLeftClick();
+                else if (right)
+                    OnRightClick();
             }
         }
 
-        private void OnClicked()
+        private void OnLeftClick()
         {
             if (definition != null && definition.pickupItem != null)
                 InventoryBridge.AddItem(definition.pickupItem, 1);
@@ -42,6 +51,12 @@ namespace Pets
             PetDropSystem.DespawnActive();
             PetToastUI.Show("You pick up the pet.");
             Destroy(gameObject);
+        }
+
+        private void OnRightClick()
+        {
+            if (storage != null)
+                storage.Open();
         }
     }
 }

--- a/Assets/Scripts/Pets/PetDefinition.cs
+++ b/Assets/Scripts/Pets/PetDefinition.cs
@@ -22,6 +22,10 @@ namespace Pets
         [Tooltip("Item awarded when picking up the pet.")]
         public ItemData pickupItem;
 
+        [Header("Storage")]
+        [Tooltip("If true, this pet has its own inventory.")]
+        public bool hasInventory;
+
         [Header("Visuals")]
         [Tooltip("Idle sprite if no animation clips are provided.")]
         public Sprite sprite;

--- a/Assets/Scripts/Pets/PetSpawner.cs
+++ b/Assets/Scripts/Pets/PetSpawner.cs
@@ -123,11 +123,19 @@ namespace Pets
             var follower = go.AddComponent<PetFollower>();
             if (player != null)
                 follower.SetPlayer(player);
-            var clickable = go.AddComponent<PetClickable>();
-            clickable.Init(def);
 
             var exp = go.AddComponent<PetExperience>();
             exp.definition = def;
+
+            PetStorage storage = null;
+            if (def.hasInventory)
+            {
+                storage = go.AddComponent<PetStorage>();
+                storage.definition = def;
+            }
+
+            var clickable = go.AddComponent<PetClickable>();
+            clickable.Init(def, storage);
 
             if (def.canFight)
             {

--- a/Assets/Scripts/Pets/PetStorage.cs
+++ b/Assets/Scripts/Pets/PetStorage.cs
@@ -1,0 +1,84 @@
+using UnityEngine;
+using Inventory;
+
+namespace Pets
+{
+    /// <summary>
+    /// Provides per-pet storage using the project's inventory system.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class PetStorage : MonoBehaviour
+    {
+        public PetDefinition definition;
+        private Inventory.Inventory inventory;
+        private PetExperience experience;
+
+        private void Awake()
+        {
+            experience = GetComponent<PetExperience>();
+        }
+
+        private void Start()
+        {
+            if (definition != null && definition.hasInventory)
+            {
+                CreateInventory();
+                if (experience != null)
+                    experience.OnLevelChanged += HandleLevelChanged;
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (experience != null)
+                experience.OnLevelChanged -= HandleLevelChanged;
+        }
+
+        private void CreateInventory()
+        {
+            inventory = gameObject.AddComponent<Inventory.Inventory>();
+            inventory.useSharedUIRoot = false;
+            inventory.columns = 4;
+            inventory.showCloseButton = true;
+            inventory.size = GetSlotsForLevel(experience != null ? experience.Level : 1);
+            inventory.saveKey = $"PetInv_{definition?.id}";
+            var inventories = FindObjectsOfType<Inventory.Inventory>();
+            foreach (var inv in inventories)
+            {
+                if (inv.gameObject != gameObject)
+                {
+                    inventory.windowColor = inv.windowColor;
+                    break;
+                }
+            }
+        }
+
+        private void HandleLevelChanged(int lvl)
+        {
+            if (inventory == null)
+                return;
+            int newSize = GetSlotsForLevel(lvl);
+            if (newSize != inventory.size)
+            {
+                inventory.Save();
+                Destroy(inventory);
+                CreateInventory();
+            }
+        }
+
+        private int GetSlotsForLevel(int level)
+        {
+            if (level >= 99) return 20;
+            if (level >= 75) return 16;
+            if (level >= 50) return 12;
+            if (level >= 25) return 8;
+            return 4;
+        }
+
+        public void Open()
+        {
+            if (inventory != null)
+                inventory.OpenUI();
+        }
+    }
+}

--- a/Assets/Scripts/Pets/PetStorage.cs.meta
+++ b/Assets/Scripts/Pets/PetStorage.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3262e4fc36c24d0688a38d417840f3be
+timeCreated: 1755869290


### PR DESCRIPTION
## Summary
- allow pets to have their own inventory via new `PetStorage` component
- extend inventory system for variable columns, close button, and unique save keys
- enable right-clicking pets to open their storage and toggle via `hasInventory`

## Testing
- `dotnet build` *(fails: project or solution file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a86f6f1740832eb292333fd495e4d9