### PR TITLE
Add toggleable pet roll debug

### DIFF
--- a/Assets/Scripts/Pets/PetDropSystem.cs
+++ b/Assets/Scripts/Pets/PetDropSystem.cs
@@ -18,6 +18,7 @@ namespace Pets
         public static PetDefinition ActivePet => activePetDef;
         public static GameObject ActivePetObject => activePetGO;
         public static PetCombatController ActivePetCombat => activePetGO != null ? activePetGO.GetComponent<PetCombatController>() : null;
+        public static bool DebugPetRolls { get; set; }
         public static bool GuardModeEnabled { get; set; }
         private static bool initialized;
         private static bool quittingRegistered;
@@ -168,8 +169,8 @@ namespace Pets
                     }
 
                     int roll = rng != null ? rng.Next(effectiveOneInN) : UnityEngine.Random.Range(0, effectiveOneInN);
-                    if (string.Equals(sourceId, "woodcutting", StringComparison.OrdinalIgnoreCase))
-                        Debug.Log($"Woodcutting pet roll: {roll} (chance 1 in {effectiveOneInN})");
+                    if (DebugPetRolls)
+                        Debug.Log($"{sourceId} pet roll: {roll} (chance 1 in {effectiveOneInN})");
                     if (roll == 0)
                     {
                         SpawnPetInternal(entry.pet, worldPosition);

--- a/Assets/Scripts/Skills/SkillsDebugMenu.cs
+++ b/Assets/Scripts/Skills/SkillsDebugMenu.cs
@@ -4,6 +4,7 @@ using Skills.Mining;
 using Skills.Woodcutting;
 using Skills.Fishing;
 using Beastmaster;
+using Pets;
 
 namespace Skills
 {
@@ -187,6 +188,11 @@ namespace Skills
             if (GUILayout.Button("Reset Merge Timer"))
             {
                 PetMergeController.Instance?.ResetMergeTimer();
+            }
+
+            if (GUILayout.Button(PetDropSystem.DebugPetRolls ? "Disable Pet Roll Debug" : "Enable Pet Roll Debug"))
+            {
+                PetDropSystem.DebugPetRolls = !PetDropSystem.DebugPetRolls;
             }
 
             GUILayout.EndScrollView();


### PR DESCRIPTION
## Summary
- add DebugPetRolls flag to PetDropSystem
- log pet roll results when enabled
- expose pet roll debug toggle in F2 debug menu

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b3fe64f02c832ea825afa2c6d4a2b9