### PR TITLE
Add BycatchInitializer to configure BycatchManager

### DIFF
--- a/Assets/Scripts/Skills/Fishing/Bycatch/BycatchInitializer.cs
+++ b/Assets/Scripts/Skills/Fishing/Bycatch/BycatchInitializer.cs
@@ -1,0 +1,31 @@
+using System.Collections;
+using UnityEngine;
+
+namespace Skills.Fishing
+{
+    public class BycatchInitializer : MonoBehaviour
+    {
+        public BycatchTable table;
+        public string resourcesPath = "FishingDatabase/ByCatch/BycatchTable";
+
+        private void Start()
+        {
+            StartCoroutine(AssignWhenManagerReady());
+        }
+
+        private IEnumerator AssignWhenManagerReady()
+        {
+            BycatchManager manager;
+            while ((manager = FindObjectOfType<BycatchManager>()) == null)
+                yield return null;
+
+            if (table == null)
+                table = Resources.Load<BycatchTable>(resourcesPath);
+
+            if (table != null)
+                manager.bycatchTable = table;
+            else
+                Debug.LogWarning($"BycatchInitializer could not load BycatchTable at Resources/{resourcesPath}");
+        }
+    }
+}

--- a/Assets/Scripts/Skills/Fishing/Bycatch/BycatchInitializer.cs.meta
+++ b/Assets/Scripts/Skills/Fishing/Bycatch/BycatchInitializer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f2dac18e0344ce9df38b55e23c046a29


### PR DESCRIPTION
## Summary
- add a `BycatchInitializer` MonoBehaviour that waits for `BycatchManager` to be present and assigns its `BycatchTable`
- load `BycatchTable` from `Resources/FishingDatabase/ByCatch/BycatchTable` when no table is assigned in the inspector

## Testing
- `dotnet build` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68b86164e888832e8d6fed86d6193f2f