### PR TITLE
Implement player death and respawn system

### DIFF
--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -4,6 +4,7 @@ using Util;
 using World;
 using Inventory;
 using ShopSystem;
+using Player;
 
 namespace Core
 {
@@ -18,6 +19,7 @@ namespace Core
         private ScreenFader screenFader;
         private ItemDatabase itemDatabase;
         private ShopUI shopUI;
+        private PlayerRespawnSystem respawnSystem;
 
         /// <summary>
         /// Event fired once all services are initialized.
@@ -43,6 +45,7 @@ namespace Core
             screenFader = FindOrCreate<ScreenFader>();
             itemDatabase = FindOrCreate<ItemDatabase>();
             shopUI = FindOrCreate<ShopUI>();
+            respawnSystem = FindOrCreate<PlayerRespawnSystem>();
 
             ServicesReady?.Invoke();
         }

--- a/Assets/Scripts/Player/PlayerRespawnSystem.cs
+++ b/Assets/Scripts/Player/PlayerRespawnSystem.cs
@@ -1,0 +1,86 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using Core;
+using World;
+
+namespace Player
+{
+    /// <summary>
+    /// Listens for player death and handles respawning with a screen fade.
+    /// </summary>
+    public class PlayerRespawnSystem : MonoBehaviour
+    {
+        public static PlayerRespawnSystem Instance { get; private set; }
+
+        private PlayerHitpoints hitpoints;
+        private bool isRespawning;
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+
+        private void OnEnable()
+        {
+            SceneManager.sceneLoaded += OnSceneLoaded;
+            FindPlayer();
+        }
+
+        private void OnDisable()
+        {
+            SceneManager.sceneLoaded -= OnSceneLoaded;
+            if (hitpoints != null)
+                hitpoints.OnHealthChanged -= HandleHealthChanged;
+        }
+
+        private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+        {
+            FindPlayer();
+        }
+
+        private void FindPlayer()
+        {
+            if (hitpoints != null)
+                hitpoints.OnHealthChanged -= HandleHealthChanged;
+
+            var playerObj = GameObject.FindGameObjectWithTag("Player");
+            hitpoints = playerObj != null ? playerObj.GetComponent<PlayerHitpoints>() : null;
+            if (hitpoints != null)
+                hitpoints.OnHealthChanged += HandleHealthChanged;
+        }
+
+        private void HandleHealthChanged(int current, int max)
+        {
+            if (!isRespawning && current <= 0)
+                StartCoroutine(RespawnRoutine());
+        }
+
+        private IEnumerator RespawnRoutine()
+        {
+            isRespawning = true;
+
+            var fader = GameManager.ScreenFader;
+            if (fader != null)
+                yield return fader.FadeOut();
+
+            if (RespawnPoint.Current != null && hitpoints != null)
+                hitpoints.transform.position = RespawnPoint.Current.transform.position;
+
+            if (hitpoints != null)
+                hitpoints.Heal(hitpoints.MaxHp);
+
+            if (fader != null)
+                yield return fader.FadeIn();
+
+            isRespawning = false;
+        }
+    }
+}

--- a/Assets/Scripts/Player/PlayerRespawnSystem.cs.meta
+++ b/Assets/Scripts/Player/PlayerRespawnSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4265ae917bbc463c839850c65a2a49b4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/World/RespawnPoint.cs
+++ b/Assets/Scripts/World/RespawnPoint.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+
+namespace World
+{
+    /// <summary>
+    /// Marks a location the player should respawn at after death.
+    /// </summary>
+    public class RespawnPoint : MonoBehaviour
+    {
+        /// <summary>
+        /// The currently active respawn point in the scene.
+        /// </summary>
+        public static RespawnPoint Current { get; private set; }
+
+        private void OnEnable()
+        {
+            Current = this;
+        }
+    }
+}

--- a/Assets/Scripts/World/RespawnPoint.cs.meta
+++ b/Assets/Scripts/World/RespawnPoint.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6e1334c6ac8a446cbcdae3bfbac57bc6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- Add `RespawnPoint` marker to define where the player should respawn
- Create persistent `PlayerRespawnSystem` that listens for HP reaching zero, fades the screen, restores health and moves the player to the respawn point
- Bootstrap the new respawn system via `GameManager`

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68acc34699d4832e8539a216cf708805