### PR TITLE
Save woodcutting XP on disable

### DIFF
--- a/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
@@ -72,6 +72,8 @@ namespace Skills.Woodcutting
                 Ticker.Instance.Unsubscribe(this);
             if (tickerCoroutine != null)
                 StopCoroutine(tickerCoroutine);
+            // Persist XP when the component is disabled to avoid losing progress
+            save.SaveXp(xp);
         }
 
         private void TrySubscribeToTicker()


### PR DESCRIPTION
## Summary
- ensure woodcutting XP is saved when the component disables so levels persist between sessions

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68aae4dda044832ebb2207ba353ca5a6