### PR TITLE
Restrict pet storage to relevant gatherables

### DIFF
--- a/Assets/Scripts/Pets/PetStorage.cs
+++ b/Assets/Scripts/Pets/PetStorage.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using Inventory;
 using System.Collections;
+using System;
 
 namespace Pets
 {
@@ -123,7 +124,27 @@ namespace Pets
         {
             if (inventory == null || item == null)
                 return false;
+            if (!CanStore(item))
+                return false;
             return inventory.AddItem(item, amount);
+        }
+
+        private bool CanStore(ItemData item)
+        {
+            if (definition == null || item == null)
+                return false;
+            string name = item.itemName ?? string.Empty;
+            switch (definition.id)
+            {
+                case "Beaver":
+                    return name.IndexOf("Log", StringComparison.OrdinalIgnoreCase) >= 0;
+                case "Rock Golem":
+                    return name.IndexOf("Ore", StringComparison.OrdinalIgnoreCase) >= 0;
+                case "Heron":
+                    return name.StartsWith("Raw ", StringComparison.OrdinalIgnoreCase);
+                default:
+                    return false;
+            }
         }
 
         public void Open()

--- a/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
@@ -155,7 +155,7 @@ namespace Skills.Fishing
                     added = inventory.AddItem(item, amount);
 
                 Transform anchor = floatingTextAnchor != null ? floatingTextAnchor : transform;
-                if (!added)
+                if (!added && PetDropSystem.ActivePet?.id == "Heron")
                 {
                     var petStorage = PetDropSystem.ActivePetObject != null
                         ? PetDropSystem.ActivePetObject.GetComponent<PetStorage>()
@@ -258,14 +258,17 @@ namespace Skills.Fishing
             if (inventory.CanAddItem(item, amount))
                 return true;
 
-            var petStorage = PetDropSystem.ActivePetObject != null
-                ? PetDropSystem.ActivePetObject.GetComponent<PetStorage>()
-                : null;
-            var petInv = petStorage != null
-                ? petStorage.GetComponent<Inventory.Inventory>()
-                : null;
-            if (petInv != null)
-                return petInv.CanAddItem(item, amount);
+            if (PetDropSystem.ActivePet?.id == "Heron")
+            {
+                var petStorage = PetDropSystem.ActivePetObject != null
+                    ? PetDropSystem.ActivePetObject.GetComponent<PetStorage>()
+                    : null;
+                var petInv = petStorage != null
+                    ? petStorage.GetComponent<Inventory.Inventory>()
+                    : null;
+                if (petInv != null)
+                    return petInv.CanAddItem(item, amount);
+            }
             return false;
         }
 

--- a/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
@@ -155,7 +155,7 @@ namespace Skills.Mining
                         : transform;
                     Vector3 anchorPos = anchorTransform.position;
 
-                    if (!added)
+                    if (!added && PetDropSystem.ActivePet?.id == "Rock Golem")
                     {
                         var petStorage = PetDropSystem.ActivePetObject != null
                             ? PetDropSystem.ActivePetObject.GetComponent<PetStorage>()
@@ -255,14 +255,17 @@ namespace Skills.Mining
             if (inventory.CanAddItem(item, amount))
                 return true;
 
-            var petStorage = PetDropSystem.ActivePetObject != null
-                ? PetDropSystem.ActivePetObject.GetComponent<PetStorage>()
-                : null;
-            var petInv = petStorage != null
-                ? petStorage.GetComponent<Inventory.Inventory>()
-                : null;
-            if (petInv != null)
-                return petInv.CanAddItem(item, amount);
+            if (PetDropSystem.ActivePet?.id == "Rock Golem")
+            {
+                var petStorage = PetDropSystem.ActivePetObject != null
+                    ? PetDropSystem.ActivePetObject.GetComponent<PetStorage>()
+                    : null;
+                var petInv = petStorage != null
+                    ? petStorage.GetComponent<Inventory.Inventory>()
+                    : null;
+                if (petInv != null)
+                    return petInv.CanAddItem(item, amount);
+            }
             return false;
         }
 

--- a/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
@@ -149,7 +149,7 @@ namespace Skills.Woodcutting
                 Transform anchorTransform = floatingTextAnchor != null ? floatingTextAnchor : transform;
                 Vector3 anchorPos = anchorTransform.position;
 
-                if (!added)
+                if (!added && PetDropSystem.ActivePet?.id == "Beaver")
                 {
                     var petStorage = PetDropSystem.ActivePetObject != null
                         ? PetDropSystem.ActivePetObject.GetComponent<PetStorage>()
@@ -255,14 +255,17 @@ namespace Skills.Woodcutting
             if (inventory.CanAddItem(item, amount))
                 return true;
 
-            var petStorage = PetDropSystem.ActivePetObject != null
-                ? PetDropSystem.ActivePetObject.GetComponent<PetStorage>()
-                : null;
-            var petInv = petStorage != null
-                ? petStorage.GetComponent<Inventory.Inventory>()
-                : null;
-            if (petInv != null)
-                return petInv.CanAddItem(item, amount);
+            if (PetDropSystem.ActivePet?.id == "Beaver")
+            {
+                var petStorage = PetDropSystem.ActivePetObject != null
+                    ? PetDropSystem.ActivePetObject.GetComponent<PetStorage>()
+                    : null;
+                var petInv = petStorage != null
+                    ? petStorage.GetComponent<Inventory.Inventory>()
+                    : null;
+                if (petInv != null)
+                    return petInv.CanAddItem(item, amount);
+            }
             return false;
         }
 


### PR DESCRIPTION
## Summary
- add CanStore helper to PetStorage to limit items to pet-specific resources
- gate Woodcutting, Mining, and Fishing pet storage and inventory checks by active pet type
- show inventory full message when pet storage is unavailable

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b4aa669efc832eb5ca365524a865f4