### PR TITLE
Replace UI Outline with shader-based sprite highlight

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -121,6 +121,7 @@ namespace Inventory
         private InventoryEntry[] items;
         public int selectedIndex = -1;
         private Image[] slotHighlights;
+        private Material highlightMaterial;
 
         private GameObject tooltip;
         private Text tooltipNameText;
@@ -406,10 +407,16 @@ namespace Inventory
                     highlightImg.color = new Color(1f, 1f, 1f, 0f);
                     highlightImg.type = Image.Type.Simple;
                     highlightImg.raycastTarget = false;
-                    var highlightOutline = highlightGO.AddComponent<Outline>();
-                    highlightOutline.effectColor = Color.yellow;
-                    highlightOutline.effectDistance = new Vector2(1f, -1f);
-                    highlightOutline.useGraphicAlpha = false;
+                    if (highlightMaterial == null)
+                    {
+                        var shader = Shader.Find("Custom/SpriteOutline");
+                        if (shader != null)
+                        {
+                            highlightMaterial = new Material(shader);
+                            highlightMaterial.SetColor("_OutlineColor", Color.yellow);
+                        }
+                    }
+                    highlightImg.material = highlightMaterial;
                     var hlRect = highlightGO.GetComponent<RectTransform>();
                     hlRect.anchorMin = Vector2.zero;
                     hlRect.anchorMax = Vector2.one;
@@ -642,6 +649,11 @@ namespace Inventory
                 highlight.sprite = slotImages[index].sprite;
                 highlight.type = Image.Type.Simple;
                 highlight.color = new Color(1f, 1f, 1f, 0f); // transparent fill
+                if (highlightMaterial != null)
+                {
+                    highlight.material = highlightMaterial;
+                    highlightMaterial.SetColor("_OutlineColor", Color.yellow);
+                }
                 highlight.enabled = (selectedIndex == index);
             }
         }

--- a/Assets/Shaders.meta
+++ b/Assets/Shaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3a0847f9ff1648c5a2c7ebadc7bb3b70
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Shaders/SpriteOutline.mat
+++ b/Assets/Shaders/SpriteOutline.mat
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: SpriteOutline
+  m_Shader: {fileID: 4800000, guid: a271630e5eaa4fce9de8fdf7f81f79ac, type: 3}
+  m_ShaderKeywords:
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _OutlineSize: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 0}
+    - _OutlineColor: {r: 1, g: 1, b: 0, a: 1}

--- a/Assets/Shaders/SpriteOutline.mat.meta
+++ b/Assets/Shaders/SpriteOutline.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7a03063dee9e4ce1b5e897cdeca22706
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Shaders/SpriteOutline.shader
+++ b/Assets/Shaders/SpriteOutline.shader
@@ -1,0 +1,66 @@
+Shader "Custom/SpriteOutline"
+{
+    Properties
+    {
+        _MainTex ("Texture", 2D) = "white" {}
+        _OutlineColor ("Outline Color", Color) = (1,1,0,1)
+        _OutlineSize ("Outline Size", Float) = 1
+    }
+    SubShader
+    {
+        Tags {"Queue"="Transparent" "IgnoreProjector"="True" "RenderType"="Transparent"}
+        ZWrite Off
+        Cull Off
+        Blend SrcAlpha OneMinusSrcAlpha
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_TexelSize;
+            float4 _OutlineColor;
+            float _OutlineSize;
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = v.uv;
+                return o;
+            }
+
+            fixed4 frag (v2f i) : SV_Target
+            {
+                fixed4 col = tex2D(_MainTex, i.uv);
+                float alpha = col.a;
+                float2 offset = _OutlineSize * _MainTex_TexelSize.xy;
+                float maxAlpha = 0.0;
+                maxAlpha = max(maxAlpha, tex2D(_MainTex, i.uv + float2(offset.x, 0)).a);
+                maxAlpha = max(maxAlpha, tex2D(_MainTex, i.uv - float2(offset.x, 0)).a);
+                maxAlpha = max(maxAlpha, tex2D(_MainTex, i.uv + float2(0, offset.y)).a);
+                maxAlpha = max(maxAlpha, tex2D(_MainTex, i.uv - float2(0, offset.y)).a);
+                float outline = step(0.001, maxAlpha) * step(alpha, 0.001);
+                fixed4 result = _OutlineColor;
+                result.a *= outline;
+                return result;
+            }
+            ENDCG
+        }
+    }
+}

--- a/Assets/Shaders/SpriteOutline.shader.meta
+++ b/Assets/Shaders/SpriteOutline.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: a271630e5eaa4fce9de8fdf7f81f79ac
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- replace slot highlight Outline component with shader-based outline
- add `SpriteOutline` shader and material for alpha-dilated outline
- apply yellow outline material when creating and updating inventory slots

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68bb08241040832e898711be31bef4b7