### PR TITLE
Ensure pet inventory UI opens after initialization

### DIFF
--- a/Assets/Scripts/Pets/PetDropSystem.cs
+++ b/Assets/Scripts/Pets/PetDropSystem.cs
@@ -210,7 +210,7 @@ namespace Pets
             if (playerInventory != null && playerInventory.IsOpen && !playerInventory.BankOpen)
             {
                 var storage = activePetGO.GetComponent<PetStorage>();
-                storage?.Open();
+                storage?.StartCoroutine(storage.OpenDelayed());
             }
 
             return activePetGO;

--- a/Assets/Scripts/Pets/PetStorage.cs
+++ b/Assets/Scripts/Pets/PetStorage.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using Inventory;
+using System.Collections;
 
 namespace Pets
 {
@@ -43,7 +44,7 @@ namespace Pets
         {
             var playerInv = GameObject.FindGameObjectWithTag("Player")?.GetComponent<Inventory.Inventory>();
             if (playerInv != null && playerInv.IsOpen && !playerInv.BankOpen)
-                Open();
+                StartCoroutine(OpenDelayed());
         }
 
         private void OnDestroy()
@@ -116,6 +117,12 @@ namespace Pets
         {
             if (inventory != null)
                 inventory.OpenUI();
+        }
+
+        public System.Collections.IEnumerator OpenDelayed()
+        {
+            yield return null;
+            Open();
         }
 
         public void Close()


### PR DESCRIPTION
## Summary
- Add coroutine in `PetStorage` to open the pet inventory after a frame
- Use coroutine when spawning pet to delay opening until `Inventory.Start`

## Testing
- `dotnet test` *(fails: specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4f5fa120832e8d5148530b01459d