### PR TITLE
Initialize pet inventory in Awake

### DIFF
--- a/Assets/Scripts/Pets/PetStorage.cs
+++ b/Assets/Scripts/Pets/PetStorage.cs
@@ -16,16 +16,19 @@ namespace Pets
         private void Awake()
         {
             experience = GetComponent<PetExperience>();
-        }
-
-        private void Start()
-        {
             if (definition != null && definition.hasInventory)
             {
                 CreateInventory();
                 if (experience != null)
                     experience.OnLevelChanged += HandleLevelChanged;
             }
+        }
+
+        private void Start()
+        {
+            var playerInv = GameObject.FindGameObjectWithTag("Player")?.GetComponent<Inventory.Inventory>();
+            if (playerInv != null && playerInv.IsOpen && !playerInv.BankOpen)
+                Open();
         }
 
         private void OnDestroy()


### PR DESCRIPTION
## Summary
- Ensure pet inventory is created and hooks level-change events in `Awake`
- Auto-open pet inventory on spawn if player inventory UI is already visible

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4a1b8cd8832eafe5387bc80dd3b2