### PR TITLE
Add Fishing skill with basic mechanics

### DIFF
--- a/Assets/Resources/FishingDatabase.meta
+++ b/Assets/Resources/FishingDatabase.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 36c1148b22a547af8b96a1dfad1e3d4c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/FishingDatabase/Shrimp Spot.asset
+++ b/Assets/Resources/FishingDatabase/Shrimp Spot.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 29e2ea8386a6462d9b08c4a8243f38a1, type: 3}
+  m_Name: Shrimp Spot
+  m_EditorClassIdentifier:
+  id: ShrimpSpot
+  availableFish:
+  - {fileID: 11400000, guid: e68477b5b0bf4d9fa51f24a3e3c4d079, type: 2}
+  depletesAfterCatch: 0
+  depleteRollInverse: 8
+  respawnSeconds: 5
+  catchIntervalTicks: 4
+  interactRange: 1.5
+  cancelDistance: 3

--- a/Assets/Resources/FishingDatabase/Shrimp Spot.asset.meta
+++ b/Assets/Resources/FishingDatabase/Shrimp Spot.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0de8f53b710e4fe08e020c66f2afb1a9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/FishingDatabase/Shrimp.asset
+++ b/Assets/Resources/FishingDatabase/Shrimp.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e1f620b4fa8542bcb38d964538bf97d8, type: 3}
+  m_Name: Shrimp
+  m_EditorClassIdentifier:
+  id: Shrimp
+  displayName: Shrimp
+  requiredLevel: 1
+  xp: 10
+  itemId: Shrimp

--- a/Assets/Resources/FishingDatabase/Shrimp.asset.meta
+++ b/Assets/Resources/FishingDatabase/Shrimp.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e68477b5b0bf4d9fa51f24a3e3c4d079
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/FishingDatabase/Small Net.asset
+++ b/Assets/Resources/FishingDatabase/Small Net.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dbe34942ecc14b96a2b60f7ce249549a, type: 3}
+  m_Name: Small Net
+  m_EditorClassIdentifier:
+  id: SmallNet
+  displayName: Small Net
+  requiredLevel: 1
+  swingSpeedMultiplier: 1
+  catchBonus: 0
+  baitItemId:
+  icon: {fileID: 0}

--- a/Assets/Resources/FishingDatabase/Small Net.asset.meta
+++ b/Assets/Resources/FishingDatabase/Small Net.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c08573f61adf4bc5a7a5e768f8b513c7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Skills/Fishing.meta
+++ b/Assets/Scripts/Skills/Fishing.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0c45ee5b721e4f07bd8b1c96fce25cf6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Skills/Fishing/Core.meta
+++ b/Assets/Scripts/Skills/Fishing/Core.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a0193e4dfbd341f783b7af5120a061f8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Skills/Fishing/Core/FishableSpot.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishableSpot.cs
@@ -1,0 +1,90 @@
+using System;
+using UnityEngine;
+using Util;
+using Random = UnityEngine.Random;
+
+namespace Skills.Fishing
+{
+    [RequireComponent(typeof(Collider2D))]
+    public class FishableSpot : MonoBehaviour, ITickable
+    {
+        [Header("Definition")]
+        public FishingSpotDefinition def;
+
+        [Header("Visuals")]
+        [SerializeField] private SpriteRenderer sr;
+        [SerializeField] private Sprite activeSprite;
+        [SerializeField] private Sprite depletedSprite;
+
+        public bool IsDepleted { get; private set; }
+        public bool IsBusy { get; set; }
+
+        public event Action<FishableSpot, float> OnSpotDepleted;
+        public event Action<FishableSpot> OnSpotRespawned;
+
+        private double respawnAt;
+
+        private void Awake()
+        {
+            if (sr == null)
+                sr = GetComponent<SpriteRenderer>();
+            if (def != null)
+            {
+                if (activeSprite == null && sr != null) activeSprite = sr.sprite;
+            }
+        }
+
+        private void OnEnable()
+        {
+            if (Ticker.Instance != null)
+                Ticker.Instance.Subscribe(this);
+        }
+
+        private void OnDisable()
+        {
+            if (Ticker.Instance != null)
+                Ticker.Instance.Unsubscribe(this);
+        }
+
+        public void OnTick()
+        {
+            if (IsDepleted && Time.timeAsDouble >= respawnAt)
+                Respawn();
+        }
+
+        public void OnFishCaught()
+        {
+            if (IsDepleted || def == null)
+                return;
+
+            if (def.DepletesAfterCatch)
+            {
+                Deplete();
+            }
+            else if (def.DepleteRollInverse > 0 && Random.Range(0, def.DepleteRollInverse) == 0)
+            {
+                Deplete();
+            }
+        }
+
+        private void Deplete()
+        {
+            IsDepleted = true;
+            respawnAt = Time.timeAsDouble + def.RespawnSeconds;
+            var col = GetComponent<Collider2D>();
+            if (col) col.enabled = false;
+            if (sr && depletedSprite) sr.sprite = depletedSprite;
+            IsBusy = false;
+            OnSpotDepleted?.Invoke(this, def != null ? def.RespawnSeconds : 0f);
+        }
+
+        private void Respawn()
+        {
+            IsDepleted = false;
+            var col = GetComponent<Collider2D>();
+            if (col) col.enabled = true;
+            if (sr && activeSprite) sr.sprite = activeSprite;
+            OnSpotRespawned?.Invoke(this);
+        }
+    }
+}

--- a/Assets/Scripts/Skills/Fishing/Core/FishableSpot.cs.meta
+++ b/Assets/Scripts/Skills/Fishing/Core/FishableSpot.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a6c7b5e7790343a1a7174ba73c7bd8ac

--- a/Assets/Scripts/Skills/Fishing/Core/FisherController.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FisherController.cs
@@ -1,0 +1,163 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+using Inventory;
+using Player;
+using Skills.Mining;
+
+namespace Skills.Fishing
+{
+    [DisallowMultipleComponent]
+    public class FisherController : MonoBehaviour
+    {
+        [SerializeField] private float interactRange = 1.5f;
+        [SerializeField] private float cancelDistance = 3f;
+        [SerializeField] [Tooltip("Layers including fishing spots")] private LayerMask spotMask = ~0;
+
+        [Header("References")]
+        [SerializeField] private FishingSkill fishingSkill;
+        [SerializeField] private FishingToolToUse toolSelector;
+        [SerializeField] private PlayerMover playerMover;
+        [SerializeField] private Animator animator;
+
+        private FishableSpot nearbySpot;
+        private Camera cam;
+
+        private void Awake()
+        {
+            if (fishingSkill == null)
+                fishingSkill = GetComponent<FishingSkill>();
+            if (toolSelector == null)
+                toolSelector = GetComponent<FishingToolToUse>();
+            if (playerMover == null)
+                playerMover = GetComponent<PlayerMover>();
+            if (animator == null)
+                animator = GetComponentInChildren<Animator>();
+            cam = Camera.main;
+        }
+
+        private void OnEnable()
+        {
+            if (fishingSkill != null)
+                fishingSkill.OnStopFishing += HandleStop;
+        }
+
+        private void OnDisable()
+        {
+            if (fishingSkill != null)
+                fishingSkill.OnStopFishing -= HandleStop;
+        }
+
+        private void Update()
+        {
+            if (Input.GetMouseButtonDown(0))
+            {
+                if (EventSystem.current == null || !EventSystem.current.IsPointerOverGameObject())
+                {
+                    var spot = GetSpotUnderCursor();
+                    if (spot != null)
+                        TryStartFishing(spot);
+                }
+            }
+
+            if (Input.GetKeyDown(KeyCode.Escape))
+                fishingSkill.StopFishing();
+
+            if (nearbySpot != null && Input.GetKeyDown(KeyCode.E))
+                TryStartFishing(nearbySpot);
+
+            if (fishingSkill.IsFishing)
+            {
+                if (playerMover != null && playerMover.IsMoving)
+                    fishingSkill.StopFishing();
+                else
+                {
+                    float cancelDist = fishingSkill.CurrentSpot != null && fishingSkill.CurrentSpot.def != null
+                        ? fishingSkill.CurrentSpot.def.CancelDistance
+                        : cancelDistance;
+                    if (Vector3.Distance(transform.position, fishingSkill.CurrentSpot.transform.position) > cancelDist)
+                        fishingSkill.StopFishing();
+                    else if (fishingSkill.CurrentSpot.IsDepleted)
+                        fishingSkill.StopFishing();
+                }
+            }
+        }
+
+        private FishableSpot GetSpotUnderCursor()
+        {
+            if (cam == null)
+                cam = Camera.main;
+            Vector2 world = cam.ScreenToWorldPoint(Input.mousePosition);
+            var collider = Physics2D.OverlapPoint(world, spotMask);
+            if (collider != null)
+                return collider.GetComponentInParent<FishableSpot>();
+            return null;
+        }
+
+        private void TryStartFishing(FishableSpot spot)
+        {
+            if (spot == null || spot.IsDepleted || spot.IsBusy)
+                return;
+
+            float dist = Vector3.Distance(transform.position, spot.transform.position);
+            float range = spot.def != null ? spot.def.InteractRange : interactRange;
+            if (dist > range)
+                return;
+
+            var tool = toolSelector.GetBestTool();
+            if (tool == null)
+            {
+                FloatingText.Show("You need a fishing tool", transform.position);
+                return;
+            }
+            if (fishingSkill.Level < tool.RequiredLevel)
+            {
+                FloatingText.Show($"You need Fishing level {tool.RequiredLevel}", transform.position);
+                return;
+            }
+
+            FishDefinition catchable = null;
+            int minLevel = int.MaxValue;
+            foreach (var fish in spot.def.AvailableFish)
+            {
+                if (fish == null) continue;
+                minLevel = Mathf.Min(minLevel, fish.RequiredLevel);
+                if (fishingSkill.Level >= fish.RequiredLevel)
+                    catchable = fish;
+            }
+            if (catchable == null)
+            {
+                FloatingText.Show($"You need Fishing level {minLevel}", transform.position);
+                return;
+            }
+            if (!fishingSkill.CanAddFish(catchable))
+            {
+                FloatingText.Show("Your inventory is full", transform.position);
+                return;
+            }
+
+            fishingSkill.StartFishing(spot, tool);
+            if (animator != null)
+                animator.SetBool("isFishing", true);
+        }
+
+        private void HandleStop()
+        {
+            if (animator != null)
+                animator.SetBool("isFishing", false);
+        }
+
+        private void OnTriggerEnter2D(Collider2D other)
+        {
+            var spot = other.GetComponent<FishableSpot>();
+            if (spot != null)
+                nearbySpot = spot;
+        }
+
+        private void OnTriggerExit2D(Collider2D other)
+        {
+            var spot = other.GetComponent<FishableSpot>();
+            if (spot != null && spot == nearbySpot)
+                nearbySpot = null;
+        }
+    }
+}

--- a/Assets/Scripts/Skills/Fishing/Core/FisherController.cs.meta
+++ b/Assets/Scripts/Skills/Fishing/Core/FisherController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8dd1e793621a4b0ea9f20b17e25bfb2a

--- a/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
@@ -1,0 +1,272 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Inventory;
+using Util;
+using Skills.Mining; // reuse XP table
+using Core.Save;
+
+namespace Skills.Fishing
+{
+    [DisallowMultipleComponent]
+    public class FishingSkill : MonoBehaviour, ITickable, ISaveable
+    {
+        [SerializeField] private XpTable xpTable;
+        [SerializeField] private Inventory.Inventory inventory;
+        [SerializeField] private Transform floatingTextAnchor;
+        [SerializeField] private MonoBehaviour saveProvider; // optional custom save provider
+
+        private IFishingSave save;
+
+        private int xp;
+        private int level;
+
+        private FishableSpot currentSpot;
+        private FishingToolDefinition currentTool;
+        private int catchProgress;
+        private int currentIntervalTicks;
+
+        private Dictionary<string, ItemData> fishItems;
+
+        public event System.Action<FishableSpot> OnStartFishing;
+        public event System.Action OnStopFishing;
+        public event System.Action<string, int> OnFishCaught;
+        public event System.Action<int> OnLevelUp;
+
+        public int Level => level;
+        public int Xp => xp;
+        public bool IsFishing => currentSpot != null;
+        public FishableSpot CurrentSpot => currentSpot;
+        public FishingToolDefinition CurrentTool => currentTool;
+        public float CatchProgressNormalized => currentIntervalTicks <= 1 ? 0f : (float)catchProgress / (currentIntervalTicks - 1);
+        public int CurrentCatchIntervalTicks => currentIntervalTicks;
+
+        private Coroutine tickerCoroutine;
+
+        private void Awake()
+        {
+            if (inventory == null)
+                inventory = GetComponent<Inventory.Inventory>();
+            save = saveProvider as IFishingSave ?? new SaveManagerFishingSave();
+            PreloadFishItems();
+        }
+
+        private void OnEnable()
+        {
+            SaveManager.Register(this);
+            TrySubscribeToTicker();
+            StartCoroutine(SaveLoop());
+        }
+
+        private void OnDisable()
+        {
+            if (Ticker.Instance != null)
+                Ticker.Instance.Unsubscribe(this);
+            if (tickerCoroutine != null)
+                StopCoroutine(tickerCoroutine);
+            Save();
+            SaveManager.Unregister(this);
+        }
+
+        private void TrySubscribeToTicker()
+        {
+            if (Ticker.Instance != null)
+            {
+                Ticker.Instance.Subscribe(this);
+            }
+            else
+            {
+                tickerCoroutine = StartCoroutine(WaitForTicker());
+            }
+        }
+
+        private IEnumerator WaitForTicker()
+        {
+            while (Ticker.Instance == null)
+                yield return null;
+            Ticker.Instance.Subscribe(this);
+        }
+
+        private IEnumerator SaveLoop()
+        {
+            while (true)
+            {
+                yield return new WaitForSeconds(10f);
+                Save();
+            }
+        }
+
+        public void OnTick()
+        {
+            if (!IsFishing)
+                return;
+            if (currentSpot == null || currentSpot.IsDepleted)
+            {
+                StopFishing();
+                return;
+            }
+            catchProgress++;
+            if (catchProgress >= currentIntervalTicks)
+            {
+                catchProgress = 0;
+                AttemptCatch();
+            }
+        }
+
+        private void AttemptCatch()
+        {
+            var fish = GetBestFish(currentSpot.def);
+            if (fish == null)
+            {
+                StopFishing();
+                return;
+            }
+
+            float baseChance = 0.35f;
+            float penalty = 0.0025f * Mathf.Max(fish.RequiredLevel - 1, 0);
+            float chance = baseChance + (level * 0.005f) + currentTool.CatchBonus * 0.01f - penalty;
+            chance = Mathf.Clamp(chance, 0.05f, 0.90f);
+
+            if (Random.value <= chance)
+            {
+                fishItems.TryGetValue(fish.ItemId, out var item);
+                bool added = false;
+                if (item != null && inventory != null)
+                    added = inventory.AddItem(item);
+
+                Transform anchor = floatingTextAnchor != null ? floatingTextAnchor : transform;
+                if (!added)
+                {
+                    FloatingText.Show("Your inventory is full", anchor.position);
+                    StopFishing();
+                    return;
+                }
+
+                xp += fish.Xp;
+                FloatingText.Show($"+1 {fish.DisplayName}", anchor.position);
+                StartCoroutine(ShowXpGainDelayed(fish.Xp, anchor));
+                OnFishCaught?.Invoke(fish.Id, 1);
+
+                int newLevel = xpTable.GetLevel(xp);
+                if (newLevel > level)
+                {
+                    level = newLevel;
+                    FloatingText.Show($"Fishing level {level}", anchor.position);
+                    OnLevelUp?.Invoke(level);
+                }
+
+                currentSpot.OnFishCaught();
+                if (currentSpot.IsDepleted)
+                    StopFishing();
+            }
+        }
+
+        private FishDefinition GetBestFish(FishingSpotDefinition spot)
+        {
+            if (spot == null) return null;
+            FishDefinition best = null;
+            foreach (var f in spot.AvailableFish)
+            {
+                if (f != null && level >= f.RequiredLevel)
+                    best = f;
+            }
+            return best;
+        }
+
+        private IEnumerator ShowXpGainDelayed(int gain, Transform anchor)
+        {
+            yield return new WaitForSeconds(Ticker.TickDuration * 5f);
+            if (anchor != null)
+                FloatingText.Show($"+{gain} XP", anchor.position);
+        }
+
+        public void StartFishing(FishableSpot spot, FishingToolDefinition tool)
+        {
+            if (spot == null || tool == null)
+                return;
+            currentSpot = spot;
+            currentTool = tool;
+            catchProgress = 0;
+            currentIntervalTicks = Mathf.Max(1, Mathf.RoundToInt(spot.def.CatchIntervalTicks / Mathf.Max(0.01f, tool.SwingSpeedMultiplier)));
+            currentSpot.IsBusy = true;
+            OnStartFishing?.Invoke(spot);
+        }
+
+        public void StopFishing()
+        {
+            if (!IsFishing)
+                return;
+            if (currentSpot != null)
+                currentSpot.IsBusy = false;
+            currentSpot = null;
+            currentTool = null;
+            catchProgress = 0;
+            currentIntervalTicks = 0;
+            OnStopFishing?.Invoke();
+        }
+
+        public bool CanAddFish(FishDefinition fish)
+        {
+            if (inventory == null || fish == null)
+                return true;
+            if (fishItems == null)
+                PreloadFishItems();
+            if (!fishItems.TryGetValue(fish.ItemId, out var item) || item == null)
+                return true;
+            return inventory.CanAddItem(item);
+        }
+
+        public void DebugSetLevel(int newLevel)
+        {
+            if (xpTable == null)
+                return;
+            newLevel = Mathf.Clamp(newLevel, 1, 99);
+            xp = xpTable.GetXpForLevel(newLevel);
+            level = newLevel;
+            OnLevelUp?.Invoke(level);
+        }
+
+        public void Save()
+        {
+            save.SaveXp(xp);
+        }
+
+        public void Load()
+        {
+            xp = save.LoadXp();
+            level = xpTable != null ? xpTable.GetLevel(xp) : 1;
+        }
+
+        private void PreloadFishItems()
+        {
+            fishItems = new Dictionary<string, ItemData>();
+            var items = Resources.LoadAll<ItemData>("Item");
+            foreach (var item in items)
+            {
+                if (!string.IsNullOrEmpty(item.id))
+                    fishItems[item.id] = item;
+            }
+        }
+    }
+
+    public interface IFishingSave
+    {
+        int LoadXp();
+        void SaveXp(int xp);
+    }
+
+    public class SaveManagerFishingSave : IFishingSave
+    {
+        private const string Key = "fishing_xp";
+
+        public int LoadXp()
+        {
+            return SaveManager.Load<int>(Key);
+        }
+
+        public void SaveXp(int xp)
+        {
+            SaveManager.Save(Key, xp);
+        }
+    }
+}

--- a/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs.meta
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dd3b78d5e1484c5981fe06cfaf08763d

--- a/Assets/Scripts/Skills/Fishing/Core/FishingToolToUse.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingToolToUse.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using Inventory;
+
+namespace Skills.Fishing
+{
+    [DisallowMultipleComponent]
+    public class FishingToolToUse : MonoBehaviour
+    {
+        [SerializeField] private List<FishingToolDefinition> allTools = new List<FishingToolDefinition>();
+        [SerializeField] private Inventory.Inventory inventory;
+        [SerializeField] private Inventory.Equipment equipment;
+        [SerializeField] private FishingSkill skill;
+
+        public FishingToolDefinition Current { get; private set; }
+
+        private void Awake()
+        {
+            if (inventory == null)
+                inventory = GetComponent<Inventory.Inventory>();
+            if (equipment == null)
+                equipment = GetComponent<Inventory.Equipment>();
+            if (skill == null)
+                skill = GetComponent<FishingSkill>();
+        }
+
+        public FishingToolDefinition GetBestTool()
+        {
+            Refresh();
+            return Current;
+        }
+
+        public void Refresh()
+        {
+            Current = null;
+            if (inventory == null || skill == null)
+                return;
+
+            foreach (var tool in allTools.OrderByDescending(t => t.CatchBonus))
+            {
+                var item = Resources.Load<ItemData>("Item/" + tool.Id);
+                if (item == null)
+                    continue;
+                if (inventory.GetItemCount(item) > 0 && skill.Level >= tool.RequiredLevel)
+                {
+                    Current = tool;
+                    break;
+                }
+                else if (equipment != null)
+                {
+                    var entry = equipment.GetEquipped(EquipmentSlot.Weapon);
+                    if (entry.item == item && skill.Level >= tool.RequiredLevel)
+                    {
+                        Current = tool;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Skills/Fishing/Core/FishingToolToUse.cs.meta
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingToolToUse.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f0fb4a3603de46629f25f1dc0a93d5b5

--- a/Assets/Scripts/Skills/Fishing/Data.meta
+++ b/Assets/Scripts/Skills/Fishing/Data.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2c6b60d1bf53436bbc69d44ed612ffa7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Skills/Fishing/Data/FishDefinition.cs
+++ b/Assets/Scripts/Skills/Fishing/Data/FishDefinition.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+
+namespace Skills.Fishing
+{
+    [CreateAssetMenu(menuName = "Skills/Fishing/Fish Definition")]
+    public class FishDefinition : ScriptableObject
+    {
+        [Header("Identification")]
+        [SerializeField] private string id;
+        [SerializeField] private string displayName;
+
+        [Header("Requirements")]
+        [SerializeField] private int requiredLevel = 1;
+
+        [Header("Rewards")]
+        [SerializeField] private int xp = 10;
+        [SerializeField] private string itemId;
+
+        public string Id => id;
+        public string DisplayName => displayName;
+        public int RequiredLevel => requiredLevel;
+        public int Xp => xp;
+        public string ItemId => itemId;
+    }
+}

--- a/Assets/Scripts/Skills/Fishing/Data/FishDefinition.cs.meta
+++ b/Assets/Scripts/Skills/Fishing/Data/FishDefinition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e1f620b4fa8542bcb38d964538bf97d8

--- a/Assets/Scripts/Skills/Fishing/Data/FishingSpotDefinition.cs
+++ b/Assets/Scripts/Skills/Fishing/Data/FishingSpotDefinition.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Skills.Fishing
+{
+    [CreateAssetMenu(menuName = "Skills/Fishing/Spot Definition")]
+    public class FishingSpotDefinition : ScriptableObject
+    {
+        [Header("Identification")]
+        [SerializeField] private string id;
+
+        [Header("Fish")]
+        [SerializeField] private List<FishDefinition> availableFish = new();
+
+        [Header("Depletion")]
+        [SerializeField] private bool depletesAfterCatch = false;
+        [SerializeField] private int depleteRollInverse = 8;
+
+        [Header("Respawn")]
+        [SerializeField] private int respawnSeconds = 5;
+
+        [Header("Catch Timing")]
+        [SerializeField] private int catchIntervalTicks = 4;
+
+        [Header("Ranges")]
+        [SerializeField] private float interactRange = 1.5f;
+        [SerializeField] private float cancelDistance = 3f;
+
+        public string Id => id;
+        public List<FishDefinition> AvailableFish => availableFish;
+        public bool DepletesAfterCatch => depletesAfterCatch;
+        public int DepleteRollInverse => depleteRollInverse;
+        public int RespawnSeconds => respawnSeconds;
+        public int CatchIntervalTicks => catchIntervalTicks;
+        public float InteractRange => interactRange;
+        public float CancelDistance => cancelDistance;
+    }
+}

--- a/Assets/Scripts/Skills/Fishing/Data/FishingSpotDefinition.cs.meta
+++ b/Assets/Scripts/Skills/Fishing/Data/FishingSpotDefinition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 29e2ea8386a6462d9b08c4a8243f38a1

--- a/Assets/Scripts/Skills/Fishing/Data/FishingToolDefinition.cs
+++ b/Assets/Scripts/Skills/Fishing/Data/FishingToolDefinition.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+
+namespace Skills.Fishing
+{
+    [CreateAssetMenu(menuName = "Skills/Fishing/Tool Definition")]
+    public class FishingToolDefinition : ScriptableObject
+    {
+        [Header("Identification")]
+        [SerializeField] private string id;
+        [SerializeField] private string displayName;
+
+        [Header("Requirements")]
+        [SerializeField] private int requiredLevel = 1;
+
+        [Header("Stats")]
+        [SerializeField] private float swingSpeedMultiplier = 1f;
+        [SerializeField] private int catchBonus = 0;
+        [SerializeField] private string baitItemId;
+
+        [Header("Visuals")]
+        [SerializeField] private Sprite icon;
+
+        public string Id => id;
+        public string DisplayName => displayName;
+        public int RequiredLevel => requiredLevel;
+        public float SwingSpeedMultiplier => swingSpeedMultiplier;
+        public int CatchBonus => catchBonus;
+        public string BaitItemId => baitItemId;
+        public Sprite Icon => icon;
+    }
+}

--- a/Assets/Scripts/Skills/Fishing/Data/FishingToolDefinition.cs.meta
+++ b/Assets/Scripts/Skills/Fishing/Data/FishingToolDefinition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dbe34942ecc14b96a2b60f7ce249549a

--- a/Assets/Scripts/Skills/Fishing/UI.meta
+++ b/Assets/Scripts/Skills/Fishing/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8a67f52c9ea4470ebcecc24a45769d11
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Skills/Fishing/UI/FishingHUD.cs
+++ b/Assets/Scripts/Skills/Fishing/UI/FishingHUD.cs
@@ -1,0 +1,196 @@
+using Inventory;
+using UnityEngine;
+using UnityEngine.UI;
+using Util;
+
+namespace Skills.Fishing
+{
+    public class FishingHUD : MonoBehaviour, ITickable
+    {
+        private FishingSkill skill;
+        private Transform target;
+        private Image progressImage;
+        private GameObject progressRoot;
+        private GameObject toolRoot;
+        private SpriteRenderer toolRenderer;
+        private Canvas progressCanvas;
+        private readonly Vector3 offset = new Vector3(0f, 0.75f, 0f);
+        private readonly Vector3 toolOffset = Vector3.zero;
+
+        private float currentFill;
+        private float nextFill;
+        private float tickTimer;
+        private float step;
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void CreateInstance()
+        {
+            if (UnityEngine.Object.FindObjectOfType<FishingHUD>() != null)
+                return;
+
+            var go = new GameObject("FishingHUD");
+            UnityEngine.Object.DontDestroyOnLoad(go);
+            go.AddComponent<FishingHUD>();
+        }
+
+        private void Awake()
+        {
+            skill = FindObjectOfType<FishingSkill>();
+
+            if (skill != null)
+            {
+                skill.OnStartFishing += HandleStart;
+                skill.OnStopFishing += HandleStop;
+            }
+
+            CreateProgressBar();
+            CreateToolSprite();
+        }
+
+        private void CreateProgressBar()
+        {
+            progressRoot = new GameObject("FishingProgress");
+            progressRoot.transform.SetParent(transform);
+
+            progressCanvas = progressRoot.AddComponent<Canvas>();
+            progressCanvas.renderMode = RenderMode.WorldSpace;
+            progressCanvas.overrideSorting = true;
+            progressRoot.AddComponent<CanvasScaler>();
+            progressRoot.AddComponent<GraphicRaycaster>();
+            progressRoot.transform.localScale = Vector3.one * 0.01f;
+
+            var bg = new GameObject("Background");
+            bg.transform.SetParent(progressRoot.transform, false);
+            var bgImage = bg.AddComponent<Image>();
+            bgImage.color = new Color(0f, 0f, 0f, 0.5f);
+            var bgSprite = Sprite.Create(Texture2D.whiteTexture, new Rect(0, 0, 1, 1), new Vector2(0.5f, 0.5f));
+            bgImage.sprite = bgSprite;
+            var bgRect = bgImage.rectTransform;
+            bgRect.sizeDelta = new Vector2(150f, 25f);
+
+            var fill = new GameObject("Fill");
+            fill.transform.SetParent(bg.transform, false);
+            progressImage = fill.AddComponent<Image>();
+            progressImage.color = Color.blue;
+            progressImage.sprite = bgSprite;
+            progressImage.type = Image.Type.Filled;
+            progressImage.fillMethod = Image.FillMethod.Horizontal;
+            progressImage.fillAmount = 0f;
+            var fillRect = progressImage.rectTransform;
+            fillRect.anchorMin = Vector2.zero;
+            fillRect.anchorMax = Vector2.one;
+            fillRect.offsetMin = Vector2.zero;
+            fillRect.offsetMax = Vector2.zero;
+
+            progressRoot.SetActive(false);
+        }
+
+        private void CreateToolSprite()
+        {
+            toolRoot = new GameObject("FishingTool");
+            toolRoot.transform.SetParent(transform);
+            toolRenderer = toolRoot.AddComponent<SpriteRenderer>();
+            toolRenderer.sortingOrder = 100;
+            toolRoot.SetActive(false);
+        }
+
+        private void HandleStart(FishableSpot spot)
+        {
+            target = spot.transform;
+            progressImage.fillAmount = 0f;
+            currentFill = 0f;
+            tickTimer = 0f;
+            step = skill.CurrentCatchIntervalTicks > 0 ? 1f / skill.CurrentCatchIntervalTicks : 0f;
+            nextFill = step;
+            progressRoot.SetActive(true);
+
+            var tool = skill.CurrentTool;
+            if (tool != null && toolRenderer != null)
+            {
+                var item = Resources.Load<ItemData>("Item/" + tool.Id);
+                if (item != null && item.icon != null)
+                {
+                    toolRenderer.sprite = item.icon;
+                    toolRoot.SetActive(true);
+                }
+            }
+
+            var targetRenderer = spot.GetComponent<SpriteRenderer>();
+            if (targetRenderer != null)
+            {
+                if (progressCanvas != null)
+                {
+                    progressCanvas.sortingLayerID = targetRenderer.sortingLayerID;
+                    progressCanvas.sortingOrder = targetRenderer.sortingOrder + 1;
+                }
+                if (toolRenderer != null)
+                {
+                    toolRenderer.sortingLayerID = targetRenderer.sortingLayerID;
+                    toolRenderer.sortingOrder = targetRenderer.sortingOrder + 2;
+                }
+            }
+
+            if (Ticker.Instance != null)
+                Ticker.Instance.Subscribe(this);
+        }
+
+        private void HandleStop()
+        {
+            target = null;
+            progressRoot.SetActive(false);
+            if (toolRoot != null)
+            {
+                toolRoot.SetActive(false);
+                if (toolRenderer != null)
+                    toolRenderer.sprite = null;
+            }
+            if (Ticker.Instance != null)
+                Ticker.Instance.Unsubscribe(this);
+        }
+
+        private void Update()
+        {
+            if (target == null || progressImage == null || skill == null)
+                return;
+
+            progressRoot.transform.position = target.position + offset;
+            if (toolRoot != null && toolRoot.activeSelf)
+                toolRoot.transform.position = target.position + toolOffset;
+
+            tickTimer += Time.deltaTime;
+            float t = Mathf.Clamp01(tickTimer / Ticker.TickDuration);
+            progressImage.fillAmount = Mathf.Lerp(currentFill, nextFill, t);
+        }
+
+        public void OnTick()
+        {
+            if (target == null || skill == null || !skill.IsFishing)
+                return;
+
+            tickTimer = 0f;
+            currentFill = nextFill;
+
+            if (currentFill >= 1f - step)
+            {
+                currentFill = 0f;
+                nextFill = step;
+            }
+            else
+            {
+                nextFill = Mathf.Min(1f, currentFill + step);
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (skill != null)
+            {
+                skill.OnStartFishing -= HandleStart;
+                skill.OnStopFishing -= HandleStop;
+            }
+
+            if (Ticker.Instance != null)
+                Ticker.Instance.Unsubscribe(this);
+        }
+    }
+}

--- a/Assets/Scripts/Skills/Fishing/UI/FishingHUD.cs.meta
+++ b/Assets/Scripts/Skills/Fishing/UI/FishingHUD.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a22d5130b22d4f5ba546f1105ad9d1f8

--- a/Assets/Scripts/Skills/Fishing/UI/SpotRespawnLabel.cs
+++ b/Assets/Scripts/Skills/Fishing/UI/SpotRespawnLabel.cs
@@ -1,0 +1,113 @@
+using TMPro;
+using UnityEngine;
+
+namespace Skills.Fishing
+{
+    public class SpotRespawnLabel : MonoBehaviour
+    {
+        [SerializeField] private Color textColor = Color.white;
+        [SerializeField] private int fontSize = 32;
+        [SerializeField] private TMP_FontAsset font;
+        [SerializeField] private Color outlineColor = Color.black;
+        [SerializeField] private float outlineWidth = 0f;
+
+        private FishableSpot spot;
+        private TMP_Text tmp;
+        private Transform labelTransform;
+        private float remaining;
+        private bool counting;
+
+        private void Awake()
+        {
+            spot = GetComponent<FishableSpot>();
+            if (spot == null)
+                spot = GetComponentInParent<FishableSpot>();
+            CreateLabel();
+        }
+
+        private void OnEnable()
+        {
+            if (spot != null)
+            {
+                spot.OnSpotDepleted += HandleDepleted;
+                spot.OnSpotRespawned += HandleRespawned;
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (spot != null)
+            {
+                spot.OnSpotDepleted -= HandleDepleted;
+                spot.OnSpotRespawned -= HandleRespawned;
+            }
+        }
+
+        private void CreateLabel()
+        {
+            if (spot == null || labelTransform != null)
+                return;
+
+            var existing = spot.transform.Find("SpotRespawnLabel");
+            if (existing != null)
+            {
+                labelTransform = existing;
+                tmp = existing.GetComponent<TMP_Text>();
+                if (tmp == null)
+                    tmp = existing.gameObject.AddComponent<TextMeshPro>();
+            }
+            else
+            {
+                var go = new GameObject("SpotRespawnLabel");
+                labelTransform = go.transform;
+                labelTransform.SetParent(spot.transform, false);
+
+                tmp = go.AddComponent<TextMeshPro>();
+                tmp.alignment = TextAlignmentOptions.Center;
+                tmp.color = textColor;
+                tmp.fontSize = fontSize;
+                tmp.enableWordWrapping = false;
+                if (font != null) tmp.font = font;
+                if (outlineWidth > 0f)
+                {
+                    tmp.outlineWidth = outlineWidth;
+                    tmp.outlineColor = outlineColor;
+                }
+            }
+
+            labelTransform.gameObject.SetActive(false);
+        }
+
+        private void HandleDepleted(FishableSpot node, float respawnSeconds)
+        {
+            if (labelTransform == null)
+                return;
+            remaining = respawnSeconds;
+            counting = true;
+            labelTransform.gameObject.SetActive(true);
+        }
+
+        private void HandleRespawned(FishableSpot node)
+        {
+            counting = false;
+            if (labelTransform != null)
+                labelTransform.gameObject.SetActive(false);
+        }
+
+        private void Update()
+        {
+            if (!counting || tmp == null)
+                return;
+            remaining -= Time.deltaTime;
+            if (remaining <= 0f)
+            {
+                counting = false;
+                labelTransform.gameObject.SetActive(false);
+            }
+            else
+            {
+                tmp.text = $"Respawns in {Mathf.CeilToInt(remaining)}s";
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Skills/Fishing/UI/SpotRespawnLabel.cs.meta
+++ b/Assets/Scripts/Skills/Fishing/UI/SpotRespawnLabel.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5e61b948f26241f8ab8f5a49be7c988d

--- a/Assets/Scripts/Skills/SkillType.cs
+++ b/Assets/Scripts/Skills/SkillType.cs
@@ -14,6 +14,7 @@ namespace Skills
         Hitpoints,
         Attack,
         Strength,
-        Defence
+        Defence,
+        Fishing
     }
 }

--- a/Assets/Scripts/Skills/SkillsDebugMenu.cs
+++ b/Assets/Scripts/Skills/SkillsDebugMenu.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using Player;
 using Skills.Mining;
 using Skills.Woodcutting;
+using Skills.Fishing;
 using Beastmaster;
 
 namespace Skills
@@ -16,6 +17,7 @@ namespace Skills
         private SkillManager skillManager;
         private MiningSkill miningSkill;
         private WoodcuttingSkill woodcuttingSkill;
+        private FishingSkill fishingSkill;
         private IBeastmasterService beastmasterService;
         private MergeConfig mergeConfig;
 
@@ -26,6 +28,7 @@ namespace Skills
         private string defenceLevel = "";
         private string miningLevel = "";
         private string woodcuttingLevel = "";
+        private string fishingLevel = "";
         private string beastmasterLevel = "";
 
         // Scroll position for the debug menu
@@ -68,6 +71,8 @@ namespace Skills
                 miningSkill = FindObjectOfType<MiningSkill>();
             if (woodcuttingSkill == null)
                 woodcuttingSkill = FindObjectOfType<WoodcuttingSkill>();
+            if (fishingSkill == null)
+                fishingSkill = FindObjectOfType<FishingSkill>();
             if (beastmasterService == null)
             {
                 foreach (var mb in FindObjectsOfType<MonoBehaviour>())
@@ -87,6 +92,7 @@ namespace Skills
             skillManager = FindObjectOfType<SkillManager>();
             miningSkill = FindObjectOfType<MiningSkill>();
             woodcuttingSkill = FindObjectOfType<WoodcuttingSkill>();
+            fishingSkill = FindObjectOfType<FishingSkill>();
             beastmasterService = null;
             foreach (var mb in FindObjectsOfType<MonoBehaviour>())
             {
@@ -105,6 +111,7 @@ namespace Skills
             defenceLevel = skillManager != null ? skillManager.GetLevel(SkillType.Defence).ToString() : "";
             miningLevel = miningSkill != null ? miningSkill.Level.ToString() : "";
             woodcuttingLevel = woodcuttingSkill != null ? woodcuttingSkill.Level.ToString() : "";
+            fishingLevel = fishingSkill != null ? fishingSkill.Level.ToString() : "";
             beastmasterLevel = beastmasterService != null ? beastmasterService.CurrentLevel.ToString() : "";
         }
 
@@ -139,6 +146,9 @@ namespace Skills
             GUILayout.Label("Woodcutting Level");
             woodcuttingLevel = GUILayout.TextField(woodcuttingLevel);
 
+            GUILayout.Label("Fishing Level");
+            fishingLevel = GUILayout.TextField(fishingLevel);
+
             GUILayout.Label("Beastmaster Level");
             beastmasterLevel = GUILayout.TextField(beastmasterLevel);
             if (mergeConfig != null && int.TryParse(beastmasterLevel, out var bmLevel))
@@ -166,6 +176,8 @@ namespace Skills
                     miningSkill.DebugSetLevel(mine);
                 if (woodcuttingSkill != null && int.TryParse(woodcuttingLevel, out var wood))
                     woodcuttingSkill.DebugSetLevel(wood);
+                if (fishingSkill != null && int.TryParse(fishingLevel, out var fish))
+                    fishingSkill.DebugSetLevel(fish);
                 if (beastmasterService != null && int.TryParse(beastmasterLevel, out var bm))
                     beastmasterService.SetLevel(Mathf.Clamp(bm, 1, 99));
 

--- a/Assets/Scripts/Skills/SkillsUI.cs
+++ b/Assets/Scripts/Skills/SkillsUI.cs
@@ -16,6 +16,7 @@ namespace Skills
         private Text skillText;
         private Mining.MiningSkill miningSkill;
         private Woodcutting.WoodcuttingSkill woodcuttingSkill;
+        private Fishing.FishingSkill fishingSkill;
         private PlayerHitpoints hitpoints;
         private SkillManager skillManager;
 
@@ -46,6 +47,7 @@ namespace Skills
 
             miningSkill = FindObjectOfType<Mining.MiningSkill>();
             woodcuttingSkill = FindObjectOfType<Woodcutting.WoodcuttingSkill>();
+            fishingSkill = FindObjectOfType<Fishing.FishingSkill>();
             hitpoints = FindObjectOfType<PlayerHitpoints>();
             skillManager = FindObjectOfType<SkillManager>();
             CreateUI();
@@ -146,6 +148,12 @@ namespace Skills
                     if (text.Length > 0)
                         text += "\n";
                     text += $"Woodcutting Level: {woodcuttingSkill.Level}  XP: {woodcuttingSkill.Xp}";
+                }
+                if (fishingSkill != null)
+                {
+                    if (text.Length > 0)
+                        text += "\n";
+                    text += $"Fishing Level: {fishingSkill.Level}  XP: {fishingSkill.Xp}";
                 }
                 skillText.text = text;
             }


### PR DESCRIPTION
## Summary
- add `Fishing` to skill enum with UI and debug hooks
- implement fishing data definitions and core skill logic
- provide sample ScriptableObject assets and HUD for fishing

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68af5c5c6d30832eb03862b64e255aa2