### PR TITLE
Add toggleable pet inventory

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -177,7 +177,12 @@ namespace Inventory
                 var pet = PetDropSystem.ActivePetObject;
                 var storage = pet != null ? pet.GetComponent<PetStorage>() : null;
                 if (!BankOpen)
-                    storage?.Open();
+                {
+                    if (PetDropSystem.PetInventoryVisible)
+                        storage?.Open();
+                    else
+                        storage?.Close();
+                }
                 else
                     storage?.Close();
             }

--- a/Assets/Scripts/Pets/PetDropSystem.cs
+++ b/Assets/Scripts/Pets/PetDropSystem.cs
@@ -21,6 +21,7 @@ namespace Pets
         public static PetCombatController ActivePetCombat => activePetGO != null ? activePetGO.GetComponent<PetCombatController>() : null;
         public static bool DebugPetRolls { get; set; }
         public static bool GuardModeEnabled { get; set; }
+        public static bool PetInventoryVisible { get; set; }
         private static bool initialized;
         private static bool quittingRegistered;
 
@@ -211,6 +212,7 @@ namespace Pets
             {
                 var storage = activePetGO.GetComponent<PetStorage>();
                 storage?.Close();
+                PetInventoryVisible = false;
                 UnityEngine.Object.Destroy(activePetGO);
                 activePetGO = null;
                 activePetDef = null;
@@ -252,7 +254,8 @@ namespace Pets
             Debug.Log($"Spawned pet '{pet.displayName}' at {spawnPos}.");
 
             var playerInventory = playerTransform != null ? playerTransform.GetComponent<Inventory.Inventory>() : null;
-            if (playerInventory != null && playerInventory.IsOpen && !playerInventory.BankOpen)
+            PetInventoryVisible = false;
+            if (playerInventory != null && playerInventory.IsOpen && !playerInventory.BankOpen && PetInventoryVisible)
             {
                 var storage = activePetGO.GetComponent<PetStorage>();
                 storage?.StartCoroutine(storage.OpenDelayed());

--- a/Assets/Scripts/Pets/PetLevelBarHUD.cs
+++ b/Assets/Scripts/Pets/PetLevelBarHUD.cs
@@ -144,6 +144,26 @@ namespace Pets
             PetDropSystem.GuardModeEnabled = !PetDropSystem.GuardModeEnabled;
         }
 
+        public void ToggleInventory()
+        {
+            var pet = PetDropSystem.ActivePetObject;
+            if (pet == null)
+                return;
+            var storage = pet.GetComponent<PetStorage>();
+            if (storage == null)
+                return;
+            if (PetDropSystem.PetInventoryVisible)
+            {
+                storage.Close();
+                PetDropSystem.PetInventoryVisible = false;
+            }
+            else
+            {
+                storage.Open();
+                PetDropSystem.PetInventoryVisible = true;
+            }
+        }
+
         public void OnPointerClick(PointerEventData eventData)
         {
             if (eventData.button == PointerEventData.InputButton.Right)

--- a/Assets/Scripts/Pets/PetLevelBarMenu.cs
+++ b/Assets/Scripts/Pets/PetLevelBarMenu.cs
@@ -11,6 +11,8 @@ namespace Pets
         private Button xpButton;
         private Button guardButton;
         private Text guardText;
+        private Button inventoryButton;
+        private Text inventoryText;
         private PetLevelBarHUD current;
 
         private static PetLevelBarMenu instance;
@@ -22,6 +24,13 @@ namespace Pets
                 CreateInstance();
             instance.current = hud;
             instance.guardText.text = PetDropSystem.GuardModeEnabled ? "Guard Mode: On" : "Guard Mode: Off";
+            var pet = PetDropSystem.ActivePetObject;
+            var storage = pet != null ? pet.GetComponent<PetStorage>() : null;
+            var inv = pet != null ? pet.GetComponent<Inventory.Inventory>() : null;
+            bool hasInventory = storage != null && inv != null;
+            instance.inventoryButton.gameObject.SetActive(hasInventory);
+            if (hasInventory)
+                instance.inventoryText.text = PetDropSystem.PetInventoryVisible ? "Inventory: On" : "Inventory: Off";
             instance.transform.position = position;
             instance.gameObject.SetActive(true);
             instance.OnMenuShown();
@@ -62,6 +71,14 @@ namespace Pets
             instance.guardButton.onClick.AddListener(() =>
             {
                 instance.current?.ToggleGuardMode();
+                instance.Hide();
+            });
+
+            instance.inventoryButton = CreateButton(menuGO.transform, "Inventory");
+            instance.inventoryText = instance.inventoryButton.GetComponentInChildren<Text>();
+            instance.inventoryButton.onClick.AddListener(() =>
+            {
+                instance.current?.ToggleInventory();
                 instance.Hide();
             });
 

--- a/Assets/Scripts/Pets/PetStorage.cs
+++ b/Assets/Scripts/Pets/PetStorage.cs
@@ -48,7 +48,7 @@ namespace Pets
         private void Start()
         {
             var playerInv = GameObject.FindGameObjectWithTag("Player")?.GetComponent<Inventory.Inventory>();
-            if (playerInv != null && playerInv.IsOpen && !playerInv.BankOpen)
+            if (playerInv != null && playerInv.IsOpen && !playerInv.BankOpen && PetDropSystem.PetInventoryVisible)
                 StartCoroutine(OpenDelayed());
         }
 


### PR DESCRIPTION
## Summary
- add Inventory toggle to pet context menu under Guard Mode
- track pet inventory visibility and default to off on spawn
- gate auto-opening logic on visibility flag

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b751f16a40832e807bc24f444b6f45