### PR TITLE
Expire untouched item drops

### DIFF
--- a/Assets/Scripts/Inventory/ItemPickup.cs
+++ b/Assets/Scripts/Inventory/ItemPickup.cs
@@ -13,6 +13,8 @@ namespace Inventory
         public ItemData item;
         public int amount;
         public SpriteRenderer iconRenderer;
+        /// <summary>Time in seconds before the pickup is removed if untouched.</summary>
+        public float lifetime = 60f;
 
         private void Reset()
         {
@@ -25,6 +27,8 @@ namespace Inventory
         private void Start()
         {
             Initialize(item, amount);
+            // Automatically remove the item after its lifetime expires.
+            Destroy(gameObject, lifetime);
         }
 
         private void OnValidate()


### PR DESCRIPTION
## Summary
- auto-delete item drops 60 seconds after spawning

## Testing
- `dotnet test` *(fails: Specify a project or solution file. The current working directory does not contain a project or solution file.)*


------
https://chatgpt.com/codex/tasks/task_e_68a8bf77b408832eb5a4ea1f1f37e764