### PR TITLE
Align stack limits with OSRS

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -596,9 +596,9 @@ namespace Inventory
             {
                 for (int i = 0; i < items.Length && remaining > 0; i++)
                 {
-                    if (items[i].item == item && items[i].count < item.maxStack)
+                    if (items[i].item == item && items[i].count < item.MaxStack)
                     {
-                        int add = Mathf.Min(item.maxStack - items[i].count, remaining);
+                        int add = Mathf.Min(item.MaxStack - items[i].count, remaining);
                         items[i].count += add;
                         remaining -= add;
                         UpdateSlotVisual(i);
@@ -611,7 +611,7 @@ namespace Inventory
                 if (items[i].item == null)
                 {
                     items[i].item = item;
-                    items[i].count = item.stackable ? Mathf.Min(item.maxStack, remaining) : 1;
+                    items[i].count = item.stackable ? Mathf.Min(item.MaxStack, remaining) : 1;
                     remaining -= items[i].count;
                     UpdateSlotVisual(i);
                 }
@@ -654,9 +654,9 @@ namespace Inventory
                 for (int i = 0; i < items.Length; i++)
                 {
                     if (items[i].item == item)
-                        space += item.maxStack - items[i].count;
+                        space += item.MaxStack - items[i].count;
                     else if (items[i].item == null)
-                        space += item.maxStack;
+                        space += item.MaxStack;
 
                     if (space >= quantity)
                         return true;

--- a/Assets/Scripts/Inventory/ItemData.cs
+++ b/Assets/Scripts/Inventory/ItemData.cs
@@ -50,11 +50,33 @@ namespace Inventory
         [Header("Stacking")] [Tooltip("If true, multiple items can occupy a single inventory slot.")]
         public bool stackable;
 
-        [Tooltip("Maximum number of items per stack when stackable.")]
-        public int maxStack = 1;
+        /// <summary>
+        /// Maximum stack size for stackable items. Old School RuneScape uses a
+        /// 32-bit signed integer limit (2,147,483,647) for all stackable items,
+        /// so we mirror that behaviour here.
+        /// </summary>
+        public const int OSRS_MAX_STACK = int.MaxValue;
+
+        // Serialized only so existing assets don't lose data. At runtime the
+        // <see cref="MaxStack"/> property should be used instead which returns
+        // the OSRS limit for stackable items or 1 for non-stackables.
+        [HideInInspector] public int maxStack = OSRS_MAX_STACK;
+
+        /// <summary>
+        /// Gets the maximum number of items that can occupy a single inventory
+        /// slot. Stackable items use the OSRS limit; non-stackables always return
+        /// 1.
+        /// </summary>
+        public int MaxStack => stackable ? OSRS_MAX_STACK : 1;
 
         [Tooltip("If true, stacks of this item can be split in the inventory.")]
         public bool splittable = true;
+
+        private void OnValidate()
+        {
+            // Keep the serialized value in sync for inspector visibility.
+            maxStack = stackable ? OSRS_MAX_STACK : 1;
+        }
 
         [Header("Equipment")] [Tooltip("Slot this item can be equipped to. Use None for non-equippable items.")]
         public EquipmentSlot equipmentSlot = EquipmentSlot.None;

--- a/Assets/Scripts/Shop/Shop.cs
+++ b/Assets/Scripts/Shop/Shop.cs
@@ -194,7 +194,7 @@ namespace ShopSystem
             if (!playerInventory.CanAddItem(currency, config.playerSellPrice))
             {
                 if (playerSlotIndex >= 0 && !item.stackable && currency != null &&
-                    currency.stackable && config.playerSellPrice <= currency.maxStack)
+                    currency.stackable && config.playerSellPrice <= currency.MaxStack)
                 {
                     if (!playerInventory.ReplaceItem(playerSlotIndex, item, currency, config.playerSellPrice))
                         return false;


### PR DESCRIPTION
## Summary
- Mirror Old School RuneScape's stack behaviour with a constant `OSRS_MAX_STACK`
- Use new `MaxStack` property in inventory logic
- Check `MaxStack` when selling items in shops

## Testing
- `dotnet build` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d8ac59dc832e91f1875dfc49b76c