### PR TITLE
Use ThaleahFat font for bank stack counts

### DIFF
--- a/Assets/Scripts/Bank/BankUI.cs
+++ b/Assets/Scripts/Bank/BankUI.cs
@@ -101,7 +101,9 @@ namespace BankSystem
                 defaultFont = null;
             }
 
-            stackCountFont = stackCountFont ?? defaultFont;
+            stackCountFont = Resources.Load<Font>("ThaleahFat_TTF") ??
+                             Resources.Load<Font>("ThaleahFAT_TTF") ??
+                             stackCountFont ?? defaultFont;
 
             CreateUI();
             uiRoot.SetActive(false);
@@ -308,7 +310,9 @@ namespace BankSystem
                 var countText = countGO.GetComponent<Text>();
                 countText.font = stackCountFont;
                 countText.fontSize = stackCountFontSize;
-                countText.alignment = TextAnchor.LowerRight;
+                countText.alignment = TextAnchor.UpperLeft;
+                countText.horizontalOverflow = HorizontalWrapMode.Overflow;
+                countText.verticalOverflow = VerticalWrapMode.Overflow;
                 countText.raycastTarget = false;
                 countText.color = Color.white;
                 var countRect = countGO.GetComponent<RectTransform>();


### PR DESCRIPTION
## Summary
- load ThaleahFat_TTF for Bank stack counts
- align stack value text top-left and allow overflow

## Testing
- `dotnet test` *(fails: specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b5dd1f1278832ebb2a2d3fe83dae39