### PR TITLE
Integrate Equipment window with UIManager

### DIFF
--- a/Assets/Scripts/UI/InterfaceTabButtons.cs
+++ b/Assets/Scripts/UI/InterfaceTabButtons.cs
@@ -105,7 +105,13 @@ namespace UI
         {
             CloseAttackStyle();
             var eq = Object.FindObjectOfType<Equipment>();
-            eq?.ToggleUI();
+            if (eq != null)
+            {
+                if (eq.IsOpen)
+                    eq.Close();
+                else
+                    eq.Open();
+            }
         }
 
         private void ToggleAttackStyle()


### PR DESCRIPTION
## Summary
- Implement IUIWindow in Equipment and register with UIManager for centralized window control
- Add open/close APIs in Equipment that coordinate with UIManager
- Use new Equipment open/close methods from InterfaceTabButtons

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae16ef4e6c832ea29a105acfd60953