### PR TITLE
Ensure inventory uses custom stack count font

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -248,6 +248,10 @@ namespace Inventory
                 defaultFont = null;
             }
 
+            stackCountFont = Resources.Load<Font>("ThaleahFat_TTF") ??
+                             Resources.Load<Font>("ThaleahFAT_TTF") ??
+                             stackCountFont ?? defaultFont;
+
             items = new InventoryEntry[size];
 
             if (EventSystem.current == null)


### PR DESCRIPTION
## Summary
- load ThaleahFat font for inventory stack count text so item quantities use the custom font instead of the Legacy default

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b5df201c50832eac0b4bb860973ee9