### PR TITLE
Respect shared UI root flag for inventory windows

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -150,7 +150,7 @@ namespace Inventory
 
         public void OpenUI()
         {
-            if (!BankOpen && !InShop)
+            if (!BankOpen && !InShop && useSharedUIRoot)
                 UIManager.Instance.OpenWindow(this);
             if (uiRoot != null)
                 uiRoot.SetActive(true);


### PR DESCRIPTION
## Summary
- only open UI window through UIManager when `useSharedUIRoot` is true

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae47cbea3c832ebaff0bcf77127a9f