### PR TITLE
Shrink NPC drop item sprites

### DIFF
--- a/Assets/Scripts/Drops/GroundItemSpawner.cs
+++ b/Assets/Scripts/Drops/GroundItemSpawner.cs
@@ -65,6 +65,13 @@ namespace MyGame.Drops
                     amtField.SetValue(pickup, amount);
                 }
             }
+
+            // Shrink the pickup's sprite to one-third of its original size.
+            var renderer = pickup.GetComponentInChildren<SpriteRenderer>();
+            if (renderer != null)
+            {
+                renderer.transform.localScale *= 1f / 3f;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Reduce size of item pickup sprites spawned by NPC drops to one-third of original

## Testing
- `dotnet build` *(fails: MSB1003 project file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bdb4de5c832ea28b31b692dd7e1e