### PR TITLE
Add menu-based pet pickup option

### DIFF
--- a/Assets/Scripts/Pets/PetClickable.cs
+++ b/Assets/Scripts/Pets/PetClickable.cs
@@ -1,11 +1,10 @@
 using UnityEngine;
-using UnityEngine.EventSystems;
 using Inventory;
 
 namespace Pets
 {
     /// <summary>
-    /// Detects clicks on the pet and converts it to an inventory item.
+    /// Handles picking up the active pet and converting it into an inventory item.
     /// </summary>
     [RequireComponent(typeof(Collider2D))]
     public class PetClickable : MonoBehaviour
@@ -29,22 +28,10 @@ namespace Pets
             col.isTrigger = true;
         }
 
-        private void Update()
-        {
-            if (!Input.GetMouseButtonDown(0))
-                return;
-
-            if (EventSystem.current != null && EventSystem.current.IsPointerOverGameObject())
-                return;
-
-            Vector3 world = Camera.main.ScreenToWorldPoint(Input.mousePosition);
-            Vector2 p = new Vector2(world.x, world.y);
-            var hit = Physics2D.OverlapPoint(p);
-            if (hit != null && hit.gameObject == gameObject)
-                OnLeftClick();
-        }
-
-        private void OnLeftClick()
+        /// <summary>
+        /// Attempts to convert the active pet to an inventory item.
+        /// </summary>
+        public void Pickup()
         {
             if (Time.time < nextPickupTime)
                 return;
@@ -72,6 +59,6 @@ namespace Pets
             PetToastUI.Show("You pick up the pet.");
             Destroy(gameObject);
         }
-
     }
 }
+

--- a/Assets/Scripts/UI/PetLevelBarContextMenuExtender.cs
+++ b/Assets/Scripts/UI/PetLevelBarContextMenuExtender.cs
@@ -13,6 +13,7 @@ namespace Pets
     {
         private Button mergeButton;
         private Text mergeText;
+        private Button pickupButton;
         private PetMergeController mergeController;
 
         partial void OnMenuCreated(Transform menuRoot)
@@ -20,14 +21,18 @@ namespace Pets
             mergeButton = CreateButton(menuRoot, "Merge");
             mergeText = mergeButton.GetComponentInChildren<Text>();
             mergeButton.onClick.AddListener(OnMergeClicked);
+
+            pickupButton = CreateButton(menuRoot, "Pick up");
+            pickupButton.onClick.AddListener(OnPickupClicked);
         }
 
         partial void OnMenuShown()
         {
-            if (mergeButton == null)
+            if (mergeButton == null || pickupButton == null)
                 return;
             if (mergeController == null)
                 mergeController = Object.FindObjectOfType<PetMergeController>();
+            pickupButton.gameObject.SetActive(PetDropSystem.ActivePetObject != null);
             if (mergeController == null)
             {
                 mergeButton.gameObject.SetActive(false);
@@ -65,6 +70,17 @@ namespace Pets
                 mergeController.EndMerge();
             else
                 mergeController.TryStartMerge();
+            Hide();
+        }
+
+        private void OnPickupClicked()
+        {
+            var pet = PetDropSystem.ActivePetObject;
+            if (pet != null)
+            {
+                var clickable = pet.GetComponent<PetClickable>();
+                clickable?.Pickup();
+            }
             Hide();
         }
     }


### PR DESCRIPTION
## Summary
- add Pick up button to pet level menu under Merge
- enable pet pickup via menu and remove click-to-pickup behaviour

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b74d3fa708832eb5975890bc626162