### PR TITLE
Fix fishing spot detection when colliders overlap

### DIFF
--- a/Assets/Scripts/Skills/Fishing/Core/FisherController.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FisherController.cs
@@ -93,9 +93,13 @@ namespace Skills.Fishing
             if (cam == null)
                 cam = Camera.main;
             Vector2 world = cam.ScreenToWorldPoint(Input.mousePosition);
-            var collider = Physics2D.OverlapPoint(world, spotMask);
-            if (collider != null)
-                return collider.GetComponentInParent<FishableSpot>();
+            var colliders = Physics2D.OverlapPointAll(world, spotMask);
+            foreach (var col in colliders)
+            {
+                var spot = col.GetComponentInParent<FishableSpot>();
+                if (spot != null)
+                    return spot;
+            }
             return null;
         }
 


### PR DESCRIPTION
## Summary
- Avoid missing fishing spots when clicking a location with multiple colliders by checking all colliders under the cursor

## Testing
- ⚠️ `dotnet test` *(no project or solution file found)*

------
https://chatgpt.com/codex/tasks/task_e_68b37ed6f704832ebb8f161ae17531ac