### PR TITLE
Synchronize pet inventory with player and bank

### DIFF
--- a/Assets/Scripts/Bank/BankUI.cs
+++ b/Assets/Scripts/Bank/BankUI.cs
@@ -495,8 +495,8 @@ namespace BankSystem
                 playerInventory = FindObjectOfType<Inventory.Inventory>();
             if (playerInventory != null)
             {
-                playerInventory.OpenUI();
                 playerInventory.BankOpen = true;
+                playerInventory.OpenUI();
             }
             var skills = SkillsUI.Instance;
             if (skills != null && skills.IsOpen)

--- a/Assets/Scripts/Beastmaster/PetMergeController.cs
+++ b/Assets/Scripts/Beastmaster/PetMergeController.cs
@@ -150,6 +150,8 @@ namespace Beastmaster
             if (!petService.TryGetActiveCombatPet(out var pet))
                 return false;
 
+            pet?.GetComponent<PetStorage>()?.Close();
+
             durationRemaining = (float)dur.TotalSeconds;
             cooldownRemaining = (float)cd.TotalSeconds;
             merged = true;

--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -129,12 +129,27 @@ namespace Inventory
         {
             if (uiRoot != null)
                 uiRoot.SetActive(false);
+            if (playerMover != null)
+            {
+                var pet = PetDropSystem.ActivePetObject;
+                var storage = pet != null ? pet.GetComponent<PetStorage>() : null;
+                storage?.Close();
+            }
         }
 
         public void OpenUI()
         {
             if (uiRoot != null)
                 uiRoot.SetActive(true);
+            if (playerMover != null)
+            {
+                var pet = PetDropSystem.ActivePetObject;
+                var storage = pet != null ? pet.GetComponent<PetStorage>() : null;
+                if (!BankOpen)
+                    storage?.Open();
+                else
+                    storage?.Close();
+            }
         }
 
         public InventoryEntry GetSlot(int index)
@@ -1051,23 +1066,26 @@ namespace Inventory
             bool toggle = Input.GetKeyDown(KeyCode.I);
 #endif
 
+            if (playerMover == null)
+                return;
+
             var quest = Object.FindObjectOfType<QuestUI>();
             if (quest != null && quest.IsOpen)
             {
                 if (uiRoot != null && uiRoot.activeSelf)
-                    uiRoot.SetActive(false);
+                    CloseUI();
                 return;
             }
             if (currentShop != null)
             {
                 if (uiRoot != null && !uiRoot.activeSelf)
-                    uiRoot.SetActive(true);
+                    OpenUI();
                 return;
             }
             if (BankOpen)
             {
                 if (uiRoot != null && !uiRoot.activeSelf)
-                    uiRoot.SetActive(true);
+                    OpenUI();
                 return;
             }
             if (toggle && uiRoot != null)
@@ -1077,8 +1095,12 @@ namespace Inventory
                     var skills = SkillsUI.Instance;
                     if (skills != null && skills.IsOpen)
                         skills.Close();
+                    OpenUI();
                 }
-                uiRoot.SetActive(!uiRoot.activeSelf);
+                else
+                {
+                    CloseUI();
+                }
             }
         }
 

--- a/Assets/Scripts/Pets/PetClickable.cs
+++ b/Assets/Scripts/Pets/PetClickable.cs
@@ -48,6 +48,7 @@ namespace Pets
             if (definition != null && definition.pickupItem != null)
                 InventoryBridge.AddItem(definition.pickupItem, 1);
 
+            storage?.Close();
             PetDropSystem.DespawnActive();
             PetToastUI.Show("You pick up the pet.");
             Destroy(gameObject);

--- a/Assets/Scripts/Pets/PetStorage.cs
+++ b/Assets/Scripts/Pets/PetStorage.cs
@@ -39,7 +39,8 @@ namespace Pets
             inventory = gameObject.AddComponent<Inventory.Inventory>();
             inventory.useSharedUIRoot = false;
             inventory.columns = 4;
-            inventory.showCloseButton = true;
+            inventory.showCloseButton = false;
+            inventory.emptySlotColor = Color.clear;
             inventory.centerOnScreen = true;
             inventory.size = GetSlotsForLevel(experience != null ? experience.Level : 1);
             inventory.saveKey = $"PetInv_{definition?.id}";
@@ -80,6 +81,12 @@ namespace Pets
         {
             if (inventory != null)
                 inventory.OpenUI();
+        }
+
+        public void Close()
+        {
+            if (inventory != null)
+                inventory.CloseUI();
         }
     }
 }


### PR DESCRIPTION
## Summary
- Hide pet inventory close button/background and add close helper
- Open/close pet inventory alongside player inventory and close on pickup or merge
- Prevent pet inventory from appearing when bank is open

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68a875ebf378832e9ee42ab63c7f4273