### PR TITLE
Add woodcutting pet drop chance

### DIFF
--- a/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using Inventory;
 using Util;
 using Skills.Mining; // reuse XP table
+using Skills;
 using Pets;
 using Quests;
 using Core.Save;
@@ -31,6 +32,8 @@ namespace Skills.Woodcutting
         private int chopProgress;
         private int currentIntervalTicks;
 
+        private SkillManager skills;
+
         private Dictionary<string, ItemData> logItems;
         private int questLogCount;
 
@@ -52,6 +55,7 @@ namespace Skills.Woodcutting
         {
             if (inventory == null)
                 inventory = GetComponent<Inventory.Inventory>();
+            skills = GetComponent<SkillManager>();
             save = saveProvider as IWoodcuttingSave ?? new SaveManagerWoodcuttingSave();
             PreloadLogItems();
         }
@@ -157,6 +161,9 @@ namespace Skills.Woodcutting
                 FloatingText.Show($"+{amount} {logName}", anchorPos);
                 StartCoroutine(ShowXpGainDelayed(currentTree.def.XpPerLog * amount, anchorTransform));
                 OnLogGained?.Invoke(logId, amount);
+
+                if (currentTree.def.PetDropChance > 0)
+                    PetDropSystem.TryRollPet("woodcutting", currentTree.transform.position, skills, currentTree.def.PetDropChance, out _);
 
                 if (QuestManager.Instance != null && QuestManager.Instance.IsQuestActive("ToolsOfSurvival"))
                 {

--- a/Assets/Scripts/Skills/Woodcutting/Data/TreeDefinition.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Data/TreeDefinition.cs
@@ -26,6 +26,9 @@ namespace Skills.Woodcutting
         [Header("Chop Timing")]
         [SerializeField] private int chopIntervalTicks = 4;
 
+        [Header("Pet Drop Chance")]
+        [SerializeField] private int petDropChance = 0;
+
         [Header("Ranges")]
         [SerializeField] private float interactRange = 1.5f;
         [SerializeField] private float cancelDistance = 3f;
@@ -43,6 +46,7 @@ namespace Skills.Woodcutting
         public int DepleteRollInverse => depleteRollInverse;
         public int RespawnSeconds => respawnSeconds;
         public int ChopIntervalTicks => chopIntervalTicks;
+        public int PetDropChance => petDropChance;
         public float InteractRange => interactRange;
         public float CancelDistance => cancelDistance;
         public Sprite AliveSprite => aliveSprite;

--- a/Assets/WoodcuttingDatabase/Magic Tree.asset
+++ b/Assets/WoodcuttingDatabase/Magic Tree.asset
@@ -21,6 +21,7 @@ MonoBehaviour:
   depleteRollInverse: 8
   respawnSeconds: 234
   chopIntervalTicks: 4
+  petDropChance: 2500
   interactRange: 3
   cancelDistance: 4.5
   aliveSprite: {fileID: 0}

--- a/Assets/WoodcuttingDatabase/Maple Tree.asset
+++ b/Assets/WoodcuttingDatabase/Maple Tree.asset
@@ -21,6 +21,7 @@ MonoBehaviour:
   depleteRollInverse: 8
   respawnSeconds: 60
   chopIntervalTicks: 4
+  petDropChance: 4500
   interactRange: 3
   cancelDistance: 4.5
   aliveSprite: {fileID: 0}

--- a/Assets/WoodcuttingDatabase/Normal Tree.asset
+++ b/Assets/WoodcuttingDatabase/Normal Tree.asset
@@ -21,5 +21,6 @@ MonoBehaviour:
   depleteRollInverse: 8
   respawnSeconds: 10
   chopIntervalTicks: 4
+  petDropChance: 7500
   aliveSprite: {fileID: 21300000, guid: 6fcc0156bb0e34640b91d4a2d234b296, type: 3}
   depletedSprite: {fileID: 21300000, guid: fc6d96e646a87464baec31629e5e7c6f, type: 3}

--- a/Assets/WoodcuttingDatabase/Oak Tree.asset
+++ b/Assets/WoodcuttingDatabase/Oak Tree.asset
@@ -21,6 +21,7 @@ MonoBehaviour:
   depleteRollInverse: 8
   respawnSeconds: 27
   chopIntervalTicks: 4
+  petDropChance: 6500
   interactRange: 3
   cancelDistance: 4.5
   aliveSprite: {fileID: 21300000, guid: 2db2cce082b6ecb4bae06730f42f4346, type: 3}

--- a/Assets/WoodcuttingDatabase/Willow Tree.asset
+++ b/Assets/WoodcuttingDatabase/Willow Tree.asset
@@ -21,6 +21,7 @@ MonoBehaviour:
   depleteRollInverse: 8
   respawnSeconds: 30
   chopIntervalTicks: 4
+  petDropChance: 5500
   interactRange: 3
   cancelDistance: 4.5
   aliveSprite: {fileID: 21300000, guid: 0e1bd934d1e677c4bb4724459d2718ad, type: 3}

--- a/Assets/WoodcuttingDatabase/Yew Tree.asset
+++ b/Assets/WoodcuttingDatabase/Yew Tree.asset
@@ -21,6 +21,7 @@ MonoBehaviour:
   depleteRollInverse: 8
   respawnSeconds: 114
   chopIntervalTicks: 4
+  petDropChance: 3500
   interactRange: 3
   cancelDistance: 4.5
   aliveSprite: {fileID: 0}


### PR DESCRIPTION
## Summary
- add pet drop chance to tree definitions and expose property
- support pet roll overrides and new overloads in PetDropSystem
- roll for woodcutting pet drops using tree-specific chances and update tree assets

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f706befc832eb1053053c9248f74