### PR TITLE
Add bank clearing option to debug menu

### DIFF
--- a/Assets/Scripts/Bank/BankUI.cs
+++ b/Assets/Scripts/Bank/BankUI.cs
@@ -739,6 +739,17 @@ namespace BankSystem
             return false;
         }
 
+        public void ClearBank()
+        {
+            for (int i = 0; i < items.Length; i++)
+            {
+                items[i].item = null;
+                items[i].count = 0;
+                UpdateSlotVisual(i);
+            }
+            SaveState();
+        }
+
         private void SaveState()
         {
             if (playerInventory != null)

--- a/Assets/Scripts/Skills/SkillsDebugMenu.cs
+++ b/Assets/Scripts/Skills/SkillsDebugMenu.cs
@@ -212,6 +212,11 @@ namespace Skills
                 }
             }
 
+            if (GUILayout.Button("Clear Bank"))
+            {
+                BankUI.Instance?.ClearBank();
+            }
+
             GUILayout.EndScrollView();
 
             GUILayout.EndArea();


### PR DESCRIPTION
## Summary
- add `ClearBank` method to bank UI for removing all stored items
- expose new **Clear Bank** button in the F2 skills debug menu

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d7720780832ebdabc0d05d408a2e