### PR TITLE
Close merge menu after merge/unmerge actions

### DIFF
--- a/Assets/Scripts/UI/PetLevelBarContextMenuExtender.cs
+++ b/Assets/Scripts/UI/PetLevelBarContextMenuExtender.cs
@@ -65,7 +65,7 @@ namespace Pets
                 mergeController.EndMerge();
             else
                 mergeController.TryStartMerge();
-            OnMenuShown();
+            Hide();
         }
     }
 }


### PR DESCRIPTION
## Summary
- Hide the pet level bar context menu immediately after merging or unmerging

## Testing
- ⚠️ `dotnet test` *(no project or solution file found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d4020030832e95c71d0d0b11046c