### PR TITLE
feat: add water-type specific fishing xp bonuses

### DIFF
--- a/Assets/Resources/Item/Freshwater Fishing Charm.asset
+++ b/Assets/Resources/Item/Freshwater Fishing Charm.asset
@@ -21,7 +21,8 @@ MonoBehaviour:
   splittable: 0
   equipmentSlot: 0
   bycatchChanceBonus: 0
-  fishingXpBonusMultiplier: 0
+  fishingXpBonusMultiplier: 0.02
+  fishingXpBonusWaterTypes: 1
   woodcuttingXpBonusMultiplier: 0
   miningXpBonusMultiplier: 0
   skillRequirements: []

--- a/Assets/Scripts/Inventory/ItemData.cs
+++ b/Assets/Scripts/Inventory/ItemData.cs
@@ -2,6 +2,7 @@ using System;
 using UnityEngine;
 using Items;
 using Skills;
+using Skills.Fishing;
 
 namespace Inventory
 {
@@ -88,6 +89,9 @@ namespace Inventory
 
         [Tooltip("Additional fishing XP multiplier (0.025 = +2.5% XP).")]
         public float fishingXpBonusMultiplier = 0f;
+
+        [Tooltip("Water types where the fishing XP bonus applies.")]
+        public WaterType fishingXpBonusWaterTypes = WaterType.Any;
 
         [Header("Woodcutting Bonuses")]
         [Tooltip("Additional woodcutting XP multiplier (0.025 = +2.5% XP).")]

--- a/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
@@ -189,6 +189,7 @@ namespace Skills.Fishing
                 }
 
                 float xpBonus = 0f;
+                var waterType = currentSpot != null && currentSpot.def != null ? currentSpot.def.WaterType : WaterType.Any;
                 if (equipment != null)
                 {
                     foreach (EquipmentSlot slot in Enum.GetValues(typeof(EquipmentSlot)))
@@ -196,7 +197,7 @@ namespace Skills.Fishing
                         if (slot == EquipmentSlot.None)
                             continue;
                         var entry = equipment.GetEquipped(slot);
-                        if (entry.item != null)
+                        if (entry.item != null && (entry.item.fishingXpBonusWaterTypes & waterType) != 0)
                             xpBonus += entry.item.fishingXpBonusMultiplier;
                     }
                 }


### PR DESCRIPTION
## Summary
- add water-type selector to item data for fishing xp bonuses
- apply water-type check when granting fishing xp
- configure Freshwater Fishing Charm for freshwater bonus

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68baf4bc5c6c832ea9d4c7890776f4ab