### PR TITLE
Fix duplicate Awake method in InterfaceTabButtons

### DIFF
--- a/Assets/Scripts/UI/InterfaceTabButtons.cs
+++ b/Assets/Scripts/UI/InterfaceTabButtons.cs
@@ -21,11 +21,6 @@ namespace UI
             go.AddComponent<InterfaceTabButtons>();
         }
 
-        private void Awake()
-        {
-            CreateUI();
-        }
-
         private void CreateUI()
         {
             var canvas = gameObject.AddComponent<Canvas>();
@@ -81,6 +76,8 @@ namespace UI
 
         private void Awake()
         {
+            CreateUI();
+
             if (questUI == null)
                 questUI = FindObjectOfType<QuestUI>();
             if (inventory == null)


### PR DESCRIPTION
## Summary
- merge duplicate Awake implementations into one to resolve CS0111 compile error

## Testing
- `dotnet test` *(fails: no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68ade3d10560832e8269a8803a85ff52