### PR TITLE
Add mining pet drop chances

### DIFF
--- a/Assets/Item/MiningDatabase/Adamantite Ore.asset
+++ b/Assets/Item/MiningDatabase/Adamantite Ore.asset
@@ -16,3 +16,4 @@ MonoBehaviour:
   displayName: Adamantite ore
   levelRequirement: 70
   xpPerOre: 95
+  petDropChance: 3500

--- a/Assets/Item/MiningDatabase/Coal Ore.asset
+++ b/Assets/Item/MiningDatabase/Coal Ore.asset
@@ -16,3 +16,4 @@ MonoBehaviour:
   displayName: Coal
   levelRequirement: 30
   xpPerOre: 50
+  petDropChance: 5000

--- a/Assets/Item/MiningDatabase/Copper Ore.asset
+++ b/Assets/Item/MiningDatabase/Copper Ore.asset
@@ -16,3 +16,4 @@ MonoBehaviour:
   displayName: Copper ore
   levelRequirement: 1
   xpPerOre: 18
+  petDropChance: 7500

--- a/Assets/Item/MiningDatabase/Iron Ore.asset
+++ b/Assets/Item/MiningDatabase/Iron Ore.asset
@@ -16,3 +16,4 @@ MonoBehaviour:
   displayName: Iron ore
   levelRequirement: 15
   xpPerOre: 35
+  petDropChance: 6000

--- a/Assets/Item/MiningDatabase/Mithril Ore.asset
+++ b/Assets/Item/MiningDatabase/Mithril Ore.asset
@@ -16,3 +16,4 @@ MonoBehaviour:
   displayName: Mithril ore
   levelRequirement: 55
   xpPerOre: 80
+  petDropChance: 4500

--- a/Assets/Item/MiningDatabase/Orichalcum Ore.asset
+++ b/Assets/Item/MiningDatabase/Orichalcum Ore.asset
@@ -16,3 +16,4 @@ MonoBehaviour:
   displayName: Orichalcum ore
   levelRequirement: 62
   xpPerOre: 87
+  petDropChance: 4000

--- a/Assets/Item/MiningDatabase/Runite Ore.asset
+++ b/Assets/Item/MiningDatabase/Runite Ore.asset
@@ -16,3 +16,4 @@ MonoBehaviour:
   displayName: Runite ore
   levelRequirement: 85
   xpPerOre: 125
+  petDropChance: 2500

--- a/Assets/Item/MiningDatabase/Tin Ore.asset
+++ b/Assets/Item/MiningDatabase/Tin Ore.asset
@@ -16,3 +16,4 @@ MonoBehaviour:
   displayName: Tin Ore
   levelRequirement: 1
   xpPerOre: 18
+  petDropChance: 7500

--- a/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using Inventory;
 using Util;
 using Skills.Mining;
+using Skills;
 using Pets;
 using Quests;
 using Core.Save;
@@ -30,6 +31,7 @@ namespace Skills.Mining
         private PickaxeDefinition currentPickaxe;
         private int swingProgress;
 
+        private SkillManager skills;
         private Dictionary<string, ItemData> oreItems;
         private int questOreCount;
 
@@ -54,6 +56,7 @@ namespace Skills.Mining
             if (inventory == null)
                 inventory = GetComponent<Inventory.Inventory>();
             save = saveProvider as IMiningSave ?? new SaveManagerMiningSave();
+            skills = GetComponent<SkillManager>();
             PreloadOreItems();
         }
 
@@ -163,6 +166,9 @@ namespace Skills.Mining
                     FloatingText.Show($"+{amount} {ore.DisplayName}", anchorPos);
                     StartCoroutine(ShowXpGainDelayed(ore.XpPerOre * amount, anchorTransform));
                     OnOreGained?.Invoke(ore.Id, amount);
+
+                    if (ore.PetDropChance > 0)
+                        PetDropSystem.TryRollPet("mining", currentRock.transform.position, skills, ore.PetDropChance, out _);
 
                     if (QuestManager.Instance != null && QuestManager.Instance.IsQuestActive("ToolsOfSurvival"))
                     {

--- a/Assets/Scripts/Skills/Mining/Data/OreDefinition.cs
+++ b/Assets/Scripts/Skills/Mining/Data/OreDefinition.cs
@@ -15,9 +15,13 @@ namespace Skills.Mining
         [Header("Rewards")]
         [SerializeField] private int xpPerOre = 1;
 
+        [Header("Pet Drop Chance")]
+        [SerializeField] private int petDropChance = 0;
+
         public string Id => id;
         public string DisplayName => displayName;
         public int LevelRequirement => levelRequirement;
         public int XpPerOre => xpPerOre;
+        public int PetDropChance => petDropChance;
     }
 }


### PR DESCRIPTION
## Summary
- allow mining ores to specify pet drop chances
- roll mining pet drops using new ore definitions
- configure pet drop rates for ores

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3fcbc5bec832e97bab86d0fb8fe46