### PR TITLE
Clamp tooltip position within screen

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -839,9 +839,19 @@ namespace Inventory
                 string currencyName = currentShop.currency != null ? currentShop.currency.itemName : "Coins";
                 tooltipNameText.text = !string.IsNullOrEmpty(item.itemName) ? item.itemName : item.name;
                 tooltipDescriptionText.text = $"Sell for {sellPrice} {currencyName}";
+
                 var tooltipRectSell = tooltip.GetComponent<RectTransform>();
                 LayoutRebuilder.ForceRebuildLayoutImmediate(tooltipRectSell);
-                tooltip.transform.position = slotRect.position + new Vector3(slotSize.x, 0f, 0f);
+
+                Vector3 pos = slotRect.position + new Vector3(slotSize.x, 0f, 0f);
+                Vector3[] corners = new Vector3[4];
+                tooltipRectSell.GetWorldCorners(corners);
+                float width = corners[2].x - corners[0].x;
+                float height = corners[2].y - corners[0].y;
+                pos.x = Mathf.Min(pos.x, Screen.width - width);
+                pos.y = Mathf.Max(pos.y, height);
+                tooltipRectSell.position = pos;
+
                 tooltip.SetActive(true);
                 return;
             }
@@ -853,7 +863,15 @@ namespace Inventory
             var tooltipRect = tooltip.GetComponent<RectTransform>();
             LayoutRebuilder.ForceRebuildLayoutImmediate(tooltipRect);
 
-            tooltip.transform.position = slotRect.position + new Vector3(slotSize.x, 0f, 0f);
+            Vector3 pos = slotRect.position + new Vector3(slotSize.x, 0f, 0f);
+            Vector3[] corners = new Vector3[4];
+            tooltipRect.GetWorldCorners(corners);
+            float width = corners[2].x - corners[0].x;
+            float height = corners[2].y - corners[0].y;
+            pos.x = Mathf.Min(pos.x, Screen.width - width);
+            pos.y = Mathf.Max(pos.y, height);
+            tooltipRect.position = pos;
+
             tooltip.SetActive(true);
         }
 
@@ -868,7 +886,15 @@ namespace Inventory
             var tooltipRect = tooltip.GetComponent<RectTransform>();
             LayoutRebuilder.ForceRebuildLayoutImmediate(tooltipRect);
 
-            tooltip.transform.position = slotRect.position + new Vector3(slotSize.x, 0f, 0f);
+            Vector3 pos = slotRect.position + new Vector3(slotSize.x, 0f, 0f);
+            Vector3[] corners = new Vector3[4];
+            tooltipRect.GetWorldCorners(corners);
+            float width = corners[2].x - corners[0].x;
+            float height = corners[2].y - corners[0].y;
+            pos.x = Mathf.Min(pos.x, Screen.width - width);
+            pos.y = Mathf.Max(pos.y, height);
+            tooltipRect.position = pos;
+
             tooltip.SetActive(true);
         }
 

--- a/Assets/Scripts/Shop/ShopUI.cs
+++ b/Assets/Scripts/Shop/ShopUI.cs
@@ -340,12 +340,31 @@ namespace ShopSystem
 
             string currencyName = currentShop.currency != null ? currentShop.currency.itemName : "Coins";
             tooltipText.text = $"\"{entry.item.itemName}\" costs {entry.price} {currencyName}";
+
+            var tooltipRect = tooltipText.GetComponent<RectTransform>();
+            LayoutRebuilder.ForceRebuildLayoutImmediate(tooltipRect);
+
+            RectTransform slotRect = (slotImages != null && index < slotImages.Length) ? slotImages[index].rectTransform : null;
+            if (slotRect != null)
+            {
+                Vector3 pos = slotRect.position + new Vector3(slotSize.x, 0f, 0f);
+                Vector3[] corners = new Vector3[4];
+                tooltipRect.GetWorldCorners(corners);
+                float width = corners[2].x - corners[0].x;
+                float height = corners[2].y - corners[0].y;
+                pos.x = Mathf.Min(pos.x, Screen.width - width);
+                pos.y = Mathf.Max(pos.y, height);
+                tooltipRect.position = pos;
+            }
         }
 
         public void HideTooltip()
         {
             if (tooltipText != null)
+            {
                 tooltipText.text = string.Empty;
+                tooltipText.rectTransform.position = Vector3.zero;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Clamp inventory tooltip position within screen bounds using world-space size
- Reposition shop tooltips near slots and clamp within screen

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68b404b3ddf0832ea5bc53321fb76265