### PR TITLE
Add prospecting cooldown to miner and fisher controllers

### DIFF
--- a/Assets/Scripts/Skills/Fishing/Core/FisherController.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FisherController.cs
@@ -14,6 +14,8 @@ namespace Skills.Fishing
         [SerializeField] private float cancelDistance = 3f;
         [SerializeField] [Tooltip("Layers including fishing spots")] private LayerMask spotMask = ~0;
 
+        [SerializeField] private float prospectCooldown = 3f;
+
         [Header("References")]
         [SerializeField] private FishingSkill fishingSkill;
         [SerializeField] private FishingToolToUse toolSelector;
@@ -22,6 +24,7 @@ namespace Skills.Fishing
 
         private FishableSpot nearbySpot;
         private Camera cam;
+        private float nextInteractionTime = 0f;
 
         private void Awake()
         {
@@ -52,17 +55,23 @@ namespace Skills.Fishing
         {
             bool pointerOverUI = EventSystem.current != null && EventSystem.current.IsPointerOverGameObject();
 
-            if (Input.GetMouseButtonDown(0) && !pointerOverUI)
+            if (Time.time >= nextInteractionTime)
             {
-                var spot = GetSpotUnderCursor();
-                if (spot != null)
-                    TryStartFishing(spot);
-            }
-            else if (Input.GetMouseButtonDown(1) && !pointerOverUI)
-            {
-                var spot = GetSpotUnderCursor();
-                if (spot != null)
-                    spot.Prospect(transform);
+                if (Input.GetMouseButtonDown(0) && !pointerOverUI)
+                {
+                    var spot = GetSpotUnderCursor();
+                    if (spot != null)
+                        TryStartFishing(spot);
+                }
+                else if (Input.GetMouseButtonDown(1) && !pointerOverUI)
+                {
+                    var spot = GetSpotUnderCursor();
+                    if (spot != null)
+                    {
+                        spot.Prospect(transform);
+                        nextInteractionTime = Time.time + prospectCooldown;
+                    }
+                }
             }
 
             if (Input.GetKeyDown(KeyCode.Escape))

--- a/Assets/Scripts/Skills/Mining/Core/MinerController.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MinerController.cs
@@ -15,6 +15,8 @@ namespace Skills.Mining
         [SerializeField] private float cancelDistance = 3f;
         [SerializeField] private LayerMask rockMask = ~0;
 
+        [SerializeField] private float prospectCooldown = 3f;
+
         [Header("References")]
         [SerializeField] private MiningSkill miningSkill;
         [SerializeField] private PickaxeToUse pickaxeSelector;
@@ -23,6 +25,7 @@ namespace Skills.Mining
         private MineableRock nearbyRock;
 
         private Camera cam;
+        private float nextInteractionTime = 0f;
 
         private void Awake()
         {
@@ -39,17 +42,23 @@ namespace Skills.Mining
         {
             bool pointerOverUI = EventSystem.current != null && EventSystem.current.IsPointerOverGameObject();
 
-            if (Input.GetMouseButtonDown(0) && !pointerOverUI)
+            if (Time.time >= nextInteractionTime)
             {
-                var rock = GetRockUnderCursor();
-                if (rock != null)
-                    TryStartMining(rock);
-            }
-            else if (Input.GetMouseButtonDown(1) && !pointerOverUI)
-            {
-                var rock = GetRockUnderCursor();
-                if (rock != null)
-                    rock.Prospect(transform);
+                if (Input.GetMouseButtonDown(0) && !pointerOverUI)
+                {
+                    var rock = GetRockUnderCursor();
+                    if (rock != null)
+                        TryStartMining(rock);
+                }
+                else if (Input.GetMouseButtonDown(1) && !pointerOverUI)
+                {
+                    var rock = GetRockUnderCursor();
+                    if (rock != null)
+                    {
+                        rock.Prospect(transform);
+                        nextInteractionTime = Time.time + prospectCooldown;
+                    }
+                }
             }
 
             if (Input.GetKeyDown(KeyCode.Escape))


### PR DESCRIPTION
## Summary
- add configurable prospecting cooldown for mining
- gate mining and fishing interactions after prospecting

## Testing
- `dotnet test` *(fails: MSBUILD error MSB1003, no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f4618000832ea6300652b925581f