### PR TITLE
Handle pet rolls when a pet is already active

### DIFF
--- a/Assets/Scripts/Bank/BankUI.cs
+++ b/Assets/Scripts/Bank/BankUI.cs
@@ -663,6 +663,17 @@ namespace BankSystem
             return true;
         }
 
+        public bool AddItemToBank(ItemData item, int count = 1)
+        {
+            int added = AddItem(item, count);
+            if (added > 0)
+            {
+                SaveState();
+                return true;
+            }
+            return false;
+        }
+
         private void SaveState()
         {
             if (playerInventory != null)

--- a/Assets/Scripts/Pets/PetDropSystem.cs
+++ b/Assets/Scripts/Pets/PetDropSystem.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using Inventory;
 using Skills;
+using BankSystem;
 
 namespace Pets
 {
@@ -173,8 +174,26 @@ namespace Pets
                         Debug.Log($"{sourceId} pet roll: {roll} (chance 1 in {effectiveOneInN})");
                     if (roll == 0)
                     {
-                        SpawnPetInternal(entry.pet, worldPosition);
                         pet = entry.pet;
+                        if (activePetGO == null)
+                        {
+                            SpawnPetInternal(entry.pet, worldPosition);
+                        }
+                        else
+                        {
+                            var player = GameObject.FindGameObjectWithTag("Player");
+                            var inventory = player != null ? player.GetComponent<Inventory.Inventory>() : null;
+                            if (inventory != null && inventory.CanAddItem(entry.pet.pickupItem))
+                            {
+                                inventory.AddItem(entry.pet.pickupItem);
+                                PetToastUI.Show("You feel something crawl inside your backpack", entry.pet.messageColor);
+                            }
+                            else
+                            {
+                                BankUI.Instance?.AddItemToBank(entry.pet.pickupItem);
+                                PetToastUI.Show("You have a feeling something has snuck into your bank", entry.pet.messageColor);
+                            }
+                        }
                         return true;
                     }
                 }


### PR DESCRIPTION
## Summary
- Prevent spawning a new pet if one is active; instead add the rolled pet item to the player or bank
- Add BankUI.AddItemToBank helper and use it when inventory has no space

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b437c6062c832e9af749d7ae6b07d5