### PR TITLE
Ensure pet kills still trigger NPC drops

### DIFF
--- a/Assets/Scripts/NPC/NpcCombatant.cs
+++ b/Assets/Scripts/NPC/NpcCombatant.cs
@@ -40,9 +40,12 @@ namespace NPC
             OnHealthChanged?.Invoke(currentHp, MaxHP);
             if (currentHp <= 0)
             {
-                OnDeath?.Invoke();
+                // Trigger drops before other death listeners in case they
+                // destroy this NPC immediately (e.g. when killed by pets).
                 var dropper = GetComponent<NpcDropper>();
                 dropper?.OnDeath();
+
+                OnDeath?.Invoke();
                 if (collider2D) collider2D.enabled = false;
                 if (spriteRenderer) spriteRenderer.enabled = false;
                 if (profile != null && profile.RespawnSeconds > 0f)


### PR DESCRIPTION
## Summary
- Roll NPC loot before firing death events so listeners that destroy NPCs (like pet kill handlers) don't skip drops

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d546e2ec832e8a5dce8b355c2c69