### PR TITLE
Open Nolof shop directly on right-click

### DIFF
--- a/Assets/Scripts/NPC/NolofShopOpener.cs
+++ b/Assets/Scripts/NPC/NolofShopOpener.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+using ShopSystem;
+using Combat;
+using Pets;
+
+namespace NPC
+{
+    /// <summary>
+    /// Opens the assigned shop when right-clicking this NPC without showing a context menu.
+    /// </summary>
+    [RequireComponent(typeof(Collider2D))]
+    public class NolofShopOpener : MonoBehaviour
+    {
+        [Tooltip("Shop component for this NPC.")]
+        public Shop shop;
+
+        private void OnMouseOver()
+        {
+            if (EventSystem.current != null && EventSystem.current.IsPointerOverGameObject())
+                return;
+
+            if (Input.GetMouseButtonDown(1))
+            {
+                if (!PetDropSystem.GuardModeEnabled && PetDropSystem.ActivePetCombat != null && GetComponent<CombatTarget>() != null)
+                {
+                    PetDropSystem.ActivePetCombat.CommandAttack(GetComponent<CombatTarget>());
+                    return;
+                }
+
+                if (shop == null) return;
+                var ui = ShopUI.Instance;
+                if (ui != null)
+                    ui.Open(shop, GetComponent<NpcRandomMovement>());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `NolofShopOpener` script to bypass NPC context menu and open the assigned shop on right-click

## Testing
- `dotnet test` *(fails: current working directory does not contain a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ca5ea928832eae26586085115137