### PR TITLE
Fix duplicate EventSystem instances across scenes

### DIFF
--- a/Assets/Scripts/Dialogue/DialogueUI.cs
+++ b/Assets/Scripts/Dialogue/DialogueUI.cs
@@ -113,8 +113,7 @@ namespace Dialogue
         {
             if (FindObjectOfType<EventSystem>() != null)
                 return;
-            var go = new GameObject("EventSystem", typeof(EventSystem), typeof(StandaloneInputModule));
-            DontDestroyOnLoad(go);
+            new GameObject("EventSystem", typeof(EventSystem), typeof(StandaloneInputModule));
         }
     }
 }

--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -1128,14 +1128,10 @@ namespace Inventory
         {
             var existing = UnityEngine.Object.FindObjectOfType<EventSystem>();
             if (existing != null)
-            {
-                DontDestroyOnLoad(existing.gameObject);
                 return;
-            }
 
             var go = new GameObject("EventSystem", typeof(EventSystem), typeof(StandaloneInputModule));
             go.transform.SetParent(null, false);
-            DontDestroyOnLoad(go);
         }
     }
 }


### PR DESCRIPTION
## Summary
- stop persisting EventSystems in Inventory and DialogueUI
- rely on scene-specific EventSystem to avoid duplicates when changing scenes

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68af2a43161c832e99098aab23abef2e