### PR TITLE
Persist BycatchManager across scenes

### DIFF
--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -5,6 +5,7 @@ using World;
 using Inventory;
 using ShopSystem;
 using Player;
+using Fishing.Bycatch;
 
 namespace Core
 {
@@ -20,6 +21,7 @@ namespace Core
         private ItemDatabase itemDatabase;
         private ShopUI shopUI;
         private PlayerRespawnSystem respawnSystem;
+        private BycatchManager bycatchManager;
 
         /// <summary>
         /// Event fired once all services are initialized.
@@ -29,6 +31,7 @@ namespace Core
         public static Ticker Ticker => Instance.ticker;
         public static ScreenFader ScreenFader => Instance.screenFader;
         public static ItemDatabase ItemDatabase => Instance.itemDatabase;
+        public static BycatchManager BycatchManager => Instance.bycatchManager;
 
         private void Awake()
         {
@@ -46,6 +49,7 @@ namespace Core
             itemDatabase = FindOrCreate<ItemDatabase>();
             shopUI = FindOrCreate<ShopUI>();
             respawnSystem = FindOrCreate<PlayerRespawnSystem>();
+            bycatchManager = FindOrCreate<BycatchManager>();
 
             ServicesReady?.Invoke();
         }
@@ -60,6 +64,7 @@ namespace Core
             {
                 var go = new GameObject(typeof(T).Name);
                 service = go.AddComponent<T>();
+                DontDestroyOnLoad(go);
             }
             return service;
         }

--- a/Assets/Scripts/Fishing/Bycatch/BycatchManager.cs
+++ b/Assets/Scripts/Fishing/Bycatch/BycatchManager.cs
@@ -12,6 +12,20 @@ namespace Fishing.Bycatch
         private readonly Dictionary<WaterType, int> _noRareStreak = new();
         private readonly Dictionary<WaterType, int> _lastSeedDay = new();
 
+        private static BycatchManager instance;
+
+        private void Awake()
+        {
+            if (instance != null && instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+
         public int GetStreak(WaterType wt)
         {
             int today = DateTime.UtcNow.Date.GetHashCode();

--- a/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
@@ -9,6 +9,7 @@ using Core.Save;
 using Pets;
 using Fishing;
 using Fishing.Bycatch;
+using Core;
 
 namespace Skills.Fishing
 {
@@ -19,7 +20,7 @@ namespace Skills.Fishing
         [SerializeField] private Inventory.Inventory inventory;
         [SerializeField] private Transform floatingTextAnchor;
         [SerializeField] private MonoBehaviour saveProvider; // optional custom save provider
-        [SerializeField] private BycatchManager bycatchManager;
+        private BycatchManager bycatchManager;
 
         private IFishingSave save;
 
@@ -55,6 +56,8 @@ namespace Skills.Fishing
                 inventory = GetComponent<Inventory.Inventory>();
             save = saveProvider as IFishingSave ?? new SaveManagerFishingSave();
             PreloadFishItems();
+            if (bycatchManager == null)
+                bycatchManager = GameManager.BycatchManager;
         }
 
         private void OnEnable()


### PR DESCRIPTION
## Summary
- Ensure BycatchManager survives scene loads and acts as singleton
- Expose BycatchManager through GameManager and auto-bootstrap it
- Fetch BycatchManager from GameManager in FishingSkill to avoid manual references

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*
- `dotnet build` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b852758bd4832e85a26f75db5d541b