### PR TITLE
Use pet storage when player inventory is full

### DIFF
--- a/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
@@ -249,7 +249,19 @@ namespace Skills.Fishing
                 PreloadFishItems();
             if (!fishItems.TryGetValue(fish.ItemId, out var item) || item == null)
                 return true;
-            return inventory.CanAddItem(item);
+
+            if (inventory.CanAddItem(item))
+                return true;
+
+            var petStorage = PetDropSystem.ActivePetObject != null
+                ? PetDropSystem.ActivePetObject.GetComponent<PetStorage>()
+                : null;
+            var petInv = petStorage != null
+                ? petStorage.GetComponent<Inventory.Inventory>()
+                : null;
+            if (petInv != null)
+                return petInv.CanAddItem(item);
+            return false;
         }
 
         public void DebugSetLevel(int newLevel)

--- a/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
@@ -250,7 +250,20 @@ namespace Skills.Mining
                 PreloadOreItems();
             if (!oreItems.TryGetValue(ore.Id, out var item) || item == null)
                 return true;
-            return inventory.CanAddItem(item);
+
+            int amount = PetDropSystem.ActivePet?.id == "Rock Golem" ? 2 : 1;
+            if (inventory.CanAddItem(item, amount))
+                return true;
+
+            var petStorage = PetDropSystem.ActivePetObject != null
+                ? PetDropSystem.ActivePetObject.GetComponent<PetStorage>()
+                : null;
+            var petInv = petStorage != null
+                ? petStorage.GetComponent<Inventory.Inventory>()
+                : null;
+            if (petInv != null)
+                return petInv.CanAddItem(item, amount);
+            return false;
         }
 
         /// <summary>

--- a/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
@@ -250,7 +250,20 @@ namespace Skills.Woodcutting
                 PreloadLogItems();
             if (!logItems.TryGetValue(tree.LogItemId, out var item) || item == null)
                 return true;
-            return inventory.CanAddItem(item);
+
+            int amount = PetDropSystem.ActivePet?.id == "Beaver" ? 2 : 1;
+            if (inventory.CanAddItem(item, amount))
+                return true;
+
+            var petStorage = PetDropSystem.ActivePetObject != null
+                ? PetDropSystem.ActivePetObject.GetComponent<PetStorage>()
+                : null;
+            var petInv = petStorage != null
+                ? petStorage.GetComponent<Inventory.Inventory>()
+                : null;
+            if (petInv != null)
+                return petInv.CanAddItem(item, amount);
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- Allow woodcutting to fall back to active pet storage if the player's bags are full
- Apply the same pet storage check for mining and fishing gathers

## Testing
- `dotnet build` *(fails: MSBUILD error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a4f3c444832ea424ff57ff19bc78