### PR TITLE
Strip 'Raw' prefix from fish names when prospecting

### DIFF
--- a/Assets/Scripts/Skills/Fishing/Core/FishableSpot.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishableSpot.cs
@@ -109,7 +109,12 @@ namespace Skills.Fishing
                 foreach (var fish in def.AvailableFish)
                 {
                     if (fish != null)
-                        fishNames.Add(fish.DisplayName);
+                    {
+                        var cleanName = fish.DisplayName;
+                        if (cleanName.StartsWith("Raw "))
+                            cleanName = cleanName.Substring(4);
+                        fishNames.Add(cleanName);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- Clean fish names by removing `Raw ` prefix before displaying prospect results

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b375baf7bc832e97c841a7780a3534