### PR TITLE
Fix lingering slam dust effect

### DIFF
--- a/Assets/Scripts/NPC/CombatScripts/GoblinWarChief/GoblinWarChiefCombat.cs
+++ b/Assets/Scripts/NPC/CombatScripts/GoblinWarChief/GoblinWarChiefCombat.cs
@@ -203,6 +203,7 @@ namespace NPC
                     {
                         var dust = Instantiate(slamDustPrefab,
                             (Vector2)transform.position + new Vector2(x, y), Quaternion.identity);
+                        Destroy(dust, 3 * CombatMath.TICK_SECONDS);
                         StartCoroutine(FadeOutDust(dust));
                     }
                 }


### PR DESCRIPTION
## Summary
- ensure spawned slam dust destroys itself after three ticks

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf5efe92c832e81d9fac58b7c2caa