### PR TITLE
Use dark goldenrod for tooltip description text

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -260,7 +260,7 @@ MonoBehaviour:
   tooltipNameFont: {fileID: 12800000, guid: 6dc49ea977bb85a49ac4df5338f901f4, type: 3}
   tooltipNameColor: {r: 1, g: 1, b: 1, a: 1}
   tooltipDescriptionFont: {fileID: 12800000, guid: 6dc49ea977bb85a49ac4df5338f901f4, type: 3}
-  tooltipDescriptionColor: {r: 1, g: 1, b: 1, a: 1}
+  tooltipDescriptionColor: {r: 0.72156864, g: 0.5254902, b: 0.043137256, a: 1}
 --- !u!114 &4546782594985685190
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -88,7 +88,7 @@ namespace Inventory
         [Tooltip("Optional: custom font for the tooltip description. Uses LegacyRuntime if null.")]
         public Font tooltipDescriptionFont;
         [Tooltip("Color for the tooltip description text.")]
-        public Color tooltipDescriptionColor = Color.white;
+        public Color tooltipDescriptionColor = new Color(184/255f, 134/255f, 11/255f, 1f);
 
         [Header("Save")]
         [Tooltip("Save key used for persistence.")]


### PR DESCRIPTION
## Summary
- set tooltip description text default color to dark goldenrod
- update player prefab to use dark goldenrod for hover descriptions

## Testing
- `dotnet build` *(fails: project or solution file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b41df8f150832ea1836196526d4e77