### PR TITLE
Fix inventory count overflow

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -374,6 +374,7 @@ namespace Inventory
                     countText.alignment = TextAnchor.UpperLeft;
                     countText.raycastTarget = false;
                     countText.color = Color.white;
+                    countText.horizontalOverflow = HorizontalWrapMode.Overflow;
                     countText.text = string.Empty;
                     var countRect = countGO.GetComponent<RectTransform>();
                     countRect.anchorMin = new Vector2(0f, 1f);


### PR DESCRIPTION
## Summary
- ensure inventory item count text uses Overflow mode for horizontal overflow

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d62193c8832e81bfe03e5cd8d567