### PR TITLE
Use GroundItemSpawner for NPC drops

### DIFF
--- a/Assets/Scripts/Drops/NpcDropper.cs
+++ b/Assets/Scripts/Drops/NpcDropper.cs
@@ -66,23 +66,15 @@ namespace MyGame.Drops
                 Vector2 offset = UnityEngine.Random.insideUnitCircle * spawnSpreadRadius;
                 Vector3 pos = basePos + (Vector3)offset;
 
-                Debug.Log($"NpcDropper: Trying to add {drop.quantity}x {drop.item?.name} to inventory.");
-                bool added = InventoryBridge.AddItem(drop.item, drop.quantity);
-                if (added)
+                if (spawner != null)
                 {
-                    Debug.Log($"NpcDropper: Added {drop.quantity}x {drop.item?.name} to inventory.");
+                    Debug.Log($"NpcDropper: Spawning {drop.quantity}x {drop.item?.name} at {pos}.");
+                    spawner.Spawn(drop.item, drop.quantity, pos);
                 }
                 else
                 {
-                    if (spawner != null)
-                    {
-                        Debug.Log($"NpcDropper: Inventory full, spawning {drop.quantity}x {drop.item?.name} at {pos}.");
-                        spawner.Spawn(drop.item, drop.quantity, pos);
-                    }
-                    else
-                    {
-                        Debug.LogWarning($"NpcDropper: Failed to add {drop.item?.name} to inventory and no spawner available.");
-                    }
+                    Debug.LogWarning($"NpcDropper: No GroundItemSpawner available; adding {drop.quantity}x {drop.item?.name} to inventory.");
+                    InventoryBridge.AddItem(drop.item, drop.quantity);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Spawn NPC drop items on the ground using `GroundItemSpawner`
- Fallback to inventory add and warning when no spawner exists

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b86d7004832e8de1a771999c61a0