### PR TITLE
Fix player inventory hidden by pet storage

### DIFF
--- a/Assets/Scripts/UI/InterfaceTabButtons.cs
+++ b/Assets/Scripts/UI/InterfaceTabButtons.cs
@@ -3,7 +3,6 @@ using UnityEngine.UI;
 using Inventory;
 using Quests;
 using Skills;
-using System.Collections.Generic;
 using Object = UnityEngine.Object;
 
 namespace UI
@@ -85,44 +84,23 @@ namespace UI
         {
             var inventories = Object.FindObjectsOfType<Inventory.Inventory>();
             Inventory.Inventory playerInv = null;
-            var petInvs = new List<Inventory.Inventory>();
+            bool petOpen = false;
 
             foreach (var inv in inventories)
             {
                 if (inv.GetComponent<Player.PlayerMover>() != null)
                     playerInv = inv;
-                else if (inv.GetComponent<Pets.PetStorage>() != null)
-                    petInvs.Add(inv);
+                else if (inv.GetComponent<Pets.PetStorage>() != null && inv.IsOpen)
+                    petOpen = true;
             }
 
             if (playerInv == null)
                 return;
 
-            bool anyOpen = playerInv.IsOpen;
-            if (!anyOpen)
-            {
-                foreach (var inv in petInvs)
-                {
-                    if (inv.IsOpen)
-                    {
-                        anyOpen = true;
-                        break;
-                    }
-                }
-            }
-
-            if (anyOpen)
-            {
+            if (playerInv.IsOpen || petOpen)
                 playerInv.CloseUI();
-                foreach (var inv in petInvs)
-                    inv.CloseUI();
-            }
             else
-            {
                 playerInv.OpenUI();
-                foreach (var inv in petInvs)
-                    inv.OpenUI();
-            }
         }
 
         private void ToggleSkills()


### PR DESCRIPTION
## Summary
- Ensure inventory button toggles only the player's inventory; pet storage now opens via player inventory

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae45e62468832eaaab7e4783fba788