### PR TITLE
Fix equip logic when item selected

### DIFF
--- a/Assets/Scripts/Inventory/InventorySlot.cs
+++ b/Assets/Scripts/Inventory/InventorySlot.cs
@@ -76,13 +76,14 @@ namespace Inventory
             if (eventData.button == PointerEventData.InputButton.Left)
             {
                 var entry = inventory.GetSlot(index);
-                if (entry.item != null && entry.item.equipmentSlot != EquipmentSlot.None)
-                {
-                    inventory.EquipItem(index);
-                    return;
-                }
                 if (inventory.selectedIndex < 0)
                 {
+                    if (entry.item != null && entry.item.equipmentSlot != EquipmentSlot.None)
+                    {
+                        inventory.EquipItem(index);
+                        return;
+                    }
+
                     inventory.selectedIndex = index;
                     inventory.UpdateSlotVisual(index);
                 }


### PR DESCRIPTION
## Summary
- Only allow equipping items when no item is selected in the inventory
- Preserve existing left-click behavior for combining items when a selection exists

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b9db7d0f40832eb947ce78aeb70c6a