### PR TITLE
Save player hitpoints on disable

### DIFF
--- a/Assets/Scripts/Player/PlayerHitpoints.cs
+++ b/Assets/Scripts/Player/PlayerHitpoints.cs
@@ -76,6 +76,7 @@ namespace Player
             if (saveRoutine != null)
                 StopCoroutine(saveRoutine);
             StopRegen();
+            Save();
         }
 
         private void OnApplicationQuit()


### PR DESCRIPTION
## Summary
- persist player HP by saving when `PlayerHitpoints` is disabled

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68acc12d4bd8832ea155ab5bd7b4d76f