### PR TITLE
Match pet inventory tooltip fonts to player

### DIFF
--- a/Assets/Scripts/Pets/PetStorage.cs
+++ b/Assets/Scripts/Pets/PetStorage.cs
@@ -74,13 +74,28 @@ namespace Pets
             inventory.size = GetSlotsForLevel(experience != null ? experience.Level : 1);
             inventory.saveKey = $"PetInv_{definition?.id}";
             inventory.OnInventoryChanged += inventory.Save;
-            var inventories = FindObjectsOfType<Inventory.Inventory>();
-            foreach (var inv in inventories)
+
+            // Match the look and feel of the player's inventory so tooltips use the same fonts
+            var playerInv = GameObject.FindGameObjectWithTag("Player")?.GetComponent<Inventory.Inventory>();
+            if (playerInv != null && playerInv != inventory)
             {
-                if (inv.gameObject != gameObject)
+                inventory.windowColor = playerInv.windowColor;
+                inventory.tooltipNameFont = playerInv.tooltipNameFont;
+                inventory.tooltipDescriptionFont = playerInv.tooltipDescriptionFont;
+            }
+            else
+            {
+                // Fallback: copy styling from any other existing inventory
+                var inventories = FindObjectsOfType<Inventory.Inventory>();
+                foreach (var inv in inventories)
                 {
-                    inventory.windowColor = inv.windowColor;
-                    break;
+                    if (inv.gameObject != gameObject)
+                    {
+                        inventory.windowColor = inv.windowColor;
+                        inventory.tooltipNameFont = inv.tooltipNameFont;
+                        inventory.tooltipDescriptionFont = inv.tooltipDescriptionFont;
+                        break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Use player's tooltip fonts when creating pet inventory
- Fallback to existing inventories if player inventory isn't found

## Testing
- `dotnet test` (fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)

------
https://chatgpt.com/codex/tasks/task_e_68b4c4a6c058832e9b84c82d3de02b6e