### PR TITLE
Add shop sell and shift-split in inventory slot

### DIFF
--- a/Assets/Scripts/Inventory/InventorySlot.cs
+++ b/Assets/Scripts/Inventory/InventorySlot.cs
@@ -65,6 +65,14 @@ namespace Inventory
                 return;
             }
 
+            bool shift = Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);
+            if (inventory != null && inventory.InShop && eventData.button == PointerEventData.InputButton.Left)
+            {
+                if (shift) inventory.PromptStackSplit(index, StackSplitType.Sell);
+                else       inventory.SellItem(index, 1);
+                return;
+            }
+
             if (eventData.button == PointerEventData.InputButton.Left)
             {
                 var entry = inventory.GetSlot(index);
@@ -94,7 +102,6 @@ namespace Inventory
                 return;
             }
 
-            bool shift = Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);
             if (eventData.button == PointerEventData.InputButton.Right)
             {
                 if (shift)


### PR DESCRIPTION
## Summary
- Allow selling items with left click when inventory is in shop
- Support shift-click stack splitting for selling

## Testing
- `dotnet test` (fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)

------
https://chatgpt.com/codex/tasks/task_e_68b9d1a87910832e8725a6c4cd3f75df