### PR TITLE
Restrict skilling pet inventories to resource items

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -603,6 +603,10 @@ namespace Inventory
             if (item == null || quantity <= 0)
                 return false;
 
+            var petStorage = GetComponent<PetStorage>();
+            if (petStorage != null && !petStorage.CanStore(item))
+                return false;
+
             if (!CanAddItem(item, quantity))
                 return false;
 
@@ -661,6 +665,10 @@ namespace Inventory
         public bool CanAddItem(ItemData item, int quantity = 1)
         {
             if (item == null || quantity <= 0)
+                return false;
+
+            var petStorage = GetComponent<PetStorage>();
+            if (petStorage != null && !petStorage.CanStore(item))
                 return false;
 
             int space = 0;

--- a/Assets/Scripts/Pets/PetStorage.cs
+++ b/Assets/Scripts/Pets/PetStorage.cs
@@ -209,7 +209,7 @@ namespace Pets
             }
         }
 
-        private bool CanStore(ItemData item)
+        public bool CanStore(ItemData item)
         {
             if (definition == null || item == null)
                 return false;


### PR DESCRIPTION
## Summary
- expose `PetStorage.CanStore` to check if a pet may hold an item
- validate items against pet storage restrictions when adding to inventory

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68b754e60db8832eac6ab65432bf06dc