### PR TITLE
Close attack style UI when switching tabs

### DIFF
--- a/Assets/Scripts/UI/InterfaceTabButtons.cs
+++ b/Assets/Scripts/UI/InterfaceTabButtons.cs
@@ -76,12 +76,14 @@ namespace UI
 
         private void ToggleQuest()
         {
+            CloseAttackStyle();
             var quest = Object.FindObjectOfType<QuestUI>();
             quest?.Toggle();
         }
 
         private void ToggleInventory()
         {
+            CloseAttackStyle();
             var inv = Object.FindObjectOfType<Inventory.Inventory>();
             if (inv != null)
             {
@@ -94,12 +96,14 @@ namespace UI
 
         private void ToggleSkills()
         {
+            CloseAttackStyle();
             var skills = SkillsUI.Instance;
             skills?.Toggle();
         }
 
         private void ToggleEquipment()
         {
+            CloseAttackStyle();
             var eq = Object.FindObjectOfType<Equipment>();
             eq?.ToggleUI();
         }
@@ -108,6 +112,13 @@ namespace UI
         {
             var style = Object.FindObjectOfType<AttackStyleUI>();
             style?.Toggle();
+        }
+
+        private void CloseAttackStyle()
+        {
+            var style = Object.FindObjectOfType<AttackStyleUI>();
+            if (style != null && style.IsOpen)
+                style.Toggle();
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure other interface buttons close AttackStyleUI before toggling their own windows
- add helper to close AttackStyleUI when inventory, skill, equipment, or quest tabs are clicked

## Testing
- `dotnet test` *(fails: project or solution file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2b459290832e9ff8ee83db5ebea8