### PR TITLE
Add outline to item stack counts in inventory and bank

### DIFF
--- a/Assets/Scripts/Bank/BankUI.cs
+++ b/Assets/Scripts/Bank/BankUI.cs
@@ -308,6 +308,9 @@ namespace BankSystem
                 GameObject countGO = new GameObject("Count", typeof(Text));
                 countGO.transform.SetParent(slot.transform, false);
                 var countText = countGO.GetComponent<Text>();
+                var outline = countGO.AddComponent<Outline>();
+                outline.effectColor = Color.black;
+                outline.effectDistance = new Vector2(1f, -1f);
                 countText.font = stackCountFont;
                 countText.fontSize = stackCountFontSize;
                 countText.alignment = TextAnchor.UpperLeft;

--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -377,6 +377,9 @@ namespace Inventory
                     GameObject countGO = new GameObject("Count", typeof(Text));
                     countGO.transform.SetParent(slot.transform, false);
                     var countText = countGO.GetComponent<Text>();
+                    var outline = countGO.AddComponent<Outline>();
+                    outline.effectColor = Color.black;
+                    outline.effectDistance = new Vector2(1f, -1f);
                     countText.font = stackCountFont ?? defaultFont;
                     countText.fontSize = stackCountFontSize;
                     countText.alignment = TextAnchor.UpperLeft;


### PR DESCRIPTION
## Summary
- add black outline to inventory slot count text for improved readability
- add black outline to bank slot count text to match inventory

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ea25c404832e88593c093cd8cd23