### PR TITLE
Add EnumFlags attribute and refine fishing skill namespaces

### DIFF
--- a/Assets/Scripts/Fishing/Bycatch/BycatchItemDefinition.cs
+++ b/Assets/Scripts/Fishing/Bycatch/BycatchItemDefinition.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using Util;
 
 namespace Fishing.Bycatch
 {

--- a/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
@@ -151,7 +151,7 @@ namespace Skills.Fishing
             float chance = baseChance + (level * 0.005f) + currentTool.CatchBonus * 0.01f - penalty;
             chance = Mathf.Clamp(chance, 0.05f, 0.90f);
 
-            if (Random.value <= chance)
+            if (UnityEngine.Random.value <= chance)
             {
                 int amount = PetDropSystem.ActivePet?.id == "Heron" ? 2 : 1;
                 if (amount > 1)
@@ -264,17 +264,17 @@ namespace Skills.Fishing
             FloatingText.Show($"+{res.quantity} {res.item.DisplayName}", anchor.position);
         }
 
-        private Fishing.Bycatch.FishingTool MapTool(FishingToolDefinition tool)
+        private global::Fishing.Bycatch.FishingTool MapTool(FishingToolDefinition tool)
         {
             if (tool == null)
-                return Fishing.Bycatch.FishingTool.Any;
+                return global::Fishing.Bycatch.FishingTool.Any;
             string name = tool.DisplayName?.Replace(" ", "");
-            if (!string.IsNullOrEmpty(name) && Enum.TryParse(name, true, out Fishing.Bycatch.FishingTool res))
+            if (!string.IsNullOrEmpty(name) && Enum.TryParse<global::Fishing.Bycatch.FishingTool>(name, true, out var res))
                 return res;
             name = tool.Id?.Replace(" ", "");
-            if (!string.IsNullOrEmpty(name) && Enum.TryParse(name, true, out res))
+            if (!string.IsNullOrEmpty(name) && Enum.TryParse<global::Fishing.Bycatch.FishingTool>(name, true, out res))
                 return res;
-            return Fishing.Bycatch.FishingTool.Any;
+            return global::Fishing.Bycatch.FishingTool.Any;
         }
 
         public void StartFishing(FishableSpot spot, FishingToolDefinition tool)

--- a/Assets/Scripts/Util/EnumFlagsAttribute.cs
+++ b/Assets/Scripts/Util/EnumFlagsAttribute.cs
@@ -1,0 +1,11 @@
+using UnityEngine;
+
+namespace Util
+{
+    /// <summary>
+    /// Attribute for displaying enum values as flag mask in the Unity inspector.
+    /// </summary>
+    public class EnumFlagsAttribute : PropertyAttribute
+    {
+    }
+}

--- a/Assets/Scripts/Util/EnumFlagsAttribute.cs.meta
+++ b/Assets/Scripts/Util/EnumFlagsAttribute.cs.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 980045d6d75a4204bdcc87db292b5895
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Provide a simple `EnumFlagsAttribute` for flag-style enum masks in the editor
- Enable `[EnumFlags]` usage in `BycatchItemDefinition` by importing Util namespace
- Resolve ambiguous Random reference and strongly type FishingTool mapping

## Testing
- `mcs Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs` *(fails: The type or namespace name `UnityEngine` could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b855615ae8832eb370d164d7f6916d