### PR TITLE
Add attack style selection interface

### DIFF
--- a/Assets/Scripts/UI/AttackStyleUI.cs
+++ b/Assets/Scripts/UI/AttackStyleUI.cs
@@ -1,0 +1,133 @@
+using UnityEngine;
+using UnityEngine.UI;
+using Combat;
+using Player;
+
+namespace UI
+{
+    /// <summary>
+    /// Simple interface for selecting the player's combat style.
+    /// </summary>
+    public class AttackStyleUI : MonoBehaviour
+    {
+        private GameObject uiRoot;
+        private PlayerCombatLoadout loadout;
+        private Button accurateButton;
+        private Button aggressiveButton;
+        private Button defensiveButton;
+        private Button controlledButton;
+
+        /// <summary>Whether the interface is currently visible.</summary>
+        public bool IsOpen => uiRoot != null && uiRoot.activeSelf;
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void Init()
+        {
+            var go = new GameObject("AttackStyleUI");
+            DontDestroyOnLoad(go);
+            go.AddComponent<AttackStyleUI>();
+        }
+
+        private void Awake()
+        {
+            loadout = FindObjectOfType<PlayerCombatLoadout>();
+            CreateUI();
+            if (uiRoot != null)
+                uiRoot.SetActive(false);
+        }
+
+        private void CreateUI()
+        {
+            uiRoot = new GameObject("AttackStyleUIRoot");
+            uiRoot.transform.SetParent(transform, false);
+
+            var canvas = uiRoot.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            uiRoot.AddComponent<CanvasScaler>();
+            uiRoot.AddComponent<GraphicRaycaster>();
+
+            var panel = new GameObject("Panel", typeof(Image), typeof(HorizontalLayoutGroup));
+            panel.transform.SetParent(uiRoot.transform, false);
+            var panelImage = panel.GetComponent<Image>();
+            panelImage.color = new Color(0f, 0f, 0f, 0.5f);
+            var panelRect = panel.GetComponent<RectTransform>();
+            panelRect.sizeDelta = new Vector2(220f, 60f);
+            panelRect.anchorMin = new Vector2(0.5f, 0.5f);
+            panelRect.anchorMax = new Vector2(0.5f, 0.5f);
+            panelRect.pivot = new Vector2(0.5f, 0.5f);
+            panelRect.anchoredPosition = Vector2.zero;
+
+            var layout = panel.GetComponent<HorizontalLayoutGroup>();
+            layout.spacing = 5f;
+            layout.childAlignment = TextAnchor.MiddleCenter;
+            layout.childForceExpandHeight = false;
+            layout.childForceExpandWidth = false;
+
+            accurateButton = CreateStyleButton(panel.transform, "Accurate", CombatStyle.Accurate);
+            aggressiveButton = CreateStyleButton(panel.transform, "Aggressive", CombatStyle.Aggressive);
+            defensiveButton = CreateStyleButton(panel.transform, "Defensive", CombatStyle.Defensive);
+            controlledButton = CreateStyleButton(panel.transform, "Controlled", CombatStyle.Controlled);
+
+            UpdateSelection();
+        }
+
+        private Button CreateStyleButton(Transform parent, string spriteName, CombatStyle style)
+        {
+            var sprite = Resources.Load<Sprite>("Interfaces/AttackStyle/" + spriteName);
+            var go = new GameObject(spriteName, typeof(Image), typeof(Button));
+            go.transform.SetParent(parent, false);
+            var img = go.GetComponent<Image>();
+            img.sprite = sprite;
+            img.preserveAspect = true;
+            var rect = go.GetComponent<RectTransform>();
+            rect.sizeDelta = new Vector2(50f, 50f);
+            var btn = go.GetComponent<Button>();
+            btn.onClick.AddListener(() => SetStyle(style));
+            return btn;
+        }
+
+        /// <summary>Toggle the visibility of the UI.</summary>
+        public void Toggle()
+        {
+            if (uiRoot != null)
+            {
+                bool opening = !uiRoot.activeSelf;
+                uiRoot.SetActive(opening);
+                if (opening)
+                    UpdateSelection();
+            }
+        }
+
+        private void SetStyle(CombatStyle style)
+        {
+            if (loadout == null)
+                loadout = FindObjectOfType<PlayerCombatLoadout>();
+            if (loadout != null)
+                loadout.Style = style;
+            UpdateSelection();
+        }
+
+        private void UpdateSelection()
+        {
+            if (loadout == null)
+                loadout = FindObjectOfType<PlayerCombatLoadout>();
+            if (loadout == null)
+                return;
+            Highlight(accurateButton, loadout.Style == CombatStyle.Accurate);
+            Highlight(aggressiveButton, loadout.Style == CombatStyle.Aggressive);
+            Highlight(defensiveButton, loadout.Style == CombatStyle.Defensive);
+            Highlight(controlledButton, loadout.Style == CombatStyle.Controlled);
+        }
+
+        private void Highlight(Button btn, bool selected)
+        {
+            if (btn == null)
+                return;
+            var colors = btn.colors;
+            colors.normalColor = selected ? Color.green : Color.white;
+            colors.highlightedColor = selected ? Color.green : Color.white;
+            btn.colors = colors;
+        }
+    }
+}
+

--- a/Assets/Scripts/UI/InterfaceTabButtons.cs
+++ b/Assets/Scripts/UI/InterfaceTabButtons.cs
@@ -58,6 +58,7 @@ namespace UI
             AddButton(panel.transform, "InventoryTab", ToggleInventory);
             AddButton(panel.transform, "SkillTab", ToggleSkills);
             AddButton(panel.transform, "EquipmentTab", ToggleEquipment);
+            AddButton(panel.transform, "AttackStyle", ToggleAttackStyle);
         }
 
         private void AddButton(Transform parent, string spriteName, UnityEngine.Events.UnityAction onClick)
@@ -101,6 +102,12 @@ namespace UI
         {
             var eq = Object.FindObjectOfType<Equipment>();
             eq?.ToggleUI();
+        }
+
+        private void ToggleAttackStyle()
+        {
+            var style = Object.FindObjectOfType<AttackStyleUI>();
+            style?.Toggle();
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add AttackStyleUI for choosing Accurate, Aggressive, Defensive or Controlled styles
- Include Attack Style tab button to open the selection interface
- Remove attack style sprite assets so project assets can provide them

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68ab23014464832eb5dc9dd3698c7bf9