### PR TITLE
Add scene transition events and subscribers

### DIFF
--- a/Assets/Scripts/World/Door.cs
+++ b/Assets/Scripts/World/Door.cs
@@ -30,9 +30,23 @@ namespace World
         [Tooltip("How close the player must be in tiles to use the door.")]
         public float useRadius = 2f;
 
+        private bool _transitioning;
+
+        private void OnEnable()
+        {
+            SceneTransitionManager.TransitionStarted += OnTransitionStarted;
+            SceneTransitionManager.TransitionCompleted += OnTransitionCompleted;
+        }
+
+        private void OnDisable()
+        {
+            SceneTransitionManager.TransitionStarted -= OnTransitionStarted;
+            SceneTransitionManager.TransitionCompleted -= OnTransitionCompleted;
+        }
+
         private void Update()
         {
-            if (SceneTransitionManager.IsTransitioning)
+            if (_transitioning)
                 return;
 
             if (!Input.GetMouseButtonDown(0))
@@ -54,6 +68,9 @@ namespace World
 
         private IEnumerator UseDoor()
         {
+            if (_transitioning)
+                yield break;
+
             GameObject player = GameObject.FindGameObjectWithTag("Player");
             if (player == null) yield break;
 
@@ -87,5 +104,9 @@ namespace World
                 }
             }
         }
+
+        private void OnTransitionStarted() => _transitioning = true;
+
+        private void OnTransitionCompleted() => _transitioning = false;
     }
 }


### PR DESCRIPTION
## Summary
- add TransitionStarted and TransitionCompleted events to SceneTransitionManager
- notify before fade-out and after fade-in
- subscribe Door and PlayerMover to transition events to pause interaction and movement

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*


------
https://chatgpt.com/codex/tasks/task_e_68af1b7efabc832eb571abc8a0e43f5b