### PR TITLE
Integrate inventory and attack style UIs with UI manager

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -12,6 +12,7 @@ using Player;
 using Skills;
 using Pets;
 using Quests;
+using UI;
 using Object = UnityEngine.Object;
 
 namespace Inventory
@@ -39,7 +40,7 @@ namespace Inventory
     /// as the slot frame (set to Sliced).
     /// </summary>
     [DisallowMultipleComponent]
-    public class Inventory : MonoBehaviour
+    public class Inventory : MonoBehaviour, IUIWindow
     {
         [Header("Inventory")]
         [Tooltip("Maximum number of items the inventory can hold.")]
@@ -142,8 +143,15 @@ namespace Inventory
             }
         }
 
+        public void Close()
+        {
+            CloseUI();
+        }
+
         public void OpenUI()
         {
+            if (!BankOpen && !InShop)
+                UIManager.Instance.OpenWindow(this);
             if (uiRoot != null)
                 uiRoot.SetActive(true);
             if (playerMover != null)
@@ -227,6 +235,7 @@ namespace Inventory
                 uiRoot.SetActive(false);
 
             Load();
+            UIManager.Instance.RegisterWindow(this);
         }
 
         /// <summary>

--- a/Assets/Scripts/UI/AttackStyleUI.cs
+++ b/Assets/Scripts/UI/AttackStyleUI.cs
@@ -8,7 +8,7 @@ namespace UI
     /// <summary>
     /// Simple interface for selecting the player's combat style.
     /// </summary>
-    public class AttackStyleUI : MonoBehaviour
+    public class AttackStyleUI : MonoBehaviour, IUIWindow
     {
         private GameObject uiRoot;
         private PlayerCombatLoadout loadout;
@@ -34,6 +34,7 @@ namespace UI
             CreateUI();
             if (uiRoot != null)
                 uiRoot.SetActive(false);
+            UIManager.Instance.RegisterWindow(this);
         }
 
         private void CreateUI()
@@ -90,13 +91,28 @@ namespace UI
         /// <summary>Toggle the visibility of the UI.</summary>
         public void Toggle()
         {
+            if (IsOpen)
+                Close();
+            else
+                Open();
+        }
+
+        /// <summary>Open the attack style interface.</summary>
+        public void Open()
+        {
+            UIManager.Instance.OpenWindow(this);
             if (uiRoot != null)
             {
-                bool opening = !uiRoot.activeSelf;
-                uiRoot.SetActive(opening);
-                if (opening)
-                    UpdateSelection();
+                uiRoot.SetActive(true);
+                UpdateSelection();
             }
+        }
+
+        /// <summary>Close the attack style interface.</summary>
+        public void Close()
+        {
+            if (uiRoot != null)
+                uiRoot.SetActive(false);
         }
 
         private void SetStyle(CombatStyle style)

--- a/Assets/Scripts/UI/InterfaceTabButtons.cs
+++ b/Assets/Scripts/UI/InterfaceTabButtons.cs
@@ -76,14 +76,12 @@ namespace UI
 
         private void ToggleQuest()
         {
-            CloseAttackStyle();
             var quest = Object.FindObjectOfType<QuestUI>();
             quest?.Toggle();
         }
 
         private void ToggleInventory()
         {
-            CloseAttackStyle();
             var inv = Object.FindObjectOfType<Inventory.Inventory>();
             if (inv != null)
             {
@@ -96,14 +94,12 @@ namespace UI
 
         private void ToggleSkills()
         {
-            CloseAttackStyle();
             var skills = SkillsUI.Instance;
             skills?.Toggle();
         }
 
         private void ToggleEquipment()
         {
-            CloseAttackStyle();
             var eq = Object.FindObjectOfType<Equipment>();
             if (eq != null)
             {
@@ -120,12 +116,7 @@ namespace UI
             style?.Toggle();
         }
 
-        private void CloseAttackStyle()
-        {
-            var style = Object.FindObjectOfType<AttackStyleUI>();
-            if (style != null && style.IsOpen)
-                style.Toggle();
-        }
+        // AttackStyleUI closes automatically through UIManager when other windows open.
     }
 }
 


### PR DESCRIPTION
## Summary
- Register inventory and attack style windows with the central UI manager
- Use UI manager for opening/closing inventory and attack style panels
- Simplify interface tab buttons by removing manual attack style closing

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1ec22278832ea08f4c5e0deadce0