### PR TITLE
Disallow pet pickup when inventory is full

### DIFF
--- a/Assets/Scripts/Pets/InventoryBridge.cs
+++ b/Assets/Scripts/Pets/InventoryBridge.cs
@@ -21,7 +21,12 @@ namespace Pets
             {
                 var inv = player.GetComponent<Inventory.Inventory>();
                 if (inv != null)
-                    return inv.AddItem(item, amount);
+                {
+                    bool added = inv.AddItem(item, amount);
+                    if (!added)
+                        PetToastUI.Show("Your inventory is currently full");
+                    return added;
+                }
             }
 
             Debug.Log($"InventoryBridge: Added {amount}x {item?.itemName} (stub).");

--- a/Assets/Scripts/Pets/PetClickable.cs
+++ b/Assets/Scripts/Pets/PetClickable.cs
@@ -43,7 +43,10 @@ namespace Pets
         private void OnLeftClick()
         {
             if (definition != null && definition.pickupItem != null)
-                InventoryBridge.AddItem(definition.pickupItem, 1);
+            {
+                if (!InventoryBridge.AddItem(definition.pickupItem, 1))
+                    return;
+            }
 
             storage?.Close();
             PetDropSystem.DespawnActive();


### PR DESCRIPTION
## Summary
- Block pet pickup when player's inventory has no free slots
- Show a pet toast saying "Your inventory is currently full" if adding the pet item fails

## Testing
- `dotnet test` *(fails: Project file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68b7493223c4832ea2e69c533d84de76