### PR TITLE
Add fishing spot alpha oscillator

### DIFF
--- a/Assets/Scripts/Skills/Fishing/Core/FishableSpot.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishableSpot.cs
@@ -18,6 +18,7 @@ namespace Skills.Fishing
         [SerializeField] private SpriteRenderer sr;
         [SerializeField] private Sprite activeSprite;
         [SerializeField] private Sprite depletedSprite;
+        [SerializeField] private FishingSpotAlphaOscillator oscillator;
 
         public bool IsDepleted { get; private set; }
         public bool IsBusy { get; set; }
@@ -31,6 +32,8 @@ namespace Skills.Fishing
         {
             if (sr == null)
                 sr = GetComponent<SpriteRenderer>();
+            if (oscillator == null)
+                oscillator = GetComponent<FishingSpotAlphaOscillator>();
             if (def != null)
             {
                 if (activeSprite == null && sr != null) activeSprite = sr.sprite;
@@ -77,6 +80,16 @@ namespace Skills.Fishing
             var col = GetComponent<Collider2D>();
             if (col) col.enabled = false;
             if (sr && depletedSprite) sr.sprite = depletedSprite;
+            if (oscillator)
+            {
+                oscillator.enabled = false;
+                if (sr)
+                {
+                    var color = sr.color;
+                    color.a = 1f;
+                    sr.color = color;
+                }
+            }
             IsBusy = false;
             OnSpotDepleted?.Invoke(this, def != null ? def.RespawnSeconds : 0f);
         }
@@ -87,6 +100,7 @@ namespace Skills.Fishing
             var col = GetComponent<Collider2D>();
             if (col) col.enabled = true;
             if (sr && activeSprite) sr.sprite = activeSprite;
+            if (oscillator) oscillator.enabled = true;
             OnSpotRespawned?.Invoke(this);
         }
 

--- a/Assets/Scripts/Skills/Fishing/Core/FishingSpotAlphaOscillator.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingSpotAlphaOscillator.cs
@@ -1,0 +1,47 @@
+using UnityEngine;
+
+namespace Skills.Fishing
+{
+    public class FishingSpotAlphaOscillator : MonoBehaviour
+    {
+        [SerializeField] private SpriteRenderer sr;
+        [SerializeField] private float minAlpha = 0.5f;
+        [SerializeField] private float maxAlpha = 1f;
+        [SerializeField] private float minSpeed = 0.5f;
+        [SerializeField] private float maxSpeed = 1f;
+
+        private float targetAlpha;
+        private float speed;
+
+        private void Awake()
+        {
+            if (sr == null)
+                sr = GetComponent<SpriteRenderer>();
+            PickNewTarget();
+        }
+
+        private void OnEnable()
+        {
+            PickNewTarget();
+        }
+
+        private void Update()
+        {
+            if (sr == null)
+                return;
+
+            var color = sr.color;
+            color.a = Mathf.MoveTowards(color.a, targetAlpha, speed * Time.deltaTime);
+            sr.color = color;
+
+            if (Mathf.Approximately(color.a, targetAlpha))
+                PickNewTarget();
+        }
+
+        private void PickNewTarget()
+        {
+            targetAlpha = Random.Range(minAlpha, maxAlpha);
+            speed = Random.Range(minSpeed, maxSpeed);
+        }
+    }
+}

--- a/Assets/Scripts/Skills/Fishing/Core/FishingSpotAlphaOscillator.cs.meta
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingSpotAlphaOscillator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 90581566d53d4be4b1aa84ee185b03f7


### PR DESCRIPTION
## Summary
- Add FishingSpotAlphaOscillator to pulse sprite transparency at random speeds and targets
- Integrate oscillator into FishableSpot and toggle on depletion/respawn

## Testing
- `mcs Assets/Scripts/Skills/Fishing/Core/FishableSpot.cs Assets/Scripts/Skills/Fishing/Core/FishingSpotAlphaOscillator.cs -target:library` *(fails: missing UnityEngine references)*
- `dotnet test` *(fails: no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b3773636b4832ebb9f03eec3e4afe5