### PR TITLE
Set stack count font size to 12

### DIFF
--- a/Assets/Scripts/Bank/BankUI.cs
+++ b/Assets/Scripts/Bank/BankUI.cs
@@ -40,7 +40,7 @@ namespace BankSystem
         public Font stackCountFont;
 
         [Tooltip("Font size for stack count text.")]
-        public int stackCountFontSize = 14;
+        public int stackCountFontSize = 12;
 
         private const int Columns = 8;
         private const int Rows = 50;

--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -79,6 +79,9 @@ namespace Inventory
         [Tooltip("Optional: custom font for stack count text. Uses LegacyRuntime if null.")]
         public Font stackCountFont;
 
+        [Tooltip("Font size for stack count text.")]
+        public int stackCountFontSize = 12;
+
         [Header("Window")]
         [Tooltip("Background color for the inventory window.")]
         public Color windowColor = new Color(0.15f, 0.15f, 0.15f, 0.95f);
@@ -375,6 +378,7 @@ namespace Inventory
                     countGO.transform.SetParent(slot.transform, false);
                     var countText = countGO.GetComponent<Text>();
                     countText.font = stackCountFont ?? defaultFont;
+                    countText.fontSize = stackCountFontSize;
                     countText.alignment = TextAnchor.UpperLeft;
                     countText.raycastTarget = false;
                     countText.color = Color.white;


### PR DESCRIPTION
## Summary
- Set bank stack count text size to 12
- Add configurable stack count font size for inventory and default to 12

## Testing
- `dotnet build` *(fails: project or solution file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e1218764832e8615515df9b97a91