### PR TITLE
Improve inventory slot highlight

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -400,9 +400,9 @@ namespace Inventory
                     GameObject highlightGO = new GameObject("Highlight", typeof(Image));
                     highlightGO.transform.SetParent(slot.transform, false);
                     var highlightImg = highlightGO.GetComponent<Image>();
-                    highlightImg.sprite = slotFrameSprite;
-                    highlightImg.type = (slotFrameSprite != null) ? Image.Type.Sliced : Image.Type.Simple;
-                    highlightImg.color = Color.clear;
+                    highlightImg.sprite = null;
+                    highlightImg.color = new Color(1f, 1f, 1f, 0f);
+                    highlightImg.type = Image.Type.Simple;
                     highlightImg.raycastTarget = false;
                     var highlightOutline = highlightGO.AddComponent<Outline>();
                     highlightOutline.effectColor = Color.yellow;
@@ -631,7 +631,13 @@ namespace Inventory
             }
 
             if (slotHighlights != null && slotHighlights.Length > index && slotHighlights[index] != null)
-                slotHighlights[index].enabled = (selectedIndex == index);
+            {
+                var highlight = slotHighlights[index];
+                highlight.sprite = slotImages[index].sprite;
+                highlight.type = Image.Type.Simple;
+                highlight.color = new Color(1f, 1f, 1f, 0f); // transparent fill
+                highlight.enabled = (selectedIndex == index);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- Initialize highlight images without a sprite and with transparent white so outlines draw on an invisible image
- Update slot highlight to mirror item icon and only enable when selected

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68baf671ebc8832e889501f3c70fd325