### PR TITLE
Stack attack style buttons vertically

### DIFF
--- a/Assets/Scripts/UI/AttackStyleUI.cs
+++ b/Assets/Scripts/UI/AttackStyleUI.cs
@@ -46,18 +46,18 @@ namespace UI
             uiRoot.AddComponent<CanvasScaler>();
             uiRoot.AddComponent<GraphicRaycaster>();
 
-            var panel = new GameObject("Panel", typeof(Image), typeof(HorizontalLayoutGroup));
+            var panel = new GameObject("Panel", typeof(Image), typeof(VerticalLayoutGroup));
             panel.transform.SetParent(uiRoot.transform, false);
             var panelImage = panel.GetComponent<Image>();
             panelImage.color = new Color(0f, 0f, 0f, 0.5f);
             var panelRect = panel.GetComponent<RectTransform>();
-            panelRect.sizeDelta = new Vector2(220f, 60f);
+            panelRect.sizeDelta = new Vector2(60f, 220f);
             panelRect.anchorMin = new Vector2(0.5f, 0.5f);
             panelRect.anchorMax = new Vector2(0.5f, 0.5f);
             panelRect.pivot = new Vector2(0.5f, 0.5f);
             panelRect.anchoredPosition = Vector2.zero;
 
-            var layout = panel.GetComponent<HorizontalLayoutGroup>();
+            var layout = panel.GetComponent<VerticalLayoutGroup>();
             layout.spacing = 5f;
             layout.childAlignment = TextAnchor.MiddleCenter;
             layout.childForceExpandHeight = false;


### PR DESCRIPTION
## Summary
- Use vertical layout group for AttackStyleUI buttons so they stack underneath each other instead of side-by-side

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*


------
https://chatgpt.com/codex/tasks/task_e_68ab269f18ac832ea66c1dd7bd96af0c