### PR TITLE
Randomize fishing catches

### DIFF
--- a/Assets/Scripts/Skills/Fishing/Core/FisherController.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FisherController.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using Inventory;
@@ -115,21 +116,30 @@ namespace Skills.Fishing
                 return;
             }
 
-            FishDefinition catchable = null;
+            var eligibleFish = new List<FishDefinition>();
             int minLevel = int.MaxValue;
             foreach (var fish in spot.def.AvailableFish)
             {
                 if (fish == null) continue;
                 minLevel = Mathf.Min(minLevel, fish.RequiredLevel);
                 if (fishingSkill.Level >= fish.RequiredLevel)
-                    catchable = fish;
+                    eligibleFish.Add(fish);
             }
-            if (catchable == null)
+            if (eligibleFish.Count == 0)
             {
                 FloatingText.Show($"You need Fishing level {minLevel}", transform.position);
                 return;
             }
-            if (!fishingSkill.CanAddFish(catchable))
+            bool canAdd = false;
+            foreach (var fish in eligibleFish)
+            {
+                if (fishingSkill.CanAddFish(fish))
+                {
+                    canAdd = true;
+                    break;
+                }
+            }
+            if (!canAdd)
             {
                 FloatingText.Show("Your inventory is full", transform.position);
                 return;

--- a/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
@@ -115,7 +115,7 @@ namespace Skills.Fishing
 
         private void AttemptCatch()
         {
-            var fish = GetBestFish(currentSpot.def);
+            var fish = GetRandomFish(currentSpot.def);
             if (fish == null)
             {
                 StopFishing();
@@ -161,16 +161,18 @@ namespace Skills.Fishing
             }
         }
 
-        private FishDefinition GetBestFish(FishingSpotDefinition spot)
+        private FishDefinition GetRandomFish(FishingSpotDefinition spot)
         {
             if (spot == null) return null;
-            FishDefinition best = null;
+            var eligible = new List<FishDefinition>();
             foreach (var f in spot.AvailableFish)
             {
                 if (f != null && level >= f.RequiredLevel)
-                    best = f;
+                    eligible.Add(f);
             }
-            return best;
+            if (eligible.Count == 0)
+                return null;
+            return eligible[UnityEngine.Random.Range(0, eligible.Count)];
         }
 
         private IEnumerator ShowXpGainDelayed(int gain, Transform anchor)


### PR DESCRIPTION
## Summary
- choose random eligible fish instead of highest-level when catching
- ensure fishing starts only if at least one eligible fish fits in inventory

## Testing
- `dotnet test` *(fails: no project or solution file found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3614dfa80832e9e8fa5a73bb14182