### PR TITLE
Enable fishing spot-specific bait requirements

### DIFF
--- a/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
@@ -121,16 +121,16 @@ namespace Skills.Fishing
                 StopFishing();
                 return;
             }
-            if (!string.IsNullOrEmpty(currentTool.BaitItemId))
+            if (!string.IsNullOrEmpty(currentSpot.def.BaitItemId))
             {
                 Transform anchor = floatingTextAnchor != null ? floatingTextAnchor : transform;
-                if (inventory == null || !inventory.RemoveItem(currentTool.BaitItemId))
+                if (inventory == null || !inventory.RemoveItem(currentSpot.def.BaitItemId))
                 {
                     FloatingText.Show("You need bait", anchor.position);
                     StopFishing();
                     return;
                 }
-                var baitItem = ItemDatabase.GetItem(currentTool.BaitItemId);
+                var baitItem = ItemDatabase.GetItem(currentSpot.def.BaitItemId);
                 if (baitItem != null)
                     FloatingText.Show($"-1 {baitItem.itemName}", anchor.position);
                 else
@@ -201,9 +201,9 @@ namespace Skills.Fishing
         {
             if (spot == null || tool == null)
                 return;
-            if (!string.IsNullOrEmpty(tool.BaitItemId))
+            if (!string.IsNullOrEmpty(spot.def.BaitItemId))
             {
-                if (inventory == null || !inventory.HasItem(tool.BaitItemId))
+                if (inventory == null || !inventory.HasItem(spot.def.BaitItemId))
                 {
                     Transform anchor = floatingTextAnchor != null ? floatingTextAnchor : transform;
                     FloatingText.Show("You need bait", anchor.position);

--- a/Assets/Scripts/Skills/Fishing/Data/FishingSpotDefinition.cs
+++ b/Assets/Scripts/Skills/Fishing/Data/FishingSpotDefinition.cs
@@ -15,6 +15,9 @@ namespace Skills.Fishing
         [Header("Tools")]
         [SerializeField] private List<FishingToolDefinition> allowedTools = new();
 
+        [Header("Bait")]
+        [SerializeField] private string baitItemId;
+
         [Header("Depletion")]
         [SerializeField] private bool depletesAfterCatch = false;
         [SerializeField] private int depleteRollInverse = 8;
@@ -32,6 +35,7 @@ namespace Skills.Fishing
         public string Id => id;
         public List<FishDefinition> AvailableFish => availableFish;
         public List<FishingToolDefinition> AllowedTools => allowedTools;
+        public string BaitItemId => baitItemId;
         public bool DepletesAfterCatch => depletesAfterCatch;
         public int DepleteRollInverse => depleteRollInverse;
         public int RespawnSeconds => respawnSeconds;

--- a/Assets/Scripts/Skills/Fishing/Data/FishingToolDefinition.cs
+++ b/Assets/Scripts/Skills/Fishing/Data/FishingToolDefinition.cs
@@ -15,7 +15,6 @@ namespace Skills.Fishing
         [Header("Stats")]
         [SerializeField] private float swingSpeedMultiplier = 1f;
         [SerializeField] private int catchBonus = 0;
-        [SerializeField] private string baitItemId;
 
         [Header("Visuals")]
         [SerializeField] private Sprite icon;
@@ -25,7 +24,6 @@ namespace Skills.Fishing
         public int RequiredLevel => requiredLevel;
         public float SwingSpeedMultiplier => swingSpeedMultiplier;
         public int CatchBonus => catchBonus;
-        public string BaitItemId => baitItemId;
         public Sprite Icon => icon;
     }
 }


### PR DESCRIPTION
## Summary
- Remove bait requirement from fishing tool definitions so rods can reuse different baits
- Add bait field to fishing spot definitions and check bait consumption per spot
- Update fishing logic to use spot-defined bait

## Testing
- `dotnet build` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b369aaceac832e857d9011bbdda6e5