### PR TITLE
Restrict manual drops for skilling pets

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -994,6 +994,24 @@ namespace Inventory
                 int sourceIndex = source.draggingIndex;
                 if (slotIndex >= 0 && slotIndex < items.Length)
                 {
+                    var petStorage = GetComponent<PetStorage>();
+                    if (petStorage != null &&
+                        (petStorage.definition?.id == "Heron" ||
+                         petStorage.definition?.id == "Beaver" ||
+                         petStorage.definition?.id == "Rock Golem"))
+                    {
+                        // Skilling pets only accept auto-collected resources from their skill and cannot receive manual drops.
+                        var entry = source.items[sourceIndex];
+                        if (!petStorage.StoreItem(entry.item, entry.count))
+                        {
+                            source.EndDrag();
+                            return;
+                        }
+                        source.ClearSlot(sourceIndex);
+                        source.EndDrag();
+                        return;
+                    }
+
                     var temp = items[slotIndex];
                     items[slotIndex] = source.items[sourceIndex];
                     source.items[sourceIndex] = temp;


### PR DESCRIPTION
## Summary
- Only block manual item drops into Heron, Beaver, and Rock Golem inventories
- Allow other pet inventories to accept dragged items normally

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b51380f8832eb4ec58ecc1531913