### PR TITLE
Equip items on left click

### DIFF
--- a/Assets/Scripts/Inventory/InventorySlot.cs
+++ b/Assets/Scripts/Inventory/InventorySlot.cs
@@ -67,6 +67,12 @@ namespace Inventory
 
             if (eventData.button == PointerEventData.InputButton.Left)
             {
+                var entry = inventory.GetSlot(index);
+                if (entry.item != null && entry.item.equipmentSlot != EquipmentSlot.None)
+                {
+                    inventory.EquipItem(index);
+                    return;
+                }
                 if (inventory.selectedIndex < 0)
                 {
                     inventory.selectedIndex = index;


### PR DESCRIPTION
## Summary
- Equip gear directly from inventory when left-clicked
- Preserve existing selection and combine behavior for non-equippable items

## Testing
- `dotnet build` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cf1c9a54832e8c83704b1e1e3cc6