### PR TITLE
Prevent overlapping scene transitions

### DIFF
--- a/Assets/Scripts/World/Door.cs
+++ b/Assets/Scripts/World/Door.cs
@@ -32,6 +32,9 @@ namespace World
 
         private void Update()
         {
+            if (SceneTransitionManager.IsTransitioning)
+                return;
+
             if (!Input.GetMouseButtonDown(0))
                 return;
 

--- a/Assets/Scripts/World/SceneTransitionManager.cs
+++ b/Assets/Scripts/World/SceneTransitionManager.cs
@@ -36,6 +36,9 @@ namespace World
 
         public IEnumerator Transition(string sceneToLoad, string spawnPointName, string requiredItemId, bool removeItemOnUse)
         {
+            if (IsTransitioning)
+                yield break;
+
             if (string.IsNullOrEmpty(sceneToLoad))
                 yield break;
 


### PR DESCRIPTION
## Summary
- guard SceneTransitionManager.Transition to avoid re-entrant scene loads while already transitioning
- ignore door interaction input while a scene transition is active

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68af1a9d4e28832ea0eb0c234d18da46