### PR TITLE
Prevent inventory from closing while bank is open

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -127,6 +127,8 @@ namespace Inventory
 
         public void CloseUI()
         {
+            if (BankOpen)
+                return;
             if (uiRoot != null)
                 uiRoot.SetActive(false);
             if (playerMover != null)


### PR DESCRIPTION
## Summary
- Skip inventory closing when the bank interface is active to keep inventory open during banking

## Testing
- `dotnet test` *(fails: project or solution file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a889ed3c08832ea818137c128d16f7