### PR TITLE
Handle equip failure with slot restore

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -215,11 +215,22 @@ namespace Inventory
             var entry = items[index];
             if (entry.item == null || entry.item.equipmentSlot == EquipmentSlot.None)
                 return false;
+
+            // Temporarily free the slot before attempting to equip.
+            items[index] = default;
+            UpdateSlotVisual(index);
+
+            // Try to equip the item.
             if (equipment.Equip(entry))
             {
-                ClearSlot(index);
+                OnInventoryChanged?.Invoke();
                 return true;
             }
+
+            // Equipping failed. Restore the original item.
+            items[index] = entry;
+            UpdateSlotVisual(index);
+            OnInventoryChanged?.Invoke();
             return false;
         }
 


### PR DESCRIPTION
## Summary
- free inventory slot before equipping items
- restore slot and notify if equipping fails

## Testing
- `dotnet test` (fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)

------
https://chatgpt.com/codex/tasks/task_e_68b9b7e09ab8832e9bbcd126d7f36434