### PR TITLE
Add item combination system with selection highlight

### DIFF
--- a/Assets/Scripts/Inventory/InventorySlot.cs
+++ b/Assets/Scripts/Inventory/InventorySlot.cs
@@ -64,26 +64,32 @@ namespace Inventory
                     BankSystem.BankUI.Instance?.ShowDepositMenu(index, eventData.position);
                 return;
             }
-            bool shift = Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);
+
             if (eventData.button == PointerEventData.InputButton.Left)
             {
-                if (!eventData.dragging)
+                if (inventory.selectedIndex < 0)
                 {
-                    if (inventory != null && inventory.InShop)
-                    {
-                        if (shift)
-                            inventory?.PromptStackSplit(index, StackSplitType.Sell);
-                        else
-                            inventory?.SellItem(index, 1);
-                    }
-                    else
-                    {
-                        if (inventory == null || !inventory.EquipItem(index))
-                            inventory?.UseItem(index);
-                    }
+                    inventory.selectedIndex = index;
+                    inventory.UpdateSlotVisual(index);
                 }
+                else if (inventory.selectedIndex == index)
+                {
+                    inventory.ClearSelection();
+                    inventory.UpdateSlotVisual(index);
+                }
+                else
+                {
+                    inventory.CombineItems(inventory.selectedIndex, index);
+                    int prev = inventory.selectedIndex;
+                    inventory.ClearSelection();
+                    inventory.UpdateSlotVisual(prev);
+                    inventory.UpdateSlotVisual(index);
+                }
+                return;
             }
-            else if (eventData.button == PointerEventData.InputButton.Right)
+
+            bool shift = Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);
+            if (eventData.button == PointerEventData.InputButton.Right)
             {
                 if (shift)
                     inventory?.PromptStackSplit(index, StackSplitType.Drop);

--- a/Assets/Scripts/Inventory/ItemCombinationDatabase.cs
+++ b/Assets/Scripts/Inventory/ItemCombinationDatabase.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Inventory
+{
+    [CreateAssetMenu(menuName = "Inventory/Item Combination Database")]
+    public class ItemCombinationDatabase : ScriptableObject
+    {
+        [Serializable]
+        public struct Recipe
+        {
+            public ItemData first;
+            public ItemData second;
+            public ItemData result;
+        }
+
+        public Recipe[] recipes;
+        private Dictionary<(ItemData, ItemData), ItemData> lookup;
+
+        public ItemData GetResult(ItemData a, ItemData b)
+        {
+            if (lookup == null)
+            {
+                lookup = new Dictionary<(ItemData, ItemData), ItemData>();
+                if (recipes != null)
+                {
+                    foreach (var r in recipes)
+                    {
+                        if (r.first != null && r.second != null && r.result != null)
+                        {
+                            lookup[(r.first, r.second)] = r.result;
+                            lookup[(r.second, r.first)] = r.result;
+                        }
+                    }
+                }
+            }
+
+            ItemData result;
+            return lookup != null && lookup.TryGetValue((a, b), out result) ? result : null;
+        }
+    }
+}

--- a/Assets/Scripts/Inventory/ItemCombinationDatabase.cs.meta
+++ b/Assets/Scripts/Inventory/ItemCombinationDatabase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bc75d245a2fb728b86977c4dbb293d93


### PR DESCRIPTION
## Summary
- track selected inventory slot and highlight it with dedicated UI image
- allow combining items using recipes and clear selection afterwards
- expose item combination database for designer-defined recipes

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*
- `npm test` *(fails: no package.json found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cb6e4120832eb189710d3763c7e7