### PR TITLE
Fix pet follower sprite sorting relative to player

### DIFF
--- a/Assets/Scripts/Pets/PetFollower.cs
+++ b/Assets/Scripts/Pets/PetFollower.cs
@@ -182,9 +182,9 @@ namespace Pets
                 if (playerMover != null && playerMover.FacingDir == 3)
                 {
                     if (transform.position.y < player.position.y)
-                        baseOrder = playerOrder - 1;
-                    else if (transform.position.y > player.position.y)
                         baseOrder = playerOrder + 1;
+                    else if (transform.position.y > player.position.y)
+                        baseOrder = playerOrder - 1;
                 }
             }
             sprite.sortingOrder = baseOrder;


### PR DESCRIPTION
## Summary
- correct sprite sorting order when pet is above or below the player while facing north

## Testing
- `dotnet test` (fails: Specify a project or solution file)


------
https://chatgpt.com/codex/tasks/task_e_68b46d1d16c4832e8fa28b762c815fe6