### PR TITLE
Prevent duplicate persistent objects on scene load

### DIFF
--- a/Assets/Scripts/Bank/BankUI.cs
+++ b/Assets/Scripts/Bank/BankUI.cs
@@ -56,6 +56,9 @@ namespace BankSystem
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
         private static void Init()
         {
+            if (UnityEngine.Object.FindObjectOfType<BankUI>() != null)
+                return;
+
             var go = new GameObject("Bank");
             DontDestroyOnLoad(go);
             go.AddComponent<BankUI>();

--- a/Assets/Scripts/Combat/CombatWeaponHUD.cs
+++ b/Assets/Scripts/Combat/CombatWeaponHUD.cs
@@ -18,8 +18,11 @@ namespace Combat
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
         private static void CreateInstance()
         {
+            if (UnityEngine.Object.FindObjectOfType<CombatWeaponHUD>() != null)
+                return;
+
             var go = new GameObject("CombatWeaponHUD");
-            DontDestroyOnLoad(go);
+            UnityEngine.Object.DontDestroyOnLoad(go);
             go.AddComponent<CombatWeaponHUD>();
         }
 

--- a/Assets/Scripts/Skills/Mining/UI/MiningUI.cs
+++ b/Assets/Scripts/Skills/Mining/UI/MiningUI.cs
@@ -30,8 +30,11 @@ namespace Skills.Mining
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
         private static void CreateInstance()
         {
+            if (UnityEngine.Object.FindObjectOfType<MiningUI>() != null)
+                return;
+
             var go = new GameObject("MiningUI");
-            DontDestroyOnLoad(go);
+            UnityEngine.Object.DontDestroyOnLoad(go);
             go.AddComponent<MiningUI>();
         }
 

--- a/Assets/Scripts/Skills/SkillsDebugMenu.cs
+++ b/Assets/Scripts/Skills/SkillsDebugMenu.cs
@@ -34,6 +34,9 @@ namespace Skills
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
         private static void Create()
         {
+            if (UnityEngine.Object.FindObjectOfType<SkillsDebugMenu>() != null)
+                return;
+
             var go = new GameObject("SkillsDebugMenu");
             DontDestroyOnLoad(go);
             go.AddComponent<SkillsDebugMenu>();

--- a/Assets/Scripts/Skills/SkillsUI.cs
+++ b/Assets/Scripts/Skills/SkillsUI.cs
@@ -26,6 +26,9 @@ namespace Skills
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
         private static void CreateInstance()
         {
+            if (Instance != null || UnityEngine.Object.FindObjectOfType<SkillsUI>() != null)
+                return;
+
             var go = new GameObject("SkillsUI");
             DontDestroyOnLoad(go);
             go.AddComponent<SkillsUI>();

--- a/Assets/Scripts/Skills/Woodcutting/UI/WoodcuttingHUD.cs
+++ b/Assets/Scripts/Skills/Woodcutting/UI/WoodcuttingHUD.cs
@@ -28,8 +28,11 @@ namespace Skills.Woodcutting
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
         private static void CreateInstance()
         {
+            if (UnityEngine.Object.FindObjectOfType<WoodcuttingHUD>() != null)
+                return;
+
             var go = new GameObject("WoodcuttingHUD");
-            Object.DontDestroyOnLoad(go);
+            UnityEngine.Object.DontDestroyOnLoad(go);
             go.AddComponent<WoodcuttingHUD>();
         }
 

--- a/Assets/Scripts/UI/AttackStyleUI.cs
+++ b/Assets/Scripts/UI/AttackStyleUI.cs
@@ -23,8 +23,11 @@ namespace UI
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
         private static void Init()
         {
+            if (UnityEngine.Object.FindObjectOfType<AttackStyleUI>() != null)
+                return;
+
             var go = new GameObject("AttackStyleUI");
-            DontDestroyOnLoad(go);
+            UnityEngine.Object.DontDestroyOnLoad(go);
             go.AddComponent<AttackStyleUI>();
         }
 

--- a/Assets/Scripts/UI/InterfaceTabButtons.cs
+++ b/Assets/Scripts/UI/InterfaceTabButtons.cs
@@ -16,6 +16,9 @@ namespace UI
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
         private static void Init()
         {
+            if (Object.FindObjectOfType<InterfaceTabButtons>() != null)
+                return;
+
             var go = new GameObject("InterfaceTabButtons");
             DontDestroyOnLoad(go);
             go.AddComponent<InterfaceTabButtons>();


### PR DESCRIPTION
## Summary
- guard DontDestroyOnLoad UI bootstrap scripts against re-creating existing instances
- avoid duplicate UI elements appearing when switching scenes

## Testing
- `dotnet build` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68af32addd38832e94c3162585b47df8