### PR TITLE
Fix fishing tool selection when multiple tools

### DIFF
--- a/Assets/Scripts/Skills/Fishing/Core/FisherController.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FisherController.cs
@@ -122,28 +122,14 @@ namespace Skills.Fishing
             if (dist > range)
                 return;
 
-            var tool = toolSelector.GetBestTool();
+            var tool = toolSelector.GetBestTool(spot.def != null ? spot.def.AllowedTools : null);
             if (tool == null)
             {
-                FloatingText.Show("You need a fishing tool", transform.position);
-                return;
-            }
-            if (spot.def != null && spot.def.AllowedTools != null && spot.def.AllowedTools.Count > 0)
-            {
-                bool allowed = false;
-                foreach (var allowedTool in spot.def.AllowedTools)
-                {
-                    if (allowedTool != null && allowedTool.Id == tool.Id)
-                    {
-                        allowed = true;
-                        break;
-                    }
-                }
-                if (!allowed)
-                {
+                if (spot.def != null && spot.def.AllowedTools != null && spot.def.AllowedTools.Count > 0)
                     FloatingText.Show("You can't use that tool here", transform.position);
-                    return;
-                }
+                else
+                    FloatingText.Show("You need a fishing tool", transform.position);
+                return;
             }
             if (fishingSkill.Level < tool.RequiredLevel)
             {

--- a/Assets/Scripts/Skills/Fishing/Core/FishingToolToUse.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingToolToUse.cs
@@ -25,19 +25,26 @@ namespace Skills.Fishing
                 skill = GetComponent<FishingSkill>();
         }
 
-        public FishingToolDefinition GetBestTool()
+        public FishingToolDefinition GetBestTool(IEnumerable<FishingToolDefinition> allowed = null)
         {
-            Refresh();
+            Refresh(allowed);
             return Current;
         }
 
-        public void Refresh()
+        public void Refresh(IEnumerable<FishingToolDefinition> allowed = null)
         {
             Current = null;
             if (inventory == null || skill == null)
                 return;
 
-            foreach (var tool in allTools.OrderByDescending(t => t.CatchBonus))
+            IEnumerable<FishingToolDefinition> tools = allTools;
+            if (allowed != null)
+            {
+                var allowedSet = new HashSet<FishingToolDefinition>(allowed.Where(t => t != null));
+                tools = tools.Where(t => allowedSet.Contains(t));
+            }
+
+            foreach (var tool in tools.OrderByDescending(t => t.CatchBonus))
             {
                 var item = Resources.Load<ItemData>("Item/" + tool.Id);
                 if (item == null)


### PR DESCRIPTION
## Summary
- ensure fishing tool selector considers spot-specific allowed tools
- surface "can't use that tool here" only when no allowed tool present

## Testing
- `dotnet test` *(fails: MSBUILD error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b7ce520c832e986a60a885147b20