### PR TITLE
Adjust sprite depth by facing direction

### DIFF
--- a/Assets/Scripts/Pets/PetFollower.cs
+++ b/Assets/Scripts/Pets/PetFollower.cs
@@ -9,6 +9,7 @@ namespace Pets
     /// </summary>
     [RequireComponent(typeof(Rigidbody2D))]
     [RequireComponent(typeof(SpriteRenderer))]
+    [RequireComponent(typeof(SpriteDepth))]
     public class PetFollower : MonoBehaviour
     {
         public float followRadius = 0.6f;
@@ -47,8 +48,9 @@ namespace Pets
             body = GetComponent<Rigidbody2D>();
             sprite = GetComponent<SpriteRenderer>();
             spriteDepth = GetComponent<SpriteDepth>();
-            if (spriteDepth != null)
-                spriteDepth.offset = depthOffset;
+            if (spriteDepth == null)
+                spriteDepth = gameObject.AddComponent<SpriteDepth>();
+            spriteDepth.offset = depthOffset;
             spriteAnimator = GetComponent<PetSpriteAnimator>();
             if (player != null)
                 SetPlayer(player);
@@ -168,23 +170,6 @@ namespace Pets
                     sprite.flipX = newPos.x > player.position.x;
             }
 
-        }
-
-        private void LateUpdate()
-        {
-            if (sprite == null)
-                return;
-
-            int baseOrder = Mathf.RoundToInt(-transform.position.y * 100f) + depthOffset;
-            if (player != null)
-            {
-                int playerOrder = Mathf.RoundToInt(-player.position.y * 100f);
-                if (transform.position.y > player.position.y)
-                    baseOrder = playerOrder + 1;
-                else if (transform.position.y < player.position.y)
-                    baseOrder = playerOrder - 1;
-            }
-            sprite.sortingOrder = baseOrder;
         }
 
     }

--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -6,6 +6,7 @@ using System;
 using Core.Save;
 using World;
 using Pets;
+using Util;
 
 namespace Player
 {
@@ -88,6 +89,9 @@ namespace Player
             anim = GetComponent<Animator>();
             sr  = GetComponent<SpriteRenderer>();
             inventory = GetComponent<Inventory.Inventory>();
+            var depth = GetComponent<SpriteDepth>();
+            if (depth != null)
+                depth.directionOffset = 1;
 
             rb.bodyType = RigidbodyType2D.Dynamic;
             rb.gravityScale = 0f;

--- a/Assets/Scripts/Util/SpriteDepth.cs
+++ b/Assets/Scripts/Util/SpriteDepth.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+using UnityEngine;
+using Player;
 
 namespace Util
 {
@@ -7,17 +8,36 @@ namespace Util
     public class SpriteDepth : MonoBehaviour
     {
         public int offset;            // small positive/negative tweak if needed
+        public int directionOffset;   // magnitude for direction-based tweak
+
         private SpriteRenderer sr;
+        private PlayerMover player;
 
         void Awake()
         {
             sr = GetComponent<SpriteRenderer>();
+            player = FindObjectOfType<PlayerMover>();
         }
 
         void LateUpdate()
         {
+            int dir = 0;
+            if (player != null)
+            {
+                switch (player.FacingDir)
+                {
+                    case 0: // facing down
+                        dir = directionOffset;
+                        break;
+                    case 3: // facing up
+                        dir = -directionOffset;
+                        break;
+                }
+            }
+
             // Larger (more negative) Y => lower sorting order => appears behind
-            sr.sortingOrder = Mathf.RoundToInt(-transform.position.y * 100f) + offset;
+            sr.sortingOrder = Mathf.RoundToInt(-transform.position.y * 100f) + offset + dir;
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- offset sprite rendering order by player facing direction
- drive player sprite depth with new directional offset
- ensure pets use common SpriteDepth component

## Testing
- `dotnet test` *(fails: No project or solution file found)*

------
https://chatgpt.com/codex/tasks/task_e_68b47a498bf4832ea2193d529e7ce66f