### PR TITLE
Prevent pet clicks through inventory UI

### DIFF
--- a/Assets/Scripts/Pets/PetClickable.cs
+++ b/Assets/Scripts/Pets/PetClickable.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.EventSystems;
 using Inventory;
 
 namespace Pets
@@ -27,6 +28,9 @@ namespace Pets
         private void Update()
         {
             if (!Input.GetMouseButtonDown(0))
+                return;
+
+            if (EventSystem.current != null && EventSystem.current.IsPointerOverGameObject())
                 return;
 
             Vector3 world = Camera.main.ScreenToWorldPoint(Input.mousePosition);


### PR DESCRIPTION
## Summary
- ignore pet clicks when the pointer is over UI to avoid picking up pets while using inventory

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68a88ff7e628832ea597ea5f31a5b982