### PR TITLE
Ensure MergeHudTimer canvas persists across scenes

### DIFF
--- a/Assets/Scripts/UI/MergeHudTimer.cs
+++ b/Assets/Scripts/UI/MergeHudTimer.cs
@@ -37,8 +37,8 @@ namespace UI
                     var canvasGO = new GameObject("MergeHudCanvas", typeof(Canvas));
                     canvas = canvasGO.GetComponent<Canvas>();
                     canvas.renderMode = RenderMode.ScreenSpaceOverlay;
-                    DontDestroyOnLoad(canvasGO);
                     transform.SetParent(canvasGO.transform, false);
+                    DontDestroyOnLoad(canvasGO);
                 }
             }
             else


### PR DESCRIPTION
## Summary
- reorder MergeHudTimer canvas setup so the HUD is parented before calling `DontDestroyOnLoad`

## Testing
- `unity -batchmode -quit -projectPath . -runTests -testResults results.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ade6e3dd1c832e909f9ee94c98156a