### PR TITLE
Add prospecting to fishing spots

### DIFF
--- a/Assets/Scripts/Skills/Fishing/Core/FishableSpot.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishableSpot.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 using Util;
+using Skills.Mining;
 using Random = UnityEngine.Random;
 
 namespace Skills.Fishing
@@ -85,6 +88,38 @@ namespace Skills.Fishing
             if (col) col.enabled = true;
             if (sr && activeSprite) sr.sprite = activeSprite;
             OnSpotRespawned?.Invoke(this);
+        }
+
+        public void Prospect(Transform requester)
+        {
+            StartCoroutine(ProspectRoutine(requester));
+        }
+
+        private IEnumerator ProspectRoutine(Transform requester)
+        {
+            if (requester == null)
+                yield break;
+
+            FloatingText.Show("Checking...", requester.position);
+            yield return new WaitForSeconds(Ticker.TickDuration * 2f);
+
+            var fishNames = new List<string>();
+            if (def != null && def.AvailableFish != null)
+            {
+                foreach (var fish in def.AvailableFish)
+                {
+                    if (fish != null)
+                        fishNames.Add(fish.DisplayName);
+                }
+            }
+
+            string message;
+            if (fishNames.Count == 1)
+                message = $"This spot contains {fishNames[0]} here";
+            else
+                message = $"This spot contains {string.Join(" & ", fishNames)} here";
+
+            FloatingText.Show(message, requester.position);
         }
     }
 }

--- a/Assets/Scripts/Skills/Fishing/Core/FisherController.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FisherController.cs
@@ -50,14 +50,19 @@ namespace Skills.Fishing
 
         private void Update()
         {
-            if (Input.GetMouseButtonDown(0))
+            bool pointerOverUI = EventSystem.current != null && EventSystem.current.IsPointerOverGameObject();
+
+            if (Input.GetMouseButtonDown(0) && !pointerOverUI)
             {
-                if (EventSystem.current == null || !EventSystem.current.IsPointerOverGameObject())
-                {
-                    var spot = GetSpotUnderCursor();
-                    if (spot != null)
-                        TryStartFishing(spot);
-                }
+                var spot = GetSpotUnderCursor();
+                if (spot != null)
+                    TryStartFishing(spot);
+            }
+            else if (Input.GetMouseButtonDown(1) && !pointerOverUI)
+            {
+                var spot = GetSpotUnderCursor();
+                if (spot != null)
+                    spot.Prospect(transform);
             }
 
             if (Input.GetKeyDown(KeyCode.Escape))


### PR DESCRIPTION
## Summary
- allow right-click prospecting on fishing spots
- prospect coroutine reveals available fish after short delay

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b3735a4240832e8dc1de124a0e18f9