### PR TITLE
Use central Input System event system

### DIFF
--- a/Assets/Scripts/Dialogue/DialogueUI.cs
+++ b/Assets/Scripts/Dialogue/DialogueUI.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.EventSystems;
+using UnityEngine.InputSystem.UI;
 
 namespace Dialogue
 {
@@ -20,7 +21,10 @@ namespace Dialogue
             canvas.renderMode = RenderMode.ScreenSpaceOverlay;
             gameObject.AddComponent<CanvasScaler>().uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
             gameObject.AddComponent<GraphicRaycaster>();
-            EnsureEventSystem();
+
+            if (EventSystem.current == null)
+                EnsureEventSystem();
+
             Build();
             gameObject.SetActive(false);
         }
@@ -113,7 +117,8 @@ namespace Dialogue
         {
             if (FindObjectOfType<EventSystem>() != null)
                 return;
-            new GameObject("EventSystem", typeof(EventSystem), typeof(StandaloneInputModule));
+
+            new GameObject("EventSystem", typeof(EventSystem), typeof(InputSystemUIInputModule));
         }
     }
 }

--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -4,9 +4,8 @@ using UnityEngine;
 using Core.Save;
 using UnityEngine.UI;
 using UnityEngine.EventSystems;
-#if ENABLE_INPUT_SYSTEM
 using UnityEngine.InputSystem;
-#endif
+using UnityEngine.InputSystem.UI;
 using ShopSystem;
 using Player;
 using Skills;
@@ -215,7 +214,9 @@ namespace Inventory
             }
 
             items = new InventoryEntry[size];
-            EnsureLegacyEventSystem();
+
+            if (EventSystem.current == null)
+                EnsureEventSystem();
 
             if (useSharedUIRoot && sharedUIRoot != null)
             {
@@ -1077,12 +1078,7 @@ namespace Inventory
 
         private void Update()
         {
-#if ENABLE_INPUT_SYSTEM
             bool toggle = false;
-#else
-            bool toggle = false;
-#endif
-
             if (playerMover == null)
                 return;
 
@@ -1122,15 +1118,15 @@ namespace Inventory
         }
 
         /// <summary>
-        /// Ensure a legacy EventSystem exists for uGUI with StandaloneInputModule.
+        /// Ensure an EventSystem exists for uGUI with the Input System module.
         /// </summary>
-        private static void EnsureLegacyEventSystem()
+        private static void EnsureEventSystem()
         {
-            var existing = UnityEngine.Object.FindObjectOfType<EventSystem>();
+            var existing = Object.FindObjectOfType<EventSystem>();
             if (existing != null)
                 return;
 
-            var go = new GameObject("EventSystem", typeof(EventSystem), typeof(StandaloneInputModule));
+            var go = new GameObject("EventSystem", typeof(EventSystem), typeof(InputSystemUIInputModule));
             go.transform.SetParent(null, false);
         }
     }


### PR DESCRIPTION
## Summary
- ensure Dialogue UI only creates an EventSystem when none exists and wire it to InputSystemUIInputModule
- remove legacy StandaloneInputModule usage in Inventory and create an InputSystem-driven EventSystem only when required
- rely on a shared EventSystem prefab using InputSystemUIInputModule for consistent input across scenes

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68af2d41a994832ea5defdf593524235