### PR TITLE
Remove P key debug pet drop

### DIFF
--- a/Assets/Scripts/Pets/PetDropSystem.cs
+++ b/Assets/Scripts/Pets/PetDropSystem.cs
@@ -65,12 +65,6 @@ namespace Pets
             var loaded = Resources.LoadAll<PetDropTable>("PetDropTables");
             RegisterTables(loaded);
 
-            // Create updater for debug hotkey
-            var go = new GameObject("~PetDropSystem");
-            go.hideFlags = HideFlags.HideAndDontSave;
-            go.AddComponent<PetDropSystemUpdater>();
-            GameObject.DontDestroyOnLoad(go);
-
             string saved = PetSaveBridge.Load();
             if (!string.IsNullOrEmpty(saved))
             {
@@ -251,39 +245,6 @@ namespace Pets
             return null;
         }
 
-        private class PetDropSystemUpdater : MonoBehaviour
-        {
-            private void Update()
-            {
-                if (Input.GetKeyDown(KeyCode.P))
-                {
-                    var player = GameObject.FindGameObjectWithTag("Player");
-                    Vector3 pos = player != null ? player.transform.position : Vector3.zero;
-                    DebugForceFirstDrop(pos);
-                }
-            }
-        }
-
-        internal static bool DebugForceFirstDrop(Vector3 position)
-        {
-            Initialize();
-            if (Beastmaster.PetMergeController.Instance != null && Beastmaster.PetMergeController.Instance.IsMerged)
-                return false;
-            if (tables.Count == 0 || tables[0].entries.Count == 0)
-            {
-                Debug.LogWarning("DebugForceFirstDrop: no pet drop tables or entries found.");
-                return false;
-            }
-            var entry = tables[0].entries[0];
-            if (entry.pet == null)
-            {
-                Debug.LogWarning("DebugForceFirstDrop: first entry has no pet.");
-                return false;
-            }
-            Debug.Log("DebugForceFirstDrop spawning first pet drop.");
-            SpawnPetInternal(entry.pet, position);
-            return true;
-        }
     }
 }
 
@@ -294,6 +255,5 @@ Hookup Checklist:
 - Put sample sprite at Assets/Game/Sprites/Pets/chick_idle.png (point filter, no compression).
 - Assign DefaultPetDrops.asset into a PetDropSystem bootstrapping MonoBehaviour in the first loaded scene,
   or place it under Resources/PetDropTables for auto-loading.
-- Press P in Play Mode to force a test drop.
 - Skill/action systems can call PetDropSystem.TryRollPet("mining", hitPos, out var pet) after a successful action tick.
-*/
+ */


### PR DESCRIPTION
## Summary
- remove P key debug hotkey and forced drop method from `PetDropSystem`
- update hookup checklist comment to drop reference to debug hotkey

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68aae9776f8c832e983765b610e11bc0