### PR TITLE
Fix inventory drag icon rendering order

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -1040,7 +1040,11 @@ namespace Inventory
             dragCanvas.renderMode = RenderMode.ScreenSpaceOverlay;
             dragCanvas.overrideSorting = true;
             dragCanvas.sortingOrder = short.MaxValue;
-            draggingIcon.transform.SetParent(uiRoot.transform, false);
+            // Ensure the dragged icon renders above all inventory UIs by
+            // reparenting it to the shared root and placing it last.
+            Transform parent = sharedUIRoot != null ? sharedUIRoot.transform : uiRoot.transform;
+            draggingIcon.transform.SetParent(parent, false);
+            draggingIcon.transform.SetAsLastSibling();
             var img = draggingIcon.GetComponent<Image>();
             img.raycastTarget = false;
             img.sprite = item.icon ? item.icon : slotFrameSprite;


### PR DESCRIPTION
## Summary
- ensure dragged item icons are reparented to a shared root and placed last so they render above all inventory UIs

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b74a722e90832eb52b13cd38f6d521