### PR TITLE
Ensure Shop UI canvas exists

### DIFF
--- a/Assets/Scripts/Shop/ShopUI.cs
+++ b/Assets/Scripts/Shop/ShopUI.cs
@@ -63,18 +63,22 @@ namespace ShopSystem
             if (sharedUIRoot == null)
                 sharedUIRoot = GameObject.Find("ShopUI");
 
+            if (sharedUIRoot != null && sharedUIRoot.GetComponent<Canvas>() == null)
+                sharedUIRoot = null;
+
             if (sharedUIRoot != null)
             {
                 uiRoot = sharedUIRoot;
-                CacheSlotReferences();
             }
             else
             {
                 CreateUI();
                 sharedUIRoot = uiRoot;
             }
+
             if (uiRoot != null)
             {
+                CacheSlotReferences();
                 var canvas = uiRoot.GetComponent<Canvas>();
                 if (canvas != null && canvas.renderMode == RenderMode.ScreenSpaceCamera && canvas.worldCamera == null)
                 {


### PR DESCRIPTION
## Summary
- Verify that a found ShopUI GameObject contains a Canvas and create one if absent
- Safeguard UI setup by checking uiRoot before caching slot references

## Testing
- `dotnet test` *(fails: MSB1003 - no project or solution file found)*

------
https://chatgpt.com/codex/tasks/task_e_68b416d9913c832eaa1cccd4f232f5db