### PR TITLE
Fix inventory outline alpha to show item borders

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -404,7 +404,8 @@ namespace Inventory
                     highlightGO.transform.SetParent(slot.transform, false);
                     var highlightImg = highlightGO.GetComponent<Image>();
                     highlightImg.sprite = null;
-                    highlightImg.color = new Color(1f, 1f, 1f, 0f);
+                    // Use full alpha so the outline shader can render properly
+                    highlightImg.color = new Color(1f, 1f, 1f, 1f);
                     highlightImg.type = Image.Type.Simple;
                     highlightImg.raycastTarget = false;
                     if (highlightMaterial == null)
@@ -648,7 +649,9 @@ namespace Inventory
                 var highlight = slotHighlights[index];
                 highlight.sprite = slotImages[index].sprite;
                 highlight.type = Image.Type.Simple;
-                highlight.color = new Color(1f, 1f, 1f, 0f); // transparent fill
+                // Ensure the outline image has an opaque color; the outline shader
+                // will handle hiding the fill while keeping the border visible
+                highlight.color = new Color(1f, 1f, 1f, 1f);
                 if (highlightMaterial != null)
                 {
                     highlight.material = highlightMaterial;


### PR DESCRIPTION
## Summary
- ensure inventory highlight images have full alpha so item outlines are visible

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0b2dde0c832eb692cdcc19822c0a