### PR TITLE
Remove quotes from ShopUI tooltip

### DIFF
--- a/Assets/Scripts/Shop/ShopUI.cs
+++ b/Assets/Scripts/Shop/ShopUI.cs
@@ -380,7 +380,7 @@ namespace ShopSystem
             if (entry.item == null) return;
 
             string currencyName = currentShop.currency != null ? currentShop.currency.itemName : "Coins";
-            tooltipText.text = $"\"{entry.item.itemName}\" costs {entry.price} {currencyName}";
+            tooltipText.text = $"{entry.item.itemName} costs {entry.price} {currencyName}";
             var tooltipRect = tooltipText.GetComponent<RectTransform>();
             LayoutRebuilder.ForceRebuildLayoutImmediate(tooltipRect);
         }


### PR DESCRIPTION
## Summary
- Display ShopUI item names without surrounding quotation marks

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b41ba53c40832e8bfac09c860dbee0