### PR TITLE
Prevent highlighting empty inventory slots

### DIFF
--- a/Assets/Scripts/Inventory/InventorySlot.cs
+++ b/Assets/Scripts/Inventory/InventorySlot.cs
@@ -78,14 +78,17 @@ namespace Inventory
                 var entry = inventory.GetSlot(index);
                 if (inventory.selectedIndex < 0)
                 {
-                    if (entry.item != null && entry.item.equipmentSlot != EquipmentSlot.None)
+                    if (entry.item != null)
                     {
-                        inventory.EquipItem(index);
-                        return;
-                    }
+                        if (entry.item.equipmentSlot != EquipmentSlot.None)
+                        {
+                            inventory.EquipItem(index);
+                            return;
+                        }
 
-                    inventory.selectedIndex = index;
-                    inventory.UpdateSlotVisual(index);
+                        inventory.selectedIndex = index;
+                        inventory.UpdateSlotVisual(index);
+                    }
                 }
                 else if (inventory.selectedIndex == index)
                 {


### PR DESCRIPTION
## Summary
- guard selection logic so empty inventory slots can't be highlighted

## Testing
- `dotnet test` *(fails: project or solution file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bafc12b338832e9f7d412186219594