### PR TITLE
Route overflow gathering items to pet storage

### DIFF
--- a/Assets/Scripts/Pets/PetStorage.cs
+++ b/Assets/Scripts/Pets/PetStorage.cs
@@ -113,6 +113,19 @@ namespace Pets
             return 4;
         }
 
+        /// <summary>
+        /// Attempts to add items to the pet's storage inventory.
+        /// </summary>
+        /// <param name="item">Item definition to store.</param>
+        /// <param name="amount">Quantity of the item.</param>
+        /// <returns>True if the items were stored successfully.</returns>
+        public bool StoreItem(ItemData item, int amount = 1)
+        {
+            if (inventory == null || item == null)
+                return false;
+            return inventory.AddItem(item, amount);
+        }
+
         public void Open()
         {
             if (inventory != null)

--- a/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
@@ -5,6 +5,7 @@ using Inventory;
 using Util;
 using Skills.Mining; // reuse XP table
 using Core.Save;
+using Pets;
 
 namespace Skills.Fishing
 {
@@ -150,6 +151,15 @@ namespace Skills.Fishing
                     added = inventory.AddItem(item);
 
                 Transform anchor = floatingTextAnchor != null ? floatingTextAnchor : transform;
+                if (!added)
+                {
+                    var petStorage = PetDropSystem.ActivePetObject != null
+                        ? PetDropSystem.ActivePetObject.GetComponent<PetStorage>()
+                        : null;
+                    if (petStorage != null)
+                        added = petStorage.StoreItem(item, 1);
+                }
+
                 if (!added)
                 {
                     FloatingText.Show("Your inventory is full", anchor.position);

--- a/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
@@ -157,6 +157,15 @@ namespace Skills.Mining
 
                     if (!added)
                     {
+                        var petStorage = PetDropSystem.ActivePetObject != null
+                            ? PetDropSystem.ActivePetObject.GetComponent<PetStorage>()
+                            : null;
+                        if (petStorage != null)
+                            added = petStorage.StoreItem(item, amount);
+                    }
+
+                    if (!added)
+                    {
                         FloatingText.Show("Your inventory is full", anchorPos);
                         StopMining();
                         return;

--- a/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
@@ -151,6 +151,15 @@ namespace Skills.Woodcutting
 
                 if (!added)
                 {
+                    var petStorage = PetDropSystem.ActivePetObject != null
+                        ? PetDropSystem.ActivePetObject.GetComponent<PetStorage>()
+                        : null;
+                    if (petStorage != null)
+                        added = petStorage.StoreItem(item, amount);
+                }
+
+                if (!added)
+                {
                     FloatingText.Show("Your inventory is full", anchorPos);
                     StopChopping();
                     return;


### PR DESCRIPTION
## Summary
- allow pets to store overflow items via new `PetStorage.StoreItem`
- route mining, woodcutting, and fishing outputs into pet storage before ending the action

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b49b9e9c5c832e90b7ed65efcee9cf