### PR TITLE
Fix pet sorting order when pet faces down

### DIFF
--- a/Assets/Scripts/Pets/PetFollower.cs
+++ b/Assets/Scripts/Pets/PetFollower.cs
@@ -181,9 +181,9 @@ namespace Pets
                 int playerOrder = Mathf.RoundToInt(-player.position.y * 100f);
                 if (playerMover != null && playerMover.FacingDir == 3)
                 {
-                    if (transform.position.y < player.position.y)
+                    if (transform.position.y > player.position.y)
                         baseOrder = playerOrder + 1;
-                    else if (transform.position.y > player.position.y)
+                    else if (transform.position.y < player.position.y)
                         baseOrder = playerOrder - 1;
                 }
             }


### PR DESCRIPTION
## Summary
- correct PetFollower sorting order when player facing dir is 3

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b470939f08832e87cfaa8f6bb309b0