### PR TITLE
Add tool restrictions and bait consumption for fishing

### DIFF
--- a/Assets/Resources/FishingDatabase/Shrimp Spot.asset
+++ b/Assets/Resources/FishingDatabase/Shrimp Spot.asset
@@ -12,11 +12,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 29e2ea8386a6462d9b08c4a8243f38a1, type: 3}
   m_Name: Shrimp Spot
   m_EditorClassIdentifier:
-  id: ShrimpSpot
-  availableFish:
-  - {fileID: 11400000, guid: e68477b5b0bf4d9fa51f24a3e3c4d079, type: 2}
-  depletesAfterCatch: 0
-  depleteRollInverse: 8
+    id: ShrimpSpot
+    availableFish:
+    - {fileID: 11400000, guid: e68477b5b0bf4d9fa51f24a3e3c4d079, type: 2}
+    allowedTools:
+    - {fileID: 11400000, guid: dbe34942ecc14b96a2b60f7ce249549a, type: 2}
+    depletesAfterCatch: 0
+    depleteRollInverse: 8
   respawnSeconds: 5
   catchIntervalTicks: 4
   interactRange: 1.5

--- a/Assets/Scripts/Skills/Fishing/Core/FisherController.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FisherController.cs
@@ -110,6 +110,23 @@ namespace Skills.Fishing
                 FloatingText.Show("You need a fishing tool", transform.position);
                 return;
             }
+            if (spot.def != null && spot.def.AllowedTools != null && spot.def.AllowedTools.Count > 0)
+            {
+                bool allowed = false;
+                foreach (var allowedTool in spot.def.AllowedTools)
+                {
+                    if (allowedTool != null && allowedTool.Id == tool.Id)
+                    {
+                        allowed = true;
+                        break;
+                    }
+                }
+                if (!allowed)
+                {
+                    FloatingText.Show("You can't use that tool here", transform.position);
+                    return;
+                }
+            }
             if (fishingSkill.Level < tool.RequiredLevel)
             {
                 FloatingText.Show($"You need Fishing level {tool.RequiredLevel}", transform.position);

--- a/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
@@ -121,6 +121,21 @@ namespace Skills.Fishing
                 StopFishing();
                 return;
             }
+            if (!string.IsNullOrEmpty(currentTool.BaitItemId))
+            {
+                Transform anchor = floatingTextAnchor != null ? floatingTextAnchor : transform;
+                if (inventory == null || !inventory.RemoveItem(currentTool.BaitItemId))
+                {
+                    FloatingText.Show("You need bait", anchor.position);
+                    StopFishing();
+                    return;
+                }
+                var baitItem = ItemDatabase.GetItem(currentTool.BaitItemId);
+                if (baitItem != null)
+                    FloatingText.Show($"-1 {baitItem.itemName}", anchor.position);
+                else
+                    FloatingText.Show("-1 bait", anchor.position);
+            }
 
             float baseChance = 0.35f;
             float penalty = 0.0025f * Mathf.Max(fish.RequiredLevel - 1, 0);
@@ -186,6 +201,15 @@ namespace Skills.Fishing
         {
             if (spot == null || tool == null)
                 return;
+            if (!string.IsNullOrEmpty(tool.BaitItemId))
+            {
+                if (inventory == null || !inventory.HasItem(tool.BaitItemId))
+                {
+                    Transform anchor = floatingTextAnchor != null ? floatingTextAnchor : transform;
+                    FloatingText.Show("You need bait", anchor.position);
+                    return;
+                }
+            }
             currentSpot = spot;
             currentTool = tool;
             catchProgress = 0;

--- a/Assets/Scripts/Skills/Fishing/Data/FishingSpotDefinition.cs
+++ b/Assets/Scripts/Skills/Fishing/Data/FishingSpotDefinition.cs
@@ -12,6 +12,9 @@ namespace Skills.Fishing
         [Header("Fish")]
         [SerializeField] private List<FishDefinition> availableFish = new();
 
+        [Header("Tools")]
+        [SerializeField] private List<FishingToolDefinition> allowedTools = new();
+
         [Header("Depletion")]
         [SerializeField] private bool depletesAfterCatch = false;
         [SerializeField] private int depleteRollInverse = 8;
@@ -28,6 +31,7 @@ namespace Skills.Fishing
 
         public string Id => id;
         public List<FishDefinition> AvailableFish => availableFish;
+        public List<FishingToolDefinition> AllowedTools => allowedTools;
         public bool DepletesAfterCatch => depletesAfterCatch;
         public int DepleteRollInverse => depleteRollInverse;
         public int RespawnSeconds => respawnSeconds;


### PR DESCRIPTION
## Summary
- allow fishing spots to declare allowed tools
- block fishing with disallowed tools
- enforce bait requirements and consumption during fishing

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b365b2dd54832eb704f7c1beb46682