### PR TITLE
Ensure pet inventory updates when dropping new pet

### DIFF
--- a/Assets/Scripts/Pets/PetDropSystem.cs
+++ b/Assets/Scripts/Pets/PetDropSystem.cs
@@ -170,6 +170,8 @@ namespace Pets
             PetLevelBarHUD.DestroyInstance();
             if (activePetGO != null)
             {
+                var storage = activePetGO.GetComponent<PetStorage>();
+                storage?.Close();
                 UnityEngine.Object.Destroy(activePetGO);
                 activePetGO = null;
                 activePetDef = null;
@@ -209,6 +211,14 @@ namespace Pets
             PetLevelBarHUD.CreateForPet(exp);
             PetToastUI.Show("You have a funny feeling like you're being followed…", pet.messageColor);
             Debug.Log($"Spawned pet '{pet.displayName}' at {spawnPos}.");
+
+            var playerInventory = playerTransform != null ? playerTransform.GetComponent<Inventory.Inventory>() : null;
+            if (playerInventory != null && playerInventory.IsOpen && !playerInventory.BankOpen)
+            {
+                var storage = activePetGO.GetComponent<PetStorage>();
+                storage?.Open();
+            }
+
             return activePetGO;
         }
 


### PR DESCRIPTION
## Summary
- Close previous pet's inventory UI when despawning
- Automatically open new pet's inventory if player inventory is already open

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a88b9065dc832e8589ac67b7fc9756