### PR TITLE
Prevent unintended scene reload during transitions

### DIFF
--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -298,6 +298,8 @@ namespace Player
                 return;
             if (isTransitioning)
                 return;
+            if (SceneTransitionManager.IsTransitioning)
+                return;
 
             if (SceneManager.GetActiveScene().name == data.scene)
             {


### PR DESCRIPTION
## Summary
- Guard player position loading against in-progress scene transitions to avoid spurious scene reloads

## Testing
- `dotnet test` *(fails: MSBUILD error: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68af24de02b0832e95ed1049182c7dc1