### PR TITLE
Add fishing XP bonus and fisher hat item

### DIFF
--- a/Assets/Resources/Item/Fisher Hat.asset
+++ b/Assets/Resources/Item/Fisher Hat.asset
@@ -1,0 +1,43 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9bd10a448bc2cf140bb71ea5a65cca5d, type: 3}
+  m_Name: Fisher Hat
+  m_EditorClassIdentifier:
+  id: Fisher Hat
+  itemName: Fisher Hat
+  icon: {fileID: 0}
+  description: 'A hat for anglers'
+  stackable: 0
+  maxStack: 0
+  splittable: 0
+  equipmentSlot: 1
+  bycatchChanceBonus: 0
+  fishingXpBonusMultiplier: 0.025
+  skillRequirements: []
+  combat:
+    Attack: 0
+    Strength: 0
+    Range: 0
+    Magic: 0
+    MeleeDefence: 0
+    RangeDefence: 0
+    MagicDefence: 0
+    AttackSpeedTicks: 0
+  attackBonus: 0
+  defenceBonus: 0
+  attackSpeed: 0
+  strengthBonus: 0
+  rangeBonus: 0
+  magicBonus: 0
+  meleeDefenceBonus: 0
+  rangedDefenceBonus: 0
+  magicDefenceBonus: 0

--- a/Assets/Resources/Item/Fisher Hat.asset.meta
+++ b/Assets/Resources/Item/Fisher Hat.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9ba854da503240e9957d6bff4cee3986
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Inventory/ItemData.cs
+++ b/Assets/Scripts/Inventory/ItemData.cs
@@ -85,6 +85,9 @@ namespace Inventory
         [Tooltip("Extra bycatch roll chance (0.01 = 1%).")]
         public float bycatchChanceBonus = 0f;
 
+        [Tooltip("Additional fishing XP multiplier (0.025 = +2.5% XP).")]
+        public float fishingXpBonusMultiplier = 0f;
+
         [Header("Requirements")]
         public SkillRequirement[] skillRequirements;
 

--- a/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
@@ -188,9 +188,22 @@ namespace Skills.Fishing
                     return;
                 }
 
-                xp += fish.Xp * amount;
+                float xpBonus = 0f;
+                if (equipment != null)
+                {
+                    foreach (EquipmentSlot slot in Enum.GetValues(typeof(EquipmentSlot)))
+                    {
+                        if (slot == EquipmentSlot.None)
+                            continue;
+                        var entry = equipment.GetEquipped(slot);
+                        if (entry.item != null)
+                            xpBonus += entry.item.fishingXpBonusMultiplier;
+                    }
+                }
+                int xpGain = Mathf.RoundToInt(fish.Xp * amount * (1f + xpBonus));
+                xp += xpGain;
                 FloatingText.Show($"+{amount} {fish.DisplayName}", anchor.position);
-                StartCoroutine(ShowXpGainDelayed(fish.Xp * amount, anchor));
+                StartCoroutine(ShowXpGainDelayed(xpGain, anchor));
                 OnFishCaught?.Invoke(fish.Id, amount);
 
                 TryRollBycatch(anchor);


### PR DESCRIPTION
## Summary
- add fishing XP bonus multiplier to `ItemData`
- apply gear-based XP bonus in `FishingSkill`
- introduce Fisher Hat item granting 2.5% extra fishing XP

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ab85a55c832e882d472e478cf307