### PR TITLE
feat: add equipment slot tooltips

### DIFF
--- a/Assets/Scripts/Inventory/EquipmentSlotUI.cs
+++ b/Assets/Scripts/Inventory/EquipmentSlotUI.cs
@@ -8,7 +8,7 @@ namespace Inventory
     /// Handles click events on an equipment slot. Left clicking returns the
     /// item to the inventory.
     /// </summary>
-    public class EquipmentSlotUI : MonoBehaviour, IPointerClickHandler
+    public class EquipmentSlotUI : MonoBehaviour, IPointerClickHandler, IPointerEnterHandler, IPointerExitHandler
     {
         [HideInInspector]
         public Equipment equipment;
@@ -21,7 +21,18 @@ namespace Inventory
             if (eventData.button == PointerEventData.InputButton.Left)
             {
                 equipment?.Unequip(slot);
+                equipment?.HideTooltip();
             }
+        }
+
+        public void OnPointerEnter(PointerEventData eventData)
+        {
+            equipment?.ShowTooltip(slot, transform as RectTransform);
+        }
+
+        public void OnPointerExit(PointerEventData eventData)
+        {
+            equipment?.HideTooltip();
         }
     }
 }


### PR DESCRIPTION
## Summary
- show equipment item names when hovering over slots
- create reusable tooltip UI in Equipment
- hide tooltip on exit, unequip or closing the UI

## Testing
- `dotnet build` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68bafde34c6c832e9ca00c0505609f3e