### PR TITLE
Centralize UI window management with UIManager

### DIFF
--- a/Assets/Scripts/Bank/BankUI.cs
+++ b/Assets/Scripts/Bank/BankUI.cs
@@ -4,9 +4,8 @@ using UnityEngine.UI;
 using UnityEngine.EventSystems;
 using Inventory;
 using Core.Save;
-using Skills;
-using Quests;
 using Pets;
+using UI;
 
 namespace BankSystem
 {
@@ -14,7 +13,7 @@ namespace BankSystem
     /// Simple OSRS-style bank with 400 slots (8x50) generated at runtime.
     /// Allows depositing from the inventory and withdrawing back.
     /// </summary>
-    public class BankUI : MonoBehaviour
+    public class BankUI : MonoBehaviour, IUIWindow
     {
         public Vector2 slotSize = new Vector2(32f, 32f);
         public Vector2 slotSpacing = new Vector2(4f, 4f);
@@ -84,6 +83,7 @@ namespace BankSystem
             CreateUI();
             uiRoot.SetActive(false);
             Load();
+            UIManager.Instance.RegisterWindow(this);
         }
 
         private void CreateUI()
@@ -490,9 +490,7 @@ namespace BankSystem
         {
             if (Beastmaster.PetMergeController.Instance != null && Beastmaster.PetMergeController.Instance.IsMerged)
                 return;
-            var quest = FindObjectOfType<QuestUI>();
-            if (quest != null && quest.IsOpen)
-                return;
+            UIManager.Instance.OpenWindow(this);
             if (playerInventory == null)
                 playerInventory = FindObjectOfType<Inventory.Inventory>();
             if (playerInventory != null)
@@ -504,9 +502,6 @@ namespace BankSystem
                 var storage = pet != null ? pet.GetComponent<PetStorage>() : null;
                 storage?.Close();
             }
-            var skills = SkillsUI.Instance;
-            if (skills != null && skills.IsOpen)
-                skills.Close();
             // Ensure latest saved state is loaded whenever the bank opens
             Load();
             uiRoot.SetActive(true);

--- a/Assets/Scripts/Quests/QuestUI.cs
+++ b/Assets/Scripts/Quests/QuestUI.cs
@@ -3,16 +3,14 @@ using UnityEngine;
 using UnityEngine.UI;
 using Inventory;
 using Player;
-using Skills;
-using ShopSystem;
-using BankSystem;
+using UI;
 
 namespace Quests
 {
     /// <summary>
     /// Simple quest log UI built entirely in code.
     /// </summary>
-    public class QuestUI : MonoBehaviour
+    public class QuestUI : MonoBehaviour, IUIWindow
     {
         private RectTransform listContent;
         private Text titleText;
@@ -40,6 +38,7 @@ namespace Quests
             DontDestroyOnLoad(gameObject);
             canvas.enabled = false;
             playerMover = FindObjectOfType<PlayerMover>();
+            UIManager.Instance.RegisterWindow(this);
         }
 
         private void Start()
@@ -50,41 +49,35 @@ namespace Quests
 
         public void Toggle()
         {
-            bool opening = !canvas.enabled;
-            if (opening)
-            {
-                var inv = FindObjectOfType<Inventory.Inventory>();
-                if (inv != null && inv.IsOpen)
-                    inv.CloseUI();
-                var eq = FindObjectOfType<Inventory.Equipment>();
-                if (eq != null && eq.IsOpen)
-                    eq.CloseUI();
-                var skills = SkillsUI.Instance;
-                if (skills != null && skills.IsOpen)
-                    skills.Close();
-                var shop = ShopUI.Instance;
-                if (shop != null && shop.IsOpen)
-                    shop.Close();
-                var bank = BankUI.Instance;
-                if (bank != null && bank.IsOpen)
-                    bank.Close();
-            }
-
-            canvas.enabled = opening;
-            if (canvas.enabled)
-            {
-                Refresh();
-                if (playerMover == null)
-                    playerMover = FindObjectOfType<PlayerMover>();
-                if (playerMover != null)
-                    playerMover.enabled = false;
-            }
+            if (IsOpen)
+                Close();
             else
-            {
-                Clear();
-                if (playerMover != null)
-                    playerMover.enabled = true;
-            }
+                Open();
+        }
+
+        public void Open()
+        {
+            UIManager.Instance.OpenWindow(this);
+            var inv = FindObjectOfType<Inventory.Inventory>();
+            if (inv != null && inv.IsOpen)
+                inv.CloseUI();
+            var eq = FindObjectOfType<Inventory.Equipment>();
+            if (eq != null && eq.IsOpen)
+                eq.CloseUI();
+            canvas.enabled = true;
+            Refresh();
+            if (playerMover == null)
+                playerMover = FindObjectOfType<PlayerMover>();
+            if (playerMover != null)
+                playerMover.enabled = false;
+        }
+
+        public void Close()
+        {
+            canvas.enabled = false;
+            Clear();
+            if (playerMover != null)
+                playerMover.enabled = true;
         }
 
         private void Update()

--- a/Assets/Scripts/Shop/ShopUI.cs
+++ b/Assets/Scripts/Shop/ShopUI.cs
@@ -3,9 +3,8 @@ using UnityEngine.UI;
 using UnityEngine.EventSystems;
 using Inventory;
 using Player;
-using Skills;
 using NPC;
-using Quests;
+using UI;
 
 namespace ShopSystem
 {
@@ -13,7 +12,7 @@ namespace ShopSystem
     /// Runtime generated shop UI used to display items for sale.
     /// </summary>
     [DisallowMultipleComponent]
-    public class ShopUI : MonoBehaviour
+    public class ShopUI : MonoBehaviour, IUIWindow
     {
         [Header("Layout")]
         public Vector2 slotSize = new Vector2(32, 32);
@@ -72,6 +71,7 @@ namespace ShopSystem
             }
             if (uiRoot != null)
                 uiRoot.SetActive(false);
+            UIManager.Instance.RegisterWindow(this);
         }
 
         private void OnDestroy()
@@ -86,14 +86,9 @@ namespace ShopSystem
         public void Open(Shop shop, NpcRandomMovement npcMovement = null)
         {
             if (shop == null) return;
-            var quest = FindObjectOfType<QuestUI>();
-            if (quest != null && quest.IsOpen)
-                return;
+            UIManager.Instance.OpenWindow(this);
             currentShop = shop;
             Refresh();
-            var skills = SkillsUI.Instance;
-            if (skills != null && skills.IsOpen)
-                skills.Close();
             uiRoot.SetActive(true);
             if (playerInventory != null)
             {

--- a/Assets/Scripts/Skills/SkillsUI.cs
+++ b/Assets/Scripts/Skills/SkillsUI.cs
@@ -1,9 +1,8 @@
 using UnityEngine;
 using UnityEngine.UI;
-using ShopSystem;
 using Inventory;
 using Player;
-using Quests;
+using UI;
 
 namespace Skills
 {
@@ -11,7 +10,7 @@ namespace Skills
     /// Displays basic skill information such as mining and woodcutting levels and XP
     /// and can be toggled with the 'O' key.
     /// </summary>
-    public class SkillsUI : MonoBehaviour
+    public class SkillsUI : MonoBehaviour, IUIWindow
     {
         private GameObject uiRoot;
         private Text skillText;
@@ -49,6 +48,7 @@ namespace Skills
             CreateUI();
             if (uiRoot != null)
                 uiRoot.SetActive(false);
+            UIManager.Instance.RegisterWindow(this);
         }
 
         private void OnDestroy()
@@ -90,46 +90,29 @@ namespace Skills
 
         public void Toggle()
         {
-            var quest = FindObjectOfType<QuestUI>();
-            if (quest != null && quest.IsOpen)
-            {
-                if (uiRoot != null && uiRoot.activeSelf)
-                    uiRoot.SetActive(false);
-                return;
-            }
+            if (IsOpen)
+                Close();
+            else
+                Open();
+        }
 
-            var shop = ShopUI.Instance;
-            if (shop != null && shop.IsOpen)
-                return;
-            var bank = BankSystem.BankUI.Instance;
-            if (bank != null && bank.IsOpen)
-                return;
-
+        public void Open()
+        {
+            UIManager.Instance.OpenWindow(this);
             if (uiRoot != null)
             {
-                bool opening = !uiRoot.activeSelf;
-                if (opening)
-                {
-                    var inv = Object.FindObjectOfType<Inventory.Inventory>();
-                    if (inv != null && inv.IsOpen)
-                        inv.CloseUI();
-                    var eq = Object.FindObjectOfType<Inventory.Equipment>();
-                    if (eq != null && eq.IsOpen)
-                        eq.CloseUI();
-                }
-                uiRoot.SetActive(!uiRoot.activeSelf);
+                var inv = Object.FindObjectOfType<Inventory.Inventory>();
+                if (inv != null && inv.IsOpen)
+                    inv.CloseUI();
+                var eq = Object.FindObjectOfType<Inventory.Equipment>();
+                if (eq != null && eq.IsOpen)
+                    eq.CloseUI();
+                uiRoot.SetActive(true);
             }
         }
 
         private void Update()
         {
-            var quest = FindObjectOfType<QuestUI>();
-            if (quest != null && quest.IsOpen)
-            {
-                if (uiRoot != null && uiRoot.activeSelf)
-                    uiRoot.SetActive(false);
-                return;
-            }
             // Removed O key toggle
 
             if (uiRoot != null && uiRoot.activeSelf)

--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace UI
+{
+    public interface IUIWindow
+    {
+        bool IsOpen { get; }
+        void Close();
+    }
+
+    /// <summary>
+    /// Central manager for UI windows. Opening one window closes any others.
+    /// </summary>
+    public class UIManager : MonoBehaviour
+    {
+        public static UIManager Instance { get; private set; }
+
+        private readonly List<IUIWindow> windows = new List<IUIWindow>();
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        private static void Init()
+        {
+            var go = new GameObject("UIManager");
+            DontDestroyOnLoad(go);
+            go.AddComponent<UIManager>();
+        }
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+
+        public void RegisterWindow(IUIWindow window)
+        {
+            if (!windows.Contains(window))
+                windows.Add(window);
+        }
+
+        public void OpenWindow(IUIWindow window)
+        {
+            foreach (var w in windows)
+            {
+                if (w != window && w.IsOpen)
+                    w.Close();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `UIManager` singleton and `IUIWindow` interface to coordinate UI windows
- register Skills, Bank, Quest, and Shop UIs with the manager to auto-close other windows when one opens
- replace ad hoc toggle logic in individual UIs with centralized manager calls

## Testing
- `dotnet build` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68adeb8a255c832eb782c143b245fabe