### PR TITLE
Add item pickup initialization with icon support

### DIFF
--- a/Assets/Prefabs/ItemPickup.prefab
+++ b/Assets/Prefabs/ItemPickup.prefab
@@ -1,0 +1,121 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4}
+  - component: {fileID: 212}
+  - component: {fileID: 58}
+  - component: {fileID: 114}
+  m_Layer: 0
+  m_Name: ItemPickup
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+--- !u!212 &212
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 0
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!58 &58
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_Radius: 0.5
+--- !u!114 &114
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: be7eb6047db6e686c8e3e984c7a5ea92, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  item: {fileID: 0}
+  amount: 0
+  iconRenderer: {fileID: 212}
+

--- a/Assets/Prefabs/ItemPickup.prefab.meta
+++ b/Assets/Prefabs/ItemPickup.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 43e97bffc6e249cd9dd4906609cb174a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+

--- a/Assets/Scripts/Inventory/ItemPickup.cs
+++ b/Assets/Scripts/Inventory/ItemPickup.cs
@@ -11,12 +11,34 @@ namespace Inventory
     public class ItemPickup : MonoBehaviour
     {
         public ItemData item;
+        public int amount;
+        public SpriteRenderer iconRenderer;
 
         private void Reset()
         {
             // Ensure collider is configured as a trigger for easy pickup.
             var col = GetComponent<Collider2D>();
             col.isTrigger = true;
+            Initialize(item, amount);
+        }
+
+        private void Start()
+        {
+            Initialize(item, amount);
+        }
+
+        private void OnValidate()
+        {
+            Initialize(item, amount);
+        }
+
+        public void Initialize(ItemData item, int amount)
+        {
+            this.item = item;
+            this.amount = amount;
+            iconRenderer ??= GetComponentInChildren<SpriteRenderer>();
+            if (iconRenderer != null && item != null)
+                iconRenderer.sprite = item.icon;
         }
 
         private void OnTriggerEnter2D(Collider2D other)
@@ -25,7 +47,7 @@ namespace Inventory
                 return;
 
             Inventory inv = other.GetComponent<Inventory>();
-            if (inv != null && inv.AddItem(item))
+            if (inv != null && inv.AddItem(item, amount))
             {
                 Destroy(gameObject);
             }


### PR DESCRIPTION
## Summary
- extend ItemPickup to track amount and set icon via Initialize
- create ItemPickup prefab with SpriteRenderer hooked to iconRenderer

## Testing
- `dotnet test` *(fails: MSBUILD error missing project or solution)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bb4ce918832e8b7bfd466beed396