### PR TITLE
fix ISaveable interface compile issue

### DIFF
--- a/Assets/Scripts/Core/Save/ISaveable.cs
+++ b/Assets/Scripts/Core/Save/ISaveable.cs
@@ -1,5 +1,3 @@
-using UnityEngine;
-
 namespace Core.Save
 {
     /// <summary>


### PR DESCRIPTION
## Summary
- remove UnityEngine dependency from ISaveable interface

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68ae1b1cf57c832eafdcb00c6d4564f8