### PR TITLE
Add debug toggle for fishing bycatch logging

### DIFF
--- a/Assets/Scripts/Skills/Fishing/Bycatch/BycatchManager.cs
+++ b/Assets/Scripts/Skills/Fishing/Bycatch/BycatchManager.cs
@@ -9,6 +9,12 @@ namespace Skills.Fishing
         public BycatchTable bycatchTable;
         public bool useDailySeed = true;
 
+        /// <summary>
+        /// When enabled, the bycatch system will emit debug logs for each roll.
+        /// Controlled via the F2 debug menu.
+        /// </summary>
+        public static bool DebugBycatchRolls { get; set; }
+
         private readonly Dictionary<WaterType, int> _noRareStreak = new();
         private readonly Dictionary<WaterType, int> _lastSeedDay = new();
 

--- a/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
@@ -248,6 +248,15 @@ namespace Skills.Fishing
             };
 
             var res = bycatchManager.Roll(ctx);
+            if (BycatchManager.DebugBycatchRolls)
+            {
+                string result = res.IsNone
+                    ? "no bycatch"
+                    : $"{res.item.DisplayName} x{res.quantity} ({res.Rarity})";
+                Debug.Log(
+                    $"[Bycatch] roll {ctx.rollIndex} lvl={ctx.playerLevel} bait={ctx.hasBait} water={ctx.waterType} tool={ctx.tool} streak={streak} -> {result}");
+            }
+
             bycatchManager.ApplyStreakResult(waterType, res);
             if (res.IsNone)
                 return;

--- a/Assets/Scripts/Skills/SkillsDebugMenu.cs
+++ b/Assets/Scripts/Skills/SkillsDebugMenu.cs
@@ -196,6 +196,11 @@ namespace Skills
                 PetDropSystem.DebugPetRolls = !PetDropSystem.DebugPetRolls;
             }
 
+            if (GUILayout.Button(BycatchManager.DebugBycatchRolls ? "Disable Bycatch Debug" : "Enable Bycatch Debug"))
+            {
+                BycatchManager.DebugBycatchRolls = !BycatchManager.DebugBycatchRolls;
+            }
+
             if (GUILayout.Button("Open Bank"))
             {
                 BankUI.Instance?.Open();


### PR DESCRIPTION
## Summary
- add F2 menu toggle to enable bycatch debug logging
- add BycatchManager.DebugBycatchRolls flag and log rolls when enabled

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b85c6b38c0832e84c4367542151cc8