### PR TITLE
Disable key-based UI toggles

### DIFF
--- a/Assets/Scripts/Inventory/Equipment.cs
+++ b/Assets/Scripts/Inventory/Equipment.cs
@@ -176,10 +176,9 @@ namespace Inventory
         private void Update()
         {
 #if ENABLE_INPUT_SYSTEM
-            bool toggle = Keyboard.current != null && Keyboard.current.eKey.wasPressedThisFrame;
-            toggle |= Input.GetKeyDown(KeyCode.E);
+            bool toggle = false;
 #else
-            bool toggle = Input.GetKeyDown(KeyCode.E);
+            bool toggle = false;
 #endif
             if (toggle)
                 ToggleUI();

--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -1069,10 +1069,9 @@ namespace Inventory
         private void Update()
         {
 #if ENABLE_INPUT_SYSTEM
-            bool toggle = Keyboard.current != null && Keyboard.current.iKey.wasPressedThisFrame;
-            toggle |= Input.GetKeyDown(KeyCode.I);
+            bool toggle = false;
 #else
-            bool toggle = Input.GetKeyDown(KeyCode.I);
+            bool toggle = false;
 #endif
 
             if (playerMover == null)

--- a/Assets/Scripts/Quests/QuestUI.cs
+++ b/Assets/Scripts/Quests/QuestUI.cs
@@ -89,8 +89,7 @@ namespace Quests
 
         private void Update()
         {
-            if (Input.GetKeyDown(KeyCode.Q))
-                Toggle();
+            // Removed Q key toggle
         }
 
         private void BuildLayout()

--- a/Assets/Scripts/Skills/SkillsUI.cs
+++ b/Assets/Scripts/Skills/SkillsUI.cs
@@ -130,8 +130,7 @@ namespace Skills
                     uiRoot.SetActive(false);
                 return;
             }
-            if (Input.GetKeyDown(KeyCode.O))
-                Toggle();
+            // Removed O key toggle
 
             if (uiRoot != null && uiRoot.activeSelf)
             {


### PR DESCRIPTION
## Summary
- remove hotkeys for inventory, equipment, quests, and skills tabs

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68ab20c89c8c832e94c9a224ac79c600