### PR TITLE
Add generic ShopOpener script for NPCs

### DIFF
--- a/Assets/Scripts/NPC/ShopOpener.cs
+++ b/Assets/Scripts/NPC/ShopOpener.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+using ShopSystem;
+using Combat;
+using Pets;
+
+namespace NPC
+{
+    /// <summary>
+    /// Opens an NPC's shop when right-clicked, if a <see cref="Shop"/> component is present.
+    /// </summary>
+    [RequireComponent(typeof(Collider2D))]
+    public class ShopOpener : MonoBehaviour
+    {
+        [Tooltip("Optional shop component. If not assigned, will look on this GameObject.")]
+        public Shop shop;
+
+        private void Awake()
+        {
+            if (shop == null)
+                shop = GetComponent<Shop>();
+        }
+
+        private void OnMouseOver()
+        {
+            if (EventSystem.current != null && EventSystem.current.IsPointerOverGameObject())
+                return;
+
+            if (Input.GetMouseButtonDown(1))
+            {
+                if (!PetDropSystem.GuardModeEnabled && PetDropSystem.ActivePetCombat != null && GetComponent<CombatTarget>() != null)
+                {
+                    PetDropSystem.ActivePetCombat.CommandAttack(GetComponent<CombatTarget>());
+                    return;
+                }
+
+                if (shop == null) return;
+                var ui = ShopUI.Instance;
+                if (ui != null)
+                    ui.Open(shop, GetComponent<NpcRandomMovement>());
+            }
+        }
+    }
+}

--- a/Assets/Scripts/NPC/ShopOpener.cs.meta
+++ b/Assets/Scripts/NPC/ShopOpener.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a1327c6bd3da4bcaad4c2ace865e9e6d
+timeCreated: 1755892739


### PR DESCRIPTION
## Summary
- add a reusable ShopOpener component to open an NPC's shop on right-click

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a8cbbc45a4832eb6886344587f5958