### PR TITLE
Expand skills menu height

### DIFF
--- a/Assets/Scripts/Skills/SkillsUI.cs
+++ b/Assets/Scripts/Skills/SkillsUI.cs
@@ -77,7 +77,7 @@ namespace Skills
             var panelImage = panel.AddComponent<Image>();
             panelImage.color = new Color(0f, 0f, 0f, 0.5f);
             var panelRect = panel.GetComponent<RectTransform>();
-            panelRect.sizeDelta = new Vector2(200f, 200f);
+            panelRect.sizeDelta = new Vector2(200f, 400f);
             panelRect.anchoredPosition = Vector2.zero;
 
             var textGo = new GameObject("SkillText");


### PR DESCRIPTION
## Summary
- Increase skills menu panel height to prevent skill name truncation

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b36cf27ba4832e9789e72d80ab2e8e