### PR TITLE
Ensure pet level bar context menu overlays other UI

### DIFF
--- a/Assets/Scripts/Pets/PetLevelBarMenu.cs
+++ b/Assets/Scripts/Pets/PetLevelBarMenu.cs
@@ -32,6 +32,9 @@ namespace Pets
             var canvasGO = new GameObject("PetBarMenuCanvas", typeof(Canvas), typeof(CanvasScaler), typeof(GraphicRaycaster));
             menuCanvas = canvasGO.GetComponent<Canvas>();
             menuCanvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            // Ensure the context menu canvas renders above other UI elements
+            menuCanvas.overrideSorting = true;
+            menuCanvas.sortingOrder = short.MaxValue;
             Object.DontDestroyOnLoad(canvasGO);
 
             var menuGO = new GameObject("PetLevelBarMenu", typeof(Image), typeof(PetLevelBarMenu), typeof(VerticalLayoutGroup), typeof(ContentSizeFitter));


### PR DESCRIPTION
## Summary
- Force the pet level bar context menu canvas to sort above other UI elements

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b750213468832e805a277ac59f10ce