### PR TITLE
Refactor books to single content string and TMP paging

### DIFF
--- a/Assets/Scripts/Books/BookData.cs
+++ b/Assets/Scripts/Books/BookData.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -8,6 +9,29 @@ namespace Books
     {
         public string id;
         public string title;
+        public string content;
+
+        [Obsolete("Use content instead")]
         public List<string> pages = new List<string>();
+
+        private const string PageSplit = "\f";
+
+        private void OnEnable()
+        {
+            if (string.IsNullOrEmpty(content) && pages != null && pages.Count > 0)
+            {
+                content = string.Join(PageSplit, pages);
+            }
+        }
+
+        public IEnumerable<string> GetPages()
+        {
+            if (!string.IsNullOrEmpty(content))
+            {
+                return content.Split(new[] { PageSplit }, StringSplitOptions.None);
+            }
+
+            return pages ?? new List<string>();
+        }
     }
 }

--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -212,8 +212,7 @@ namespace Inventory
             var entry = items[index];
             if (entry.item is BookItemData bookItem && bookItem.book != null)
             {
-                BookUI.Instance.Open(bookItem.book,
-                    BookProgressManager.Instance.GetPage(bookItem.book.id));
+                BookUI.Instance.Open(bookItem.book);
                 return true;
             }
 


### PR DESCRIPTION
## Summary
- Replace book page lists with single content string and deprecated legacy pages
- Rework BookUI to use TextMeshPro for page overflow and navigation
- Update inventory to open books without page indices

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b21d3f7f78832e87101f92cc03bb6e