### PR TITLE
Add woodcutting pet roll debug

### DIFF
--- a/Assets/Scripts/Pets/PetDropSystem.cs
+++ b/Assets/Scripts/Pets/PetDropSystem.cs
@@ -168,6 +168,8 @@ namespace Pets
                     }
 
                     int roll = rng != null ? rng.Next(effectiveOneInN) : UnityEngine.Random.Range(0, effectiveOneInN);
+                    if (string.Equals(sourceId, "woodcutting", StringComparison.OrdinalIgnoreCase))
+                        Debug.Log($"Woodcutting pet roll: {roll} (chance 1 in {effectiveOneInN})");
                     if (roll == 0)
                     {
                         SpawnPetInternal(entry.pet, worldPosition);


### PR DESCRIPTION
## Summary
- log random roll and chance when attempting woodcutting pet drop

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68b3fa16cdc4832e9144d638a4663655