### PR TITLE
Add interface tab buttons

### DIFF
--- a/Assets/Scripts/Inventory/Equipment.cs
+++ b/Assets/Scripts/Inventory/Equipment.cs
@@ -152,14 +152,8 @@ namespace Inventory
                 uiRoot.SetActive(false);
         }
 
-        private void Update()
+        public void ToggleUI()
         {
-#if ENABLE_INPUT_SYSTEM
-            bool toggle = Keyboard.current != null && Keyboard.current.eKey.wasPressedThisFrame;
-            toggle |= Input.GetKeyDown(KeyCode.E);
-#else
-            bool toggle = Input.GetKeyDown(KeyCode.E);
-#endif
             var quest = Object.FindObjectOfType<QuestUI>();
             if (quest != null && quest.IsOpen)
             {
@@ -167,7 +161,7 @@ namespace Inventory
                     uiRoot.SetActive(false);
                 return;
             }
-            if (toggle && uiRoot != null)
+            if (uiRoot != null)
             {
                 bool opening = !uiRoot.activeSelf;
                 if (opening)
@@ -177,6 +171,18 @@ namespace Inventory
                 }
                 uiRoot.SetActive(!uiRoot.activeSelf);
             }
+        }
+
+        private void Update()
+        {
+#if ENABLE_INPUT_SYSTEM
+            bool toggle = Keyboard.current != null && Keyboard.current.eKey.wasPressedThisFrame;
+            toggle |= Input.GetKeyDown(KeyCode.E);
+#else
+            bool toggle = Input.GetKeyDown(KeyCode.E);
+#endif
+            if (toggle)
+                ToggleUI();
 
             bool merged = PetMergeController.Instance != null && PetMergeController.Instance.IsMerged;
             if (merged != lastMergeState)

--- a/Assets/Scripts/Quests/QuestUI.cs
+++ b/Assets/Scripts/Quests/QuestUI.cs
@@ -48,46 +48,49 @@ namespace Quests
                 QuestManager.Instance.QuestsUpdated.AddListener(Refresh);
         }
 
+        public void Toggle()
+        {
+            bool opening = !canvas.enabled;
+            if (opening)
+            {
+                var inv = FindObjectOfType<Inventory.Inventory>();
+                if (inv != null && inv.IsOpen)
+                    inv.CloseUI();
+                var eq = FindObjectOfType<Inventory.Equipment>();
+                if (eq != null && eq.IsOpen)
+                    eq.CloseUI();
+                var skills = SkillsUI.Instance;
+                if (skills != null && skills.IsOpen)
+                    skills.Close();
+                var shop = ShopUI.Instance;
+                if (shop != null && shop.IsOpen)
+                    shop.Close();
+                var bank = BankUI.Instance;
+                if (bank != null && bank.IsOpen)
+                    bank.Close();
+            }
+
+            canvas.enabled = opening;
+            if (canvas.enabled)
+            {
+                Refresh();
+                if (playerMover == null)
+                    playerMover = FindObjectOfType<PlayerMover>();
+                if (playerMover != null)
+                    playerMover.enabled = false;
+            }
+            else
+            {
+                Clear();
+                if (playerMover != null)
+                    playerMover.enabled = true;
+            }
+        }
+
         private void Update()
         {
             if (Input.GetKeyDown(KeyCode.Q))
-            {
-                bool opening = !canvas.enabled;
-                if (opening)
-                {
-                    var inv = FindObjectOfType<Inventory.Inventory>();
-                    if (inv != null && inv.IsOpen)
-                        inv.CloseUI();
-                    var eq = FindObjectOfType<Inventory.Equipment>();
-                    if (eq != null && eq.IsOpen)
-                        eq.CloseUI();
-                    var skills = SkillsUI.Instance;
-                    if (skills != null && skills.IsOpen)
-                        skills.Close();
-                    var shop = ShopUI.Instance;
-                    if (shop != null && shop.IsOpen)
-                        shop.Close();
-                    var bank = BankUI.Instance;
-                    if (bank != null && bank.IsOpen)
-                        bank.Close();
-                }
-
-                canvas.enabled = opening;
-                if (canvas.enabled)
-                {
-                    Refresh();
-                    if (playerMover == null)
-                        playerMover = FindObjectOfType<PlayerMover>();
-                    if (playerMover != null)
-                        playerMover.enabled = false;
-                }
-                else
-                {
-                    Clear();
-                    if (playerMover != null)
-                        playerMover.enabled = true;
-                }
-            }
+                Toggle();
         }
 
         private void BuildLayout()

--- a/Assets/Scripts/Skills/SkillsUI.cs
+++ b/Assets/Scripts/Skills/SkillsUI.cs
@@ -88,6 +88,39 @@ namespace Skills
             textRect.offsetMax = Vector2.zero;
         }
 
+        public void Toggle()
+        {
+            var quest = FindObjectOfType<QuestUI>();
+            if (quest != null && quest.IsOpen)
+            {
+                if (uiRoot != null && uiRoot.activeSelf)
+                    uiRoot.SetActive(false);
+                return;
+            }
+
+            var shop = ShopUI.Instance;
+            if (shop != null && shop.IsOpen)
+                return;
+            var bank = BankSystem.BankUI.Instance;
+            if (bank != null && bank.IsOpen)
+                return;
+
+            if (uiRoot != null)
+            {
+                bool opening = !uiRoot.activeSelf;
+                if (opening)
+                {
+                    var inv = Object.FindObjectOfType<Inventory.Inventory>();
+                    if (inv != null && inv.IsOpen)
+                        inv.CloseUI();
+                    var eq = Object.FindObjectOfType<Inventory.Equipment>();
+                    if (eq != null && eq.IsOpen)
+                        eq.CloseUI();
+                }
+                uiRoot.SetActive(!uiRoot.activeSelf);
+            }
+        }
+
         private void Update()
         {
             var quest = FindObjectOfType<QuestUI>();
@@ -98,29 +131,7 @@ namespace Skills
                 return;
             }
             if (Input.GetKeyDown(KeyCode.O))
-            {
-                var shop = ShopUI.Instance;
-                if (shop != null && shop.IsOpen)
-                    return;
-                var bank = BankSystem.BankUI.Instance;
-                if (bank != null && bank.IsOpen)
-                    return;
-
-                if (uiRoot != null)
-                {
-                    bool opening = !uiRoot.activeSelf;
-                    if (opening)
-                    {
-                        var inv = Object.FindObjectOfType<Inventory.Inventory>();
-                        if (inv != null && inv.IsOpen)
-                            inv.CloseUI();
-                        var eq = Object.FindObjectOfType<Inventory.Equipment>();
-                        if (eq != null && eq.IsOpen)
-                            eq.CloseUI();
-                    }
-                    uiRoot.SetActive(!uiRoot.activeSelf);
-                }
-            }
+                Toggle();
 
             if (uiRoot != null && uiRoot.activeSelf)
             {

--- a/Assets/Scripts/UI/InterfaceTabButtons.cs
+++ b/Assets/Scripts/UI/InterfaceTabButtons.cs
@@ -1,0 +1,99 @@
+using UnityEngine;
+using UnityEngine.UI;
+using Inventory;
+using Quests;
+using Skills;
+using Object = UnityEngine.Object;
+
+namespace UI
+{
+    /// <summary>
+    /// Creates tab buttons in the bottom-right corner for quick access to
+    /// quest, inventory, skill and equipment interfaces.
+    /// </summary>
+    public class InterfaceTabButtons : MonoBehaviour
+    {
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void Init()
+        {
+            var go = new GameObject("InterfaceTabButtons");
+            DontDestroyOnLoad(go);
+            go.AddComponent<InterfaceTabButtons>();
+        }
+
+        private void Awake()
+        {
+            CreateUI();
+        }
+
+        private void CreateUI()
+        {
+            var canvas = gameObject.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            gameObject.AddComponent<CanvasScaler>();
+            gameObject.AddComponent<GraphicRaycaster>();
+
+            var panel = new GameObject("Panel", typeof(RectTransform), typeof(HorizontalLayoutGroup));
+            var rect = panel.GetComponent<RectTransform>();
+            rect.SetParent(transform, false);
+            rect.anchorMin = new Vector2(1f, 0f);
+            rect.anchorMax = new Vector2(1f, 0f);
+            rect.pivot = new Vector2(1f, 0f);
+            rect.anchoredPosition = new Vector2(-10f, 10f);
+
+            var layout = panel.GetComponent<HorizontalLayoutGroup>();
+            layout.spacing = 5f;
+            layout.childForceExpandHeight = false;
+            layout.childForceExpandWidth = false;
+
+            AddButton(panel.transform, "QuestTab", ToggleQuest);
+            AddButton(panel.transform, "InventoryTab", ToggleInventory);
+            AddButton(panel.transform, "SkillTab", ToggleSkills);
+            AddButton(panel.transform, "EquipmentTab", ToggleEquipment);
+        }
+
+        private void AddButton(Transform parent, string spriteName, UnityEngine.Events.UnityAction onClick)
+        {
+            var sprite = Resources.Load<Sprite>("Interfaces/UIButtons/" + spriteName);
+            var go = new GameObject(spriteName, typeof(Image), typeof(Button));
+            go.transform.SetParent(parent, false);
+            var img = go.GetComponent<Image>();
+            img.sprite = sprite;
+            img.preserveAspect = true;
+            var rect = go.GetComponent<RectTransform>();
+            rect.sizeDelta = new Vector2(40f, 40f);
+            go.GetComponent<Button>().onClick.AddListener(onClick);
+        }
+
+        private void ToggleQuest()
+        {
+            var quest = Object.FindObjectOfType<QuestUI>();
+            quest?.Toggle();
+        }
+
+        private void ToggleInventory()
+        {
+            var inv = Object.FindObjectOfType<Inventory.Inventory>();
+            if (inv != null)
+            {
+                if (inv.IsOpen)
+                    inv.CloseUI();
+                else
+                    inv.OpenUI();
+            }
+        }
+
+        private void ToggleSkills()
+        {
+            var skills = SkillsUI.Instance;
+            skills?.Toggle();
+        }
+
+        private void ToggleEquipment()
+        {
+            var eq = Object.FindObjectOfType<Equipment>();
+            eq?.ToggleUI();
+        }
+    }
+}
+

--- a/Assets/Scripts/UI/InterfaceTabButtons.cs.meta
+++ b/Assets/Scripts/UI/InterfaceTabButtons.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 63afc0e796934b04be5ead61a49c6c52


### PR DESCRIPTION
## Summary
- create bottom-right UI buttons for quest, inventory, skills and equipment tabs
- allow quest, skills, and equipment interfaces to be toggled programmatically
- remove placeholder button sprites so existing art assets can be used

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab126a35e8832e987125f395f30f97