### PR TITLE
Prevent duplicate UI across scene changes

### DIFF
--- a/Assets/Scripts/Inventory/Equipment.cs
+++ b/Assets/Scripts/Inventory/Equipment.cs
@@ -118,6 +118,8 @@ namespace Inventory
         private GameObject playerBonusPanel;
         private GameObject petBonusPanel;
 
+        private static Equipment instance;
+
         private bool lastMergeState;
 
         public int TotalAttackBonus { get; private set; }
@@ -140,6 +142,15 @@ namespace Inventory
 
         private void Awake()
         {
+            if (instance != null && instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            instance = this;
+            DontDestroyOnLoad(gameObject);
+
             inventory = GetComponent<Inventory>();
             skillManager = skillManager != null ? skillManager : GetComponent<SkillManager>();
             if (floatingTextAnchor == null)
@@ -153,6 +164,12 @@ namespace Inventory
                 uiRoot.SetActive(false);
 
             UIManager.Instance.RegisterWindow(this);
+        }
+
+        private void OnDestroy()
+        {
+            if (instance == this)
+                instance = null;
         }
 
         public void ToggleUI()

--- a/Assets/Scripts/Quests/QuestUI.cs
+++ b/Assets/Scripts/Quests/QuestUI.cs
@@ -24,10 +24,19 @@ namespace Quests
         private Canvas canvas;
         private PlayerMover playerMover;
 
+        private static QuestUI instance;
+
         public bool IsOpen => canvas != null && canvas.enabled;
 
         private void Awake()
         {
+            if (instance != null && instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            instance = this;
             name = "QuestUI";
             canvas = gameObject.AddComponent<Canvas>();
             canvas.renderMode = RenderMode.ScreenSpaceOverlay;
@@ -39,6 +48,12 @@ namespace Quests
             canvas.enabled = false;
             playerMover = FindObjectOfType<PlayerMover>();
             UIManager.Instance.RegisterWindow(this);
+        }
+
+        private void OnDestroy()
+        {
+            if (instance == this)
+                instance = null;
         }
 
         private void Start()

--- a/Assets/Scripts/Shop/ShopUI.cs
+++ b/Assets/Scripts/Shop/ShopUI.cs
@@ -60,6 +60,9 @@ namespace ShopSystem
             instance = this;
             DontDestroyOnLoad(gameObject);
 
+            if (sharedUIRoot == null)
+                sharedUIRoot = GameObject.Find("ShopUI");
+
             if (sharedUIRoot != null)
             {
                 uiRoot = sharedUIRoot;


### PR DESCRIPTION
## Summary
- ensure QuestUI destroys duplicate instances and persists safely
- guard Equipment against multiple instances to avoid duplicating EquipmentUI
- reuse existing ShopUI root when scenes change

## Testing
- `dotnet test` (fails: Specify a project or solution file)


------
https://chatgpt.com/codex/tasks/task_e_68af38e993e8832e86f6b48010c7347a