### PR TITLE
Fix ShopUI initialization when reusing existing UI root

### DIFF
--- a/Assets/Scripts/Shop/ShopUI.cs
+++ b/Assets/Scripts/Shop/ShopUI.cs
@@ -66,6 +66,7 @@ namespace ShopSystem
             if (sharedUIRoot != null)
             {
                 uiRoot = sharedUIRoot;
+                CacheSlotReferences();
             }
             else
             {
@@ -302,9 +303,38 @@ namespace ShopSystem
             tooltipRect.offsetMax = new Vector2(-windowPadding.x, windowPadding.y + tooltipHeight);
         }
 
+        private void CacheSlotReferences()
+        {
+            if (uiRoot == null)
+                return;
+
+            var slots = uiRoot.GetComponentsInChildren<ShopSlot>(true);
+            slotImages = new Image[slots.Length];
+            slotPriceTexts = new Text[slots.Length];
+
+            for (int i = 0; i < slots.Length; i++)
+            {
+                slotImages[i] = slots[i].GetComponent<Image>();
+                slotPriceTexts[i] = slots[i].GetComponentInChildren<Text>();
+                slots[i].shopUI = this;
+                slots[i].index = i;
+            }
+
+            var texts = uiRoot.GetComponentsInChildren<Text>(true);
+            foreach (var t in texts)
+            {
+                if (t.gameObject.name == "Tooltip")
+                    tooltipText = t;
+                else if (t.gameObject.name == "Name")
+                    shopNameText = t;
+            }
+        }
+
         public void Refresh()
         {
             HideTooltip();
+            if (slotImages == null || slotPriceTexts == null)
+                CacheSlotReferences();
             if (shopNameText != null)
                 shopNameText.text = currentShop != null ? currentShop.shopName : string.Empty;
             for (int i = 0; i < slotImages.Length; i++)


### PR DESCRIPTION
## Summary
- Rebuild slot image and price caches if an existing ShopUI root is found
- Add CacheSlotReferences helper and refresh safeguard

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b40ce79ee4832e8d2a6bdf33e9a0e1