### PR TITLE
Fix InventoryDebugMenu GUIContent.Temp compilation error

### DIFF
--- a/Assets/Scripts/Inventory/InventoryDebugMenu.cs
+++ b/Assets/Scripts/Inventory/InventoryDebugMenu.cs
@@ -87,7 +87,7 @@ namespace Inventory
             {
                 if (item != null)
                 {
-                    Rect rect = GUILayoutUtility.GetRect(GUIContent.Temp(item.name), GUI.skin.button);
+                    Rect rect = GUILayoutUtility.GetRect(new GUIContent(item.name), GUI.skin.button);
                     if (Event.current.type == EventType.MouseDown && Event.current.button == 1 && rect.Contains(Event.current.mousePosition))
                     {
                         amountItem = item;


### PR DESCRIPTION
## Summary
- Replace deprecated `GUIContent.Temp` usage with `new GUIContent(item.name)` to restore compatibility with newer Unity versions

## Testing
- `dotnet build` *(fails: no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c831d210832e95d0fd62e954f6a6