### PR TITLE
Prevent outlines from using graphic alpha

### DIFF
--- a/Assets/Scripts/Bank/BankUI.cs
+++ b/Assets/Scripts/Bank/BankUI.cs
@@ -311,6 +311,7 @@ namespace BankSystem
                 var outline = countGO.AddComponent<Outline>();
                 outline.effectColor = Color.black;
                 outline.effectDistance = new Vector2(1f, -1f);
+                outline.useGraphicAlpha = false;
                 countText.font = stackCountFont;
                 countText.fontSize = stackCountFontSize;
                 countText.alignment = TextAnchor.UpperLeft;

--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -407,6 +407,7 @@ namespace Inventory
                     var highlightOutline = highlightGO.AddComponent<Outline>();
                     highlightOutline.effectColor = Color.yellow;
                     highlightOutline.effectDistance = new Vector2(1f, -1f);
+                    highlightOutline.useGraphicAlpha = false;
                     var hlRect = highlightGO.GetComponent<RectTransform>();
                     hlRect.anchorMin = Vector2.zero;
                     hlRect.anchorMax = Vector2.one;
@@ -422,6 +423,7 @@ namespace Inventory
                     var outline = countGO.AddComponent<Outline>();
                     outline.effectColor = Color.black;
                     outline.effectDistance = new Vector2(1f, -1f);
+                    outline.useGraphicAlpha = false;
                     countText.font = stackCountFont ?? defaultFont;
                     countText.fontSize = stackCountFontSize;
                     countText.alignment = TextAnchor.UpperLeft;


### PR DESCRIPTION
## Summary
- Ensure inventory highlight outline is not affected by item alpha
- Disable graphic alpha usage for count text outlines in inventory and bank UI

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68baf9b8bd04832ea0386967a98652a0