### PR TITLE
Assign main camera to ShopUI canvas when missing

### DIFF
--- a/Assets/Scripts/Shop/ShopUI.cs
+++ b/Assets/Scripts/Shop/ShopUI.cs
@@ -74,7 +74,14 @@ namespace ShopSystem
                 sharedUIRoot = uiRoot;
             }
             if (uiRoot != null)
+            {
+                var canvas = uiRoot.GetComponent<Canvas>();
+                if (canvas != null && canvas.renderMode == RenderMode.ScreenSpaceCamera && canvas.worldCamera == null)
+                {
+                    canvas.worldCamera = Camera.main;
+                }
                 uiRoot.SetActive(false);
+            }
             UIManager.Instance.RegisterWindow(this);
         }
 


### PR DESCRIPTION
## Summary
- ensure ShopUI canvas has a camera if its render mode is ScreenSpaceCamera

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b4140308d8832e85e7a5e99cbc8201