### PR TITLE
Update bank stack quantity colors

### DIFF
--- a/Assets/Scripts/Bank/BankUI.cs
+++ b/Assets/Scripts/Bank/BankUI.cs
@@ -22,15 +22,15 @@ namespace BankSystem
 
         [Header("Stack Count Colors")]
         [Tooltip("Color used for stack counts below 10,000.")]
-        public Color stackColorDefault = Color.yellow;
-        [Tooltip("Color used for stack counts of 10,000 or more.")]
-        public Color stackColor10k = Color.white;
-        [Tooltip("Color used for stack counts of 100,000 or more.")]
-        public Color stackColor100k = Color.green;
-        [Tooltip("Color used for stack counts of 10,000,000 or more.")]
-        public Color stackColor10m = Color.cyan;
+        public Color stackColorDefault = Color.white;
+        [Tooltip("Color used for stack counts between 10,000 and 99,999.")]
+        public Color stackColor10k = Color.yellow;
+        [Tooltip("Color used for stack counts between 100,000 and 999,999.")]
+        public Color stackColor100k = Color.yellow;
+        [Tooltip("Color used for stack counts of 1,000,000 or more.")]
+        public Color stackColor10m = Color.green;
         [Tooltip("Color used for stack counts of 100,000,000 or more.")]
-        public Color stackColor100m = Color.magenta;
+        public Color stackColor100m = Color.green;
 
         public Color windowColor = new Color(0.15f, 0.15f, 0.15f, 0.95f);
         public Vector2 windowPadding = new Vector2(8f, 8f);
@@ -355,15 +355,9 @@ namespace BankSystem
                 return (count / 1000000) + "m";
             }
 
-            if (count >= 10000000)
-            {
-                color = stackColor10m;
-                return (count / 1000000) + "m";
-            }
-
             if (count >= 1000000)
             {
-                color = stackColor100k;
+                color = stackColor10m;
                 return (count / 1000000) + "m";
             }
 


### PR DESCRIPTION
## Summary
- color bank stack counts yellow starting at 10k and 100k
- color bank stack counts green starting at 1m

## Testing
- `dotnet test` *(fails: `MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.`)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e7113450832ebda408202dad5359