### PR TITLE
Add inventory drop menu

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -125,6 +125,7 @@ namespace Inventory
         private GameObject tooltip;
         private Text tooltipNameText;
         private Text tooltipDescriptionText;
+        private InventoryDropMenu dropMenu;
 
         // Active shop context when interacting with a shop
         private Shop currentShop;
@@ -159,6 +160,7 @@ namespace Inventory
                 return;
             if (uiRoot != null)
                 uiRoot.SetActive(false);
+            HideDropMenu();
             if (playerMover != null)
             {
                 var pet = PetDropSystem.ActivePetObject;
@@ -544,6 +546,8 @@ namespace Inventory
             tooltipRect.pivot = new Vector2(0f, 1f);
 
             tooltip.SetActive(false);
+
+            dropMenu = InventoryDropMenu.Create(uiRoot.transform, stackCountFont);
         }
 
         private string FormatStackCount(int count, out Color color)
@@ -1087,6 +1091,17 @@ namespace Inventory
         {
             if (tooltip != null)
                 tooltip.SetActive(false);
+        }
+
+        public void ShowDropMenu(int slotIndex, Vector2 position)
+        {
+            HideTooltip();
+            dropMenu?.Show(this, slotIndex, position);
+        }
+
+        public void HideDropMenu()
+        {
+            dropMenu?.Hide();
         }
 
         /// <summary>

--- a/Assets/Scripts/Inventory/InventoryDropMenu.cs
+++ b/Assets/Scripts/Inventory/InventoryDropMenu.cs
@@ -1,0 +1,93 @@
+using UnityEngine;
+using UnityEngine.UI;
+using UnityEngine.Events;
+
+namespace Inventory
+{
+    /// <summary>
+    /// Simple right-click context menu for inventory drop options.
+    /// Built entirely in code so no prefab is needed.
+    /// </summary>
+    public class InventoryDropMenu : MonoBehaviour
+    {
+        private Inventory inventory;
+        private int slotIndex;
+        private Font font;
+
+        public static InventoryDropMenu Create(Transform parent, Font font)
+        {
+            var go = new GameObject("InventoryDropMenu", typeof(Image), typeof(InventoryDropMenu));
+            go.transform.SetParent(parent, false);
+            var menu = go.GetComponent<InventoryDropMenu>();
+            menu.font = font;
+            menu.BuildUI();
+            go.SetActive(false);
+            return menu;
+        }
+
+        private void BuildUI()
+        {
+            var bg = GetComponent<Image>();
+            bg.color = new Color(0f, 0f, 0f, 0.9f);
+            var rect = GetComponent<RectTransform>();
+            rect.pivot = new Vector2(0f, 1f);
+
+            var layout = gameObject.AddComponent<VerticalLayoutGroup>();
+            layout.childAlignment = TextAnchor.UpperLeft;
+            layout.childControlWidth = true;
+            layout.childControlHeight = true;
+            layout.childForceExpandHeight = false;
+            layout.childForceExpandWidth = true;
+            layout.spacing = 2f;
+            layout.padding = new RectOffset(2, 2, 2, 2);
+
+            CreateButton("Drop 1", () => { inventory?.DropItem(slotIndex, 1); Hide(); });
+            CreateButton("Drop All", () => { if (inventory != null) inventory.DropItem(slotIndex, inventory.GetSlot(slotIndex).count); Hide(); });
+            CreateButton("Drop X", () => { inventory?.PromptStackSplit(slotIndex, StackSplitType.Drop); Hide(); });
+        }
+
+        private void CreateButton(string label, UnityAction onClick)
+        {
+            var btnGO = new GameObject(label, typeof(Image), typeof(Button));
+            btnGO.transform.SetParent(transform, false);
+            var img = btnGO.GetComponent<Image>();
+            img.sprite = Resources.Load<Sprite>("Sprites/BankUI/Button_1");
+            img.color = new Color(0f, 0f, 0f, 0f);
+            var btn = btnGO.GetComponent<Button>();
+            btn.onClick.AddListener(onClick);
+
+            var txtGO = new GameObject("Text", typeof(Text));
+            txtGO.transform.SetParent(btnGO.transform, false);
+            var txt = txtGO.GetComponent<Text>();
+            txt.font = font;
+            txt.alignment = TextAnchor.MiddleLeft;
+            txt.color = Color.white;
+            txt.text = label;
+
+            var rect = btnGO.GetComponent<RectTransform>();
+            rect.sizeDelta = new Vector2(100f, 20f);
+            rect.pivot = new Vector2(0f, 1f);
+
+            var txtRect = txtGO.GetComponent<RectTransform>();
+            txtRect.anchorMin = Vector2.zero;
+            txtRect.anchorMax = Vector2.one;
+            txtRect.offsetMin = Vector2.zero;
+            txtRect.offsetMax = Vector2.zero;
+        }
+
+        public void Show(Inventory inventory, int index, Vector2 position)
+        {
+            this.inventory = inventory;
+            slotIndex = index;
+            transform.position = position;
+            gameObject.SetActive(true);
+            transform.SetAsLastSibling();
+        }
+
+        public void Hide()
+        {
+            gameObject.SetActive(false);
+            inventory = null;
+        }
+    }
+}

--- a/Assets/Scripts/Inventory/InventorySlot.cs
+++ b/Assets/Scripts/Inventory/InventorySlot.cs
@@ -109,9 +109,17 @@ namespace Inventory
             if (eventData.button == PointerEventData.InputButton.Right)
             {
                 if (shift)
+                {
                     inventory?.PromptStackSplit(index, StackSplitType.Drop);
+                }
                 else
-                    inventory?.DropItem(index, 1);
+                {
+                    var entry = inventory != null ? inventory.GetSlot(index) : default;
+                    if (inventory != null && entry.count > 1)
+                        inventory.ShowDropMenu(index, eventData.position);
+                    else
+                        inventory?.DropItem(index, 1);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- add InventoryDropMenu for drop actions
- integrate drop menu with Inventory UI
- route right-click on stackable slots to drop menu

## Testing
- `dotnet build` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68bb03b93ac8832e9f550d8154da4a35