### PR TITLE
Prevent duplicate persistent objects across scenes

### DIFF
--- a/Assets/Scripts/World/ScenePersistentObject.cs
+++ b/Assets/Scripts/World/ScenePersistentObject.cs
@@ -8,6 +8,25 @@ namespace World
     /// </summary>
     public class ScenePersistentObject : MonoBehaviour, IScenePersistent
     {
+        // Track duplicates early so only a single instance of a
+        // persistent object survives scene loads.  Without this check, a
+        // copy of the object placed in a newly loaded scene would remain
+        // alongside the existing instance that was carried over via
+        // DontDestroyOnLoad, leading to duplicated managers and HUD
+        // elements.
+        void Awake()
+        {
+            var others = FindObjectsOfType<ScenePersistentObject>();
+            foreach (var obj in others)
+            {
+                if (obj != this && obj.gameObject.name == gameObject.name)
+                {
+                    Destroy(gameObject);
+                    return;
+                }
+            }
+        }
+
         void OnEnable()
         {
             SceneTransitionManager.RegisterPersistentObject(this);


### PR DESCRIPTION
## Summary
- prevent duplicate persistent objects by destroying new copies on Awake

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68af365cfa18832e885a2c0b85016d31