### PR TITLE
Fix attack style UI spacing

### DIFF
--- a/Assets/Scripts/UI/AttackStyleUI.cs
+++ b/Assets/Scripts/UI/AttackStyleUI.cs
@@ -58,7 +58,7 @@ namespace UI
             panelRect.anchoredPosition = new Vector2(295f, -75f);
 
             var layout = panel.GetComponent<VerticalLayoutGroup>();
-            layout.spacing = 5f;
+            layout.spacing = 3f;
             layout.childAlignment = TextAnchor.MiddleCenter;
             layout.childForceExpandHeight = false;
             layout.childForceExpandWidth = false;


### PR DESCRIPTION
## Summary
- reduce vertical spacing between attack style buttons so the Accurate button fits within the Attack UI panel

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2a648780832e9d7a33dfd4b86b9f