### PR TITLE
Fix pet inventory UI refresh after level up

### DIFF
--- a/Assets/Scripts/Pets/PetStorage.cs
+++ b/Assets/Scripts/Pets/PetStorage.cs
@@ -68,9 +68,20 @@ namespace Pets
             int newSize = GetSlotsForLevel(lvl);
             if (newSize != inventory.size)
             {
+                // Remember if the inventory UI was open so we can restore it.
+                bool reopen = inventory.IsOpen;
+
                 inventory.Save();
+                // Close and deactivate the existing UI so it doesn't remain
+                // on screen or intercept clicks after the component is destroyed.
+                inventory.CloseUI();
                 Destroy(inventory);
                 CreateInventory();
+
+                // Reopen the UI if it was visible before the rebuild so players
+                // immediately see the updated slot count.
+                if (reopen)
+                    inventory.OpenUI();
             }
         }
 


### PR DESCRIPTION
## Summary
- Close and rebuild pet inventory UI when pet levels up
- Reopen inventory UI after rebuild if it was previously open

## Testing
- `dotnet test` *(fails: specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a88e8f215c832e838cea87054f7061