### PR TITLE
Build BookUI at runtime

### DIFF
--- a/Assets/Scripts/UI/BookUI.cs
+++ b/Assets/Scripts/UI/BookUI.cs
@@ -38,6 +38,8 @@ namespace UI
             }
             Instance = this;
             DontDestroyOnLoad(gameObject);
+            if (titleText == null || pageText == null || nextButton == null || prevButton == null || closeButton == null)
+                CreateUI();
             // Attempt to auto-bind UI components if they haven't been set in the Inspector
             if (titleText == null)
             {
@@ -99,6 +101,124 @@ namespace UI
             if (closeButton != null) closeButton.onClick.AddListener(Close);
             gameObject.SetActive(false);
             UIManager.Instance.RegisterWindow(this);
+        }
+
+        private void CreateUI()
+        {
+            var canvas = gameObject.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            gameObject.AddComponent<CanvasScaler>();
+            gameObject.AddComponent<GraphicRaycaster>();
+
+            var panel = new GameObject("Panel", typeof(Image));
+            panel.transform.SetParent(transform, false);
+            var panelImage = panel.GetComponent<Image>();
+            panelImage.color = new Color(0f, 0f, 0f, 0.5f);
+            var panelRect = panel.GetComponent<RectTransform>();
+            panelRect.sizeDelta = new Vector2(300f, 200f);
+            panelRect.anchorMin = new Vector2(0.5f, 0.5f);
+            panelRect.anchorMax = new Vector2(0.5f, 0.5f);
+            panelRect.pivot = new Vector2(0.5f, 0.5f);
+            panelRect.anchoredPosition = Vector2.zero;
+
+            var font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+
+            var titleGO = new GameObject("TitleText", typeof(Text));
+            titleGO.transform.SetParent(panel.transform, false);
+            titleText = titleGO.GetComponent<Text>();
+            titleText.font = font;
+            titleText.alignment = TextAnchor.MiddleCenter;
+            titleText.color = Color.white;
+            var titleRect = titleText.rectTransform;
+            titleRect.anchorMin = new Vector2(0f, 1f);
+            titleRect.anchorMax = new Vector2(1f, 1f);
+            titleRect.pivot = new Vector2(0.5f, 1f);
+            titleRect.sizeDelta = new Vector2(0f, 30f);
+            titleRect.anchoredPosition = Vector2.zero;
+
+            var closeGO = new GameObject("CloseButton", typeof(Image), typeof(Button));
+            closeGO.transform.SetParent(panel.transform, false);
+            closeButton = closeGO.GetComponent<Button>();
+            var closeRect = closeGO.GetComponent<RectTransform>();
+            closeRect.anchorMin = new Vector2(1f, 1f);
+            closeRect.anchorMax = new Vector2(1f, 1f);
+            closeRect.pivot = new Vector2(1f, 1f);
+            closeRect.sizeDelta = new Vector2(20f, 20f);
+            closeRect.anchoredPosition = new Vector2(-5f, -5f);
+            var closeImg = closeGO.GetComponent<Image>();
+            closeImg.color = Color.red;
+            var closeTextGO = new GameObject("Text", typeof(Text));
+            closeTextGO.transform.SetParent(closeGO.transform, false);
+            var closeText = closeTextGO.GetComponent<Text>();
+            closeText.font = font;
+            closeText.alignment = TextAnchor.MiddleCenter;
+            closeText.color = Color.white;
+            closeText.text = "X";
+            var closeTextRect = closeText.rectTransform;
+            closeTextRect.anchorMin = Vector2.zero;
+            closeTextRect.anchorMax = Vector2.one;
+            closeTextRect.offsetMin = Vector2.zero;
+            closeTextRect.offsetMax = Vector2.zero;
+
+            var pageGO = new GameObject("PageText", typeof(Text));
+            pageGO.transform.SetParent(panel.transform, false);
+            pageText = pageGO.GetComponent<Text>();
+            pageText.font = font;
+            pageText.alignment = TextAnchor.UpperLeft;
+            pageText.color = Color.white;
+            var pageRect = pageText.rectTransform;
+            pageRect.anchorMin = new Vector2(0f, 0f);
+            pageRect.anchorMax = new Vector2(1f, 1f);
+            pageRect.offsetMin = new Vector2(10f, 40f);
+            pageRect.offsetMax = new Vector2(-10f, -40f);
+
+            var prevGO = new GameObject("PrevButton", typeof(Image), typeof(Button));
+            prevGO.transform.SetParent(panel.transform, false);
+            prevButton = prevGO.GetComponent<Button>();
+            var prevRect = prevGO.GetComponent<RectTransform>();
+            prevRect.anchorMin = new Vector2(0f, 0f);
+            prevRect.anchorMax = new Vector2(0f, 0f);
+            prevRect.pivot = new Vector2(0f, 0f);
+            prevRect.sizeDelta = new Vector2(60f, 25f);
+            prevRect.anchoredPosition = new Vector2(10f, 10f);
+            var prevImg = prevGO.GetComponent<Image>();
+            prevImg.color = Color.gray;
+            var prevTextGO = new GameObject("Text", typeof(Text));
+            prevTextGO.transform.SetParent(prevGO.transform, false);
+            var prevText = prevTextGO.GetComponent<Text>();
+            prevText.font = font;
+            prevText.alignment = TextAnchor.MiddleCenter;
+            prevText.color = Color.white;
+            prevText.text = "Prev";
+            var prevTextRect = prevText.rectTransform;
+            prevTextRect.anchorMin = Vector2.zero;
+            prevTextRect.anchorMax = Vector2.one;
+            prevTextRect.offsetMin = Vector2.zero;
+            prevTextRect.offsetMax = Vector2.zero;
+
+            var nextGO = new GameObject("NextButton", typeof(Image), typeof(Button));
+            nextGO.transform.SetParent(panel.transform, false);
+            nextButton = nextGO.GetComponent<Button>();
+            var nextRect = nextGO.GetComponent<RectTransform>();
+            nextRect.anchorMin = new Vector2(1f, 0f);
+            nextRect.anchorMax = new Vector2(1f, 0f);
+            nextRect.pivot = new Vector2(1f, 0f);
+            nextRect.sizeDelta = new Vector2(60f, 25f);
+            nextRect.anchoredPosition = new Vector2(-10f, 10f);
+            var nextImg = nextGO.GetComponent<Image>();
+            nextImg.color = Color.gray;
+            var nextTextGO = new GameObject("Text", typeof(Text));
+            nextTextGO.transform.SetParent(nextGO.transform, false);
+            var nextText = nextTextGO.GetComponent<Text>();
+            nextText.font = font;
+            nextText.alignment = TextAnchor.MiddleCenter;
+            nextText.color = Color.white;
+            nextText.text = "Next";
+            var nextTextRect = nextText.rectTransform;
+            nextTextRect.anchorMin = Vector2.zero;
+            nextTextRect.anchorMax = Vector2.one;
+            nextTextRect.offsetMin = Vector2.zero;
+            nextTextRect.offsetMax = Vector2.zero;
         }
 
         public void Open(BookData data, int startPage)


### PR DESCRIPTION
## Summary
- Generate BookUI elements programmatically with a new `CreateUI` method
- Initialize UI during `Awake` when components are missing
- Hook navigation and close buttons to existing handlers

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b21a0016e0832ea3d3ee5a35113af9