### PR TITLE
Fix pet depth sorting

### DIFF
--- a/Assets/Scripts/Pets/PetFollower.cs
+++ b/Assets/Scripts/Pets/PetFollower.cs
@@ -179,13 +179,10 @@ namespace Pets
             if (player != null)
             {
                 int playerOrder = Mathf.RoundToInt(-player.position.y * 100f);
-                if (playerMover != null && playerMover.FacingDir == 3)
-                {
-                    if (transform.position.y > player.position.y)
-                        baseOrder = playerOrder + 1;
-                    else if (transform.position.y < player.position.y)
-                        baseOrder = playerOrder - 1;
-                }
+                if (transform.position.y > player.position.y)
+                    baseOrder = playerOrder + 1;
+                else if (transform.position.y < player.position.y)
+                    baseOrder = playerOrder - 1;
             }
             sprite.sortingOrder = baseOrder;
         }


### PR DESCRIPTION
## Summary
- Always compare pet and player Y positions for depth sorting

## Testing
- `dotnet build` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b47337ee44832ea200911ec55bcd8c