### PR TITLE
Adjust interface tab panel layout

### DIFF
--- a/Assets/Scripts/UI/InterfaceTabButtons.cs
+++ b/Assets/Scripts/UI/InterfaceTabButtons.cs
@@ -46,9 +46,10 @@ namespace UI
             rect.anchorMax = new Vector2(1f, 0f);
             rect.pivot = new Vector2(1f, 0f);
             rect.anchoredPosition = new Vector2(-10f, 10f);
+            rect.sizeDelta = new Vector2(400f, 100f);
 
             var layout = panel.GetComponent<HorizontalLayoutGroup>();
-            layout.spacing = 5f;
+            layout.spacing = 0f;
             layout.childForceExpandHeight = false;
             layout.childForceExpandWidth = false;
             layout.childAlignment = TextAnchor.LowerRight;
@@ -68,7 +69,7 @@ namespace UI
             img.sprite = sprite;
             img.preserveAspect = true;
             var rect = go.GetComponent<RectTransform>();
-            rect.sizeDelta = new Vector2(120f, 120f);
+            rect.sizeDelta = new Vector2(100f, 100f);
             go.GetComponent<Button>().onClick.AddListener(onClick);
         }
 


### PR DESCRIPTION
## Summary
- set interface tab panel size to 400x100
- remove spacing between interface tab buttons
- adjust button dimensions to 100x100

## Testing
- ⚠️ `dotnet build` *(no project found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1b8381b4832eb932d61264e26f08