### PR TITLE
feat: handle right click in debug inventory

### DIFF
--- a/Assets/Scripts/Inventory/InventoryDebugMenu.cs
+++ b/Assets/Scripts/Inventory/InventoryDebugMenu.cs
@@ -87,17 +87,16 @@ namespace Inventory
             {
                 if (item != null)
                 {
-                    if (GUILayout.Button(item.name))
-                    {
-                        inventory?.AddItem(item);
-                    }
-
-                    Rect r = GUILayoutUtility.GetLastRect();
-                    if (Event.current.type == EventType.MouseDown && Event.current.button == 1 && r.Contains(Event.current.mousePosition))
+                    Rect rect = GUILayoutUtility.GetRect(GUIContent.Temp(item.name), GUI.skin.button);
+                    if (Event.current.type == EventType.MouseDown && Event.current.button == 1 && rect.Contains(Event.current.mousePosition))
                     {
                         amountItem = item;
                         amountText = "1";
                         Event.current.Use();
+                    }
+                    if (GUI.Button(rect, item.name) && Event.current.button == 0)
+                    {
+                        inventory?.AddItem(item);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- avoid adding items on right-click in inventory debug menu
- open the amount dialog when right-clicking an item

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a53c8588832ead7add37130883d2