### PR TITLE
Pause ticker when game loses focus

### DIFF
--- a/Assets/Scripts/Util/Ticker.cs
+++ b/Assets/Scripts/Util/Ticker.cs
@@ -105,5 +105,29 @@ namespace Util
         {
             paused = false;
         }
+
+        private void OnApplicationFocus(bool hasFocus)
+        {
+            if (hasFocus)
+            {
+                Resume();
+            }
+            else
+            {
+                Pause();
+            }
+        }
+
+        private void OnApplicationPause(bool pauseStatus)
+        {
+            if (pauseStatus)
+            {
+                Pause();
+            }
+            else
+            {
+                Resume();
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Pause the global ticker when the game loses focus so actions stop while the window is minimized or unfocused.

## Testing
- ⚠️ `dotnet test` *(no project or solution file found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c5e7e2bc832e87fa3dce942ee070