### PR TITLE
Fix duplicate OnDestroy in PlayerMover

### DIFF
--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -139,6 +139,8 @@ namespace Player
             if (instance == this)
                 instance = null;
 
+            SceneTransitionManager.TransitionStarted -= OnTransitionStarted;
+            SceneTransitionManager.TransitionCompleted -= OnTransitionCompleted;
             SceneTransitionManager.UnregisterPersistentObject(this);
         }
 
@@ -295,13 +297,6 @@ namespace Player
         void OnApplicationQuit()
         {
             SavePosition();
-        }
-
-        private void OnDestroy()
-        {
-            SceneTransitionManager.TransitionStarted -= OnTransitionStarted;
-            SceneTransitionManager.TransitionCompleted -= OnTransitionCompleted;
-            SceneTransitionManager.UnregisterPersistentObject(this);
         }
 
         public void SavePosition()


### PR DESCRIPTION
## Summary
- merge duplicate `OnDestroy` implementations in `PlayerMover` and handle event unsubscription in one place

## Testing
- `dotnet build` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68af3147ffe8832e9217329b96a40792