### PR TITLE
refactor: cache common lookups

### DIFF
--- a/Assets/Scripts/Beastmaster/BeastmasterServiceAdapter.cs
+++ b/Assets/Scripts/Beastmaster/BeastmasterServiceAdapter.cs
@@ -15,8 +15,6 @@ namespace Beastmaster
             if (skills == null)
                 skills = GetComponent<SkillManager>();
             if (skills == null)
-                skills = FindObjectOfType<SkillManager>();
-            if (skills == null)
                 Debug.LogWarning("BeastmasterServiceAdapter could not find SkillManager.");
         }
 

--- a/Assets/Scripts/Beastmaster/PetMergeController.cs
+++ b/Assets/Scripts/Beastmaster/PetMergeController.cs
@@ -58,16 +58,11 @@ namespace Beastmaster
         {
             instance = this;
 
-            if (beastmasterServiceComponent == null)
-                beastmasterServiceComponent = FindObjectOfType<BeastmasterServiceAdapter>();
-            if (petServiceComponent == null)
-                petServiceComponent = FindObjectOfType<PetServiceAdapter>();
-
             beastmaster = beastmasterServiceComponent as IBeastmasterService;
             petService = petServiceComponent as IPetService;
 
             if (hudTimer == null)
-                hudTimer = GetComponentInChildren<MergeHudTimer>(true) ?? FindObjectOfType<MergeHudTimer>();
+                hudTimer = GetComponentInChildren<MergeHudTimer>(true);
             if (playerMover == null)
                 playerMover = GetComponent<PlayerMover>();
 

--- a/Assets/Scripts/Combat/CombatWeaponHUD.cs
+++ b/Assets/Scripts/Combat/CombatWeaponHUD.cs
@@ -8,8 +8,8 @@ namespace Combat
     /// </summary>
     public class CombatWeaponHUD : MonoBehaviour
     {
-        private CombatController controller;
-        private Equipment equipment;
+        [SerializeField] private CombatController controller;
+        [SerializeField] private Equipment equipment;
         private Transform target;
         private GameObject weaponRoot;
         private SpriteRenderer weaponRenderer;
@@ -25,11 +25,14 @@ namespace Combat
 
         private void Awake()
         {
-            controller = FindObjectOfType<CombatController>();
+            if (controller == null)
+                controller = FindObjectOfType<CombatController>();
             if (controller != null)
+            {
                 controller.OnCombatTargetChanged += HandleTargetChanged;
-            if (controller != null)
-                equipment = controller.GetComponent<Equipment>();
+                if (equipment == null)
+                    equipment = controller.GetComponent<Equipment>();
+            }
             CreateWeaponSprite();
         }
 

--- a/Assets/Scripts/Dialogue/DialogueUI.cs
+++ b/Assets/Scripts/Dialogue/DialogueUI.cs
@@ -111,7 +111,7 @@ namespace Dialogue
         
         private static void EnsureEventSystem()
         {
-            if (FindObjectOfType<EventSystem>() != null)
+            if (EventSystem.current != null)
                 return;
             var go = new GameObject("EventSystem", typeof(EventSystem), typeof(StandaloneInputModule));
             DontDestroyOnLoad(go);

--- a/Assets/Scripts/Drops/NpcDropper.cs
+++ b/Assets/Scripts/Drops/NpcDropper.cs
@@ -23,17 +23,13 @@ namespace MyGame.Drops
         public bool spawnAtFeet = true;
 
         /// <summary>Spawner responsible for instantiating ground items.</summary>
-        public GroundItemSpawner spawner;
+        [SerializeField] private GroundItemSpawner spawner;
 
         private void Awake()
         {
             if (spawner == null)
             {
-                spawner = FindObjectOfType<GroundItemSpawner>();
-                if (spawner == null)
-                {
-                    Debug.LogError("NpcDropper: No GroundItemSpawner found in scene.");
-                }
+                Debug.LogError("NpcDropper: No GroundItemSpawner assigned.");
             }
         }
 

--- a/Assets/Scripts/Inventory/Equipment.cs
+++ b/Assets/Scripts/Inventory/Equipment.cs
@@ -99,6 +99,7 @@ namespace Inventory
         private Inventory inventory;
         [SerializeField] private SkillManager skillManager;
         [SerializeField] private Transform floatingTextAnchor;
+        [SerializeField] private QuestUI questUI;
 
         private Text attackBonusText;
         private Text strengthBonusText;
@@ -143,6 +144,8 @@ namespace Inventory
             skillManager = skillManager != null ? skillManager : GetComponent<SkillManager>();
             if (floatingTextAnchor == null)
                 floatingTextAnchor = transform.Find("FloatingTextAnchor");
+            if (questUI == null)
+                questUI = FindObjectOfType<QuestUI>();
             equipped = new InventoryEntry[Enum.GetValues(typeof(EquipmentSlot)).Length - 1];
             CreateUI();
             Load();
@@ -154,8 +157,7 @@ namespace Inventory
 
         public void ToggleUI()
         {
-            var quest = Object.FindObjectOfType<QuestUI>();
-            if (quest != null && quest.IsOpen)
+            if (questUI != null && questUI.IsOpen)
             {
                 if (uiRoot != null && uiRoot.activeSelf)
                     uiRoot.SetActive(false);

--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -106,6 +106,7 @@ namespace Inventory
 
         private PlayerMover playerMover;
         private Equipment equipment;
+        [SerializeField] private QuestUI questUI;
 
         // UI
         private GameObject uiRoot; // Canvas root
@@ -209,6 +210,8 @@ namespace Inventory
             items = new InventoryEntry[size];
             EnsureLegacyEventSystem();
 
+            if (questUI == null)
+                questUI = FindObjectOfType<QuestUI>();
             if (useSharedUIRoot && sharedUIRoot != null)
             {
                 uiRoot = sharedUIRoot;
@@ -1077,8 +1080,7 @@ namespace Inventory
             if (playerMover == null)
                 return;
 
-            var quest = Object.FindObjectOfType<QuestUI>();
-            if (quest != null && quest.IsOpen)
+            if (questUI != null && questUI.IsOpen)
             {
                 if (uiRoot != null && uiRoot.activeSelf)
                     CloseUI();
@@ -1117,7 +1119,7 @@ namespace Inventory
         /// </summary>
         private static void EnsureLegacyEventSystem()
         {
-            var existing = UnityEngine.Object.FindObjectOfType<EventSystem>();
+            var existing = EventSystem.current;
             if (existing != null)
             {
                 DontDestroyOnLoad(existing.gameObject);

--- a/Assets/Scripts/NPC/CombatScripts/GoblinWarChief/GoblinWarChiefCombat.cs
+++ b/Assets/Scripts/NPC/CombatScripts/GoblinWarChief/GoblinWarChiefCombat.cs
@@ -18,7 +18,7 @@ namespace NPC
         private NpcCombatant combatant;
         private NpcWanderer wanderer;
         private CombatTarget currentTarget;
-        private PlayerCombatTarget playerTarget;
+        [SerializeField] private PlayerCombatTarget playerTarget;
         private bool hasHitPlayer;
         private Vector2 spawnPosition;
 
@@ -33,7 +33,8 @@ namespace NPC
         {
             combatant = GetComponent<NpcCombatant>();
             wanderer = GetComponent<NpcWanderer>();
-            playerTarget = FindObjectOfType<PlayerCombatTarget>();
+            if (playerTarget == null)
+                playerTarget = FindObjectOfType<PlayerCombatTarget>();
             spawnPosition = transform.position;
         }
 
@@ -42,9 +43,6 @@ namespace NPC
             var profile = combatant.Profile;
             if (profile == null || !profile.IsAggressive)
                 return;
-
-            if (playerTarget == null)
-                playerTarget = FindObjectOfType<PlayerCombatTarget>();
 
             if (playerTarget == null)
                 return;

--- a/Assets/Scripts/NPC/NpcAttackController.cs
+++ b/Assets/Scripts/NPC/NpcAttackController.cs
@@ -17,7 +17,7 @@ namespace NPC
         private NpcCombatant combatant;
         private NpcWanderer wanderer;
         private CombatTarget currentTarget;
-        private PlayerCombatTarget playerTarget;
+        [SerializeField] private PlayerCombatTarget playerTarget;
         private bool hasHitPlayer;
         private Vector2 spawnPosition;
         private NpcSpriteAnimator spriteAnimator;
@@ -28,7 +28,8 @@ namespace NPC
         {
             combatant = GetComponent<NpcCombatant>();
             wanderer = GetComponent<NpcWanderer>();
-            playerTarget = FindObjectOfType<PlayerCombatTarget>();
+            if (playerTarget == null)
+                playerTarget = FindObjectOfType<PlayerCombatTarget>();
             spawnPosition = transform.position;
             spriteAnimator = GetComponent<NpcSpriteAnimator>() ?? GetComponentInChildren<NpcSpriteAnimator>();
             spriteRenderer = GetComponent<SpriteRenderer>() ?? GetComponentInChildren<SpriteRenderer>();
@@ -54,9 +55,6 @@ namespace NPC
             var profile = combatant.Profile;
             if (profile == null || !profile.IsAggressive)
                 return;
-
-            if (playerTarget == null)
-                playerTarget = FindObjectOfType<PlayerCombatTarget>();
 
             if (playerTarget == null)
                 return;

--- a/Assets/Scripts/NPC/NpcAttackOnClick.cs
+++ b/Assets/Scripts/NPC/NpcAttackOnClick.cs
@@ -11,15 +11,17 @@ namespace NPC
     public class NpcAttackOnClick : MonoBehaviour
     {
         private NpcCombatant combatant;
+        [SerializeField] private CombatController playerController;
 
         private void Awake()
         {
             combatant = GetComponent<NpcCombatant>();
+            if (playerController == null)
+                playerController = FindObjectOfType<CombatController>();
         }
 
         private void OnMouseDown()
         {
-            var playerController = FindObjectOfType<CombatController>();
             if (playerController == null)
                 return;
             if (Vector2.Distance(playerController.transform.position, transform.position) > CombatMath.MELEE_RANGE)

--- a/Assets/Scripts/Shop/ShopUI.cs
+++ b/Assets/Scripts/Shop/ShopUI.cs
@@ -42,7 +42,8 @@ namespace ShopSystem
         private Text tooltipText;
         private Text shopNameText;
         private Shop currentShop;
-        private PlayerMover playerMover;
+        [SerializeField] private PlayerMover playerMover;
+        [SerializeField] private QuestUI questUI;
         private NpcRandomMovement npcMover;
 
         private static ShopUI instance;
@@ -72,6 +73,10 @@ namespace ShopSystem
             }
             if (uiRoot != null)
                 uiRoot.SetActive(false);
+            if (questUI == null)
+                questUI = FindObjectOfType<QuestUI>();
+            if (playerMover == null)
+                playerMover = FindObjectOfType<PlayerMover>();
         }
 
         private void OnDestroy()
@@ -86,8 +91,7 @@ namespace ShopSystem
         public void Open(Shop shop, NpcRandomMovement npcMovement = null)
         {
             if (shop == null) return;
-            var quest = FindObjectOfType<QuestUI>();
-            if (quest != null && quest.IsOpen)
+            if (questUI != null && questUI.IsOpen)
                 return;
             currentShop = shop;
             Refresh();
@@ -100,8 +104,6 @@ namespace ShopSystem
                 playerInventory.SetShopContext(shop);
                 playerInventory.OnInventoryChanged += HandleInventoryChanged;
             }
-            if (playerMover == null)
-                playerMover = FindObjectOfType<PlayerMover>();
             if (playerMover != null)
             {
                 playerMover.enabled = false;

--- a/Assets/Scripts/UI/AttackStrDefHUD.cs
+++ b/Assets/Scripts/UI/AttackStrDefHUD.cs
@@ -10,12 +10,13 @@ namespace UI
     /// </summary>
     public class AttackStrDefHUD : MonoBehaviour
     {
-        private SkillManager skills;
+        [SerializeField] private SkillManager skills;
         private Text text;
 
         private void Awake()
         {
-            skills = FindObjectOfType<SkillManager>();
+            if (skills == null)
+                skills = FindObjectOfType<SkillManager>();
             CreateUI();
         }
 

--- a/Assets/Scripts/UI/AttackStyleUI.cs
+++ b/Assets/Scripts/UI/AttackStyleUI.cs
@@ -11,7 +11,7 @@ namespace UI
     public class AttackStyleUI : MonoBehaviour
     {
         private GameObject uiRoot;
-        private PlayerCombatLoadout loadout;
+        [SerializeField] private PlayerCombatLoadout loadout;
         private Button accurateButton;
         private Button aggressiveButton;
         private Button defensiveButton;
@@ -30,7 +30,8 @@ namespace UI
 
         private void Awake()
         {
-            loadout = FindObjectOfType<PlayerCombatLoadout>();
+            if (loadout == null)
+                loadout = FindObjectOfType<PlayerCombatLoadout>();
             CreateUI();
             if (uiRoot != null)
                 uiRoot.SetActive(false);
@@ -102,16 +103,13 @@ namespace UI
         private void SetStyle(CombatStyle style)
         {
             if (loadout == null)
-                loadout = FindObjectOfType<PlayerCombatLoadout>();
-            if (loadout != null)
-                loadout.Style = style;
+                return;
+            loadout.Style = style;
             UpdateSelection();
         }
 
         private void UpdateSelection()
         {
-            if (loadout == null)
-                loadout = FindObjectOfType<PlayerCombatLoadout>();
             if (loadout == null)
                 return;
             Highlight(accurateButton, loadout.Style == CombatStyle.Accurate);

--- a/Assets/Scripts/UI/InterfaceTabButtons.cs
+++ b/Assets/Scripts/UI/InterfaceTabButtons.cs
@@ -74,23 +74,38 @@ namespace UI
             go.GetComponent<Button>().onClick.AddListener(onClick);
         }
 
+        [SerializeField] private QuestUI questUI;
+        [SerializeField] private Inventory.Inventory inventory;
+        [SerializeField] private Equipment equipmentUI;
+        [SerializeField] private AttackStyleUI attackStyleUI;
+
+        private void Awake()
+        {
+            if (questUI == null)
+                questUI = FindObjectOfType<QuestUI>();
+            if (inventory == null)
+                inventory = FindObjectOfType<Inventory.Inventory>();
+            if (equipmentUI == null)
+                equipmentUI = FindObjectOfType<Equipment>();
+            if (attackStyleUI == null)
+                attackStyleUI = FindObjectOfType<AttackStyleUI>();
+        }
+
         private void ToggleQuest()
         {
             CloseAttackStyle();
-            var quest = Object.FindObjectOfType<QuestUI>();
-            quest?.Toggle();
+            questUI?.Toggle();
         }
 
         private void ToggleInventory()
         {
             CloseAttackStyle();
-            var inv = Object.FindObjectOfType<Inventory.Inventory>();
-            if (inv != null)
+            if (inventory != null)
             {
-                if (inv.IsOpen)
-                    inv.CloseUI();
+                if (inventory.IsOpen)
+                    inventory.CloseUI();
                 else
-                    inv.OpenUI();
+                    inventory.OpenUI();
             }
         }
 
@@ -104,21 +119,18 @@ namespace UI
         private void ToggleEquipment()
         {
             CloseAttackStyle();
-            var eq = Object.FindObjectOfType<Equipment>();
-            eq?.ToggleUI();
+            equipmentUI?.ToggleUI();
         }
 
         private void ToggleAttackStyle()
         {
-            var style = Object.FindObjectOfType<AttackStyleUI>();
-            style?.Toggle();
+            attackStyleUI?.Toggle();
         }
 
         private void CloseAttackStyle()
         {
-            var style = Object.FindObjectOfType<AttackStyleUI>();
-            if (style != null && style.IsOpen)
-                style.Toggle();
+            if (attackStyleUI != null && attackStyleUI.IsOpen)
+                attackStyleUI.Toggle();
         }
     }
 }

--- a/Assets/Scripts/UI/PetLevelBarContextMenuExtender.cs
+++ b/Assets/Scripts/UI/PetLevelBarContextMenuExtender.cs
@@ -13,7 +13,7 @@ namespace Pets
     {
         private Button mergeButton;
         private Text mergeText;
-        private PetMergeController mergeController;
+        [SerializeField] private PetMergeController mergeController;
 
         partial void OnMenuCreated(Transform menuRoot)
         {
@@ -27,7 +27,7 @@ namespace Pets
             if (mergeButton == null)
                 return;
             if (mergeController == null)
-                mergeController = Object.FindObjectOfType<PetMergeController>();
+                mergeController = PetMergeController.Instance;
             if (mergeController == null)
             {
                 mergeButton.gameObject.SetActive(false);

--- a/Assets/Scripts/World/Minimap.cs
+++ b/Assets/Scripts/World/Minimap.cs
@@ -24,6 +24,10 @@ namespace World
         private RectTransform expandedMapRect;
         private Vector3 dragOffset;
 
+        [SerializeField] private PlayerHitpoints playerHitpoints;
+        [SerializeField] private Inventory.Inventory playerInventory;
+        [SerializeField] private Inventory.Equipment playerEquipment;
+
         private readonly List<MinimapMarker> markers = new List<MinimapMarker>();
         private readonly Dictionary<MinimapMarker.MarkerType, Sprite> iconCache = new Dictionary<MinimapMarker.MarkerType, Sprite>();
 
@@ -53,6 +57,12 @@ namespace World
         private void Awake()
         {
             instance = this;
+            if (playerHitpoints == null)
+                playerHitpoints = FindObjectOfType<PlayerHitpoints>();
+            if (playerInventory == null)
+                playerInventory = FindObjectOfType<Inventory.Inventory>();
+            if (playerEquipment == null)
+                playerEquipment = FindObjectOfType<Inventory.Equipment>();
             CreateCamera();
             CreateUI();
             RegisterExistingMarkers();
@@ -219,9 +229,8 @@ namespace World
             expandRect.anchoredPosition = new Vector2(-btnSpacing, -btnSpacing);
             expandGO.GetComponent<Button>().onClick.AddListener(ToggleExpanded);
 
-            var hp = Object.FindObjectOfType<PlayerHitpoints>();
-            if (hp != null)
-                HealthHUD.CreateUnderMinimap(borderRect, hp);
+            if (playerHitpoints != null)
+                HealthHUD.CreateUnderMinimap(borderRect, playerHitpoints);
 
         }
 
@@ -343,12 +352,10 @@ namespace World
                 var skills = SkillsUI.Instance;
                 if (skills != null && skills.IsOpen)
                     skills.Close();
-                var inv = Object.FindObjectOfType<Inventory.Inventory>();
-                if (inv != null && inv.IsOpen)
-                    inv.CloseUI();
-                var eq = Object.FindObjectOfType<Inventory.Equipment>();
-                if (eq != null && eq.IsOpen)
-                    eq.CloseUI();
+                if (playerInventory != null && playerInventory.IsOpen)
+                    playerInventory.CloseUI();
+                if (playerEquipment != null && playerEquipment.IsOpen)
+                    playerEquipment.CloseUI();
             }
 
             expandedRoot.SetActive(opening);


### PR DESCRIPTION
## Summary
- cache player combat target and controllers in NPC combat scripts
- reuse cached references for UI systems like minimap, shop and tab buttons
- replace legacy FindObjectOfType calls with serialized fields and start-up caching

## Testing
- `dotnet test` *(fails: no project or solution file found)*

------
https://chatgpt.com/codex/tasks/task_e_68adce59c8e8832e87668b2c6b9ab5b1