### PR TITLE
feat: close inventory and bank menus on outside click

### DIFF
--- a/Assets/Scripts/Bank/BankDepositMenu.cs
+++ b/Assets/Scripts/Bank/BankDepositMenu.cs
@@ -13,6 +13,7 @@ namespace BankSystem
         private BankUI bank;
         private int slotIndex;
         private Font font;
+        private RectTransform rect;
 
         public static BankDepositMenu Create(Transform parent, Font font)
         {
@@ -20,16 +21,33 @@ namespace BankSystem
             go.transform.SetParent(parent, false);
             var menu = go.GetComponent<BankDepositMenu>();
             menu.font = font;
+            menu.rect = go.GetComponent<RectTransform>();
             menu.BuildUI();
             go.SetActive(false);
             return menu;
+        }
+
+        private void Awake()
+        {
+            rect ??= GetComponent<RectTransform>();
+        }
+
+        private void Update()
+        {
+            if (!gameObject.activeSelf)
+                return;
+
+            if (Input.GetMouseButtonDown(0) || Input.GetMouseButtonDown(1))
+            {
+                if (!RectTransformUtility.RectangleContainsScreenPoint(rect, Input.mousePosition))
+                    Hide();
+            }
         }
 
         private void BuildUI()
         {
             var bg = GetComponent<Image>();
             bg.color = new Color(0f, 0f, 0f, 0.9f);
-            var rect = GetComponent<RectTransform>();
             rect.pivot = new Vector2(0f, 1f);
 
             var layout = gameObject.AddComponent<VerticalLayoutGroup>();
@@ -66,9 +84,9 @@ namespace BankSystem
             txt.color = Color.white;
             txt.text = label;
 
-            var rect = btnGO.GetComponent<RectTransform>();
-            rect.sizeDelta = new Vector2(100f, 20f);
-            rect.pivot = new Vector2(0f, 1f);
+            var btnRect = btnGO.GetComponent<RectTransform>();
+            btnRect.sizeDelta = new Vector2(100f, 20f);
+            btnRect.pivot = new Vector2(0f, 1f);
 
             var txtRect = txtGO.GetComponent<RectTransform>();
             txtRect.anchorMin = Vector2.zero;

--- a/Assets/Scripts/Bank/BankWithdrawMenu.cs
+++ b/Assets/Scripts/Bank/BankWithdrawMenu.cs
@@ -13,6 +13,7 @@ namespace BankSystem
         private BankUI bank;
         private int slotIndex;
         private Font font;
+        private RectTransform rect;
 
         public static BankWithdrawMenu Create(Transform parent, Font font)
         {
@@ -20,16 +21,33 @@ namespace BankSystem
             go.transform.SetParent(parent, false);
             var menu = go.GetComponent<BankWithdrawMenu>();
             menu.font = font;
+            menu.rect = go.GetComponent<RectTransform>();
             menu.BuildUI();
             go.SetActive(false);
             return menu;
+        }
+
+        private void Awake()
+        {
+            rect ??= GetComponent<RectTransform>();
+        }
+
+        private void Update()
+        {
+            if (!gameObject.activeSelf)
+                return;
+
+            if (Input.GetMouseButtonDown(0) || Input.GetMouseButtonDown(1))
+            {
+                if (!RectTransformUtility.RectangleContainsScreenPoint(rect, Input.mousePosition))
+                    Hide();
+            }
         }
 
         private void BuildUI()
         {
             var bg = GetComponent<Image>();
             bg.color = new Color(0f, 0f, 0f, 0.9f);
-            var rect = GetComponent<RectTransform>();
             rect.pivot = new Vector2(0f, 1f);
 
             var layout = gameObject.AddComponent<VerticalLayoutGroup>();
@@ -66,9 +84,9 @@ namespace BankSystem
             txt.color = Color.white;
             txt.text = label;
 
-            var rect = btnGO.GetComponent<RectTransform>();
-            rect.sizeDelta = new Vector2(100f, 20f);
-            rect.pivot = new Vector2(0f, 1f);
+            var btnRect = btnGO.GetComponent<RectTransform>();
+            btnRect.sizeDelta = new Vector2(100f, 20f);
+            btnRect.pivot = new Vector2(0f, 1f);
 
             var txtRect = txtGO.GetComponent<RectTransform>();
             txtRect.anchorMin = Vector2.zero;

--- a/Assets/Scripts/Inventory/InventoryDropMenu.cs
+++ b/Assets/Scripts/Inventory/InventoryDropMenu.cs
@@ -13,6 +13,7 @@ namespace Inventory
         private Inventory inventory;
         private int slotIndex;
         private Font font;
+        private RectTransform rect;
 
         public static InventoryDropMenu Create(Transform parent, Font font)
         {
@@ -20,16 +21,33 @@ namespace Inventory
             go.transform.SetParent(parent, false);
             var menu = go.GetComponent<InventoryDropMenu>();
             menu.font = font;
+            menu.rect = go.GetComponent<RectTransform>();
             menu.BuildUI();
             go.SetActive(false);
             return menu;
+        }
+
+        private void Awake()
+        {
+            rect ??= GetComponent<RectTransform>();
+        }
+
+        private void Update()
+        {
+            if (!gameObject.activeSelf)
+                return;
+
+            if (Input.GetMouseButtonDown(0) || Input.GetMouseButtonDown(1))
+            {
+                if (!RectTransformUtility.RectangleContainsScreenPoint(rect, Input.mousePosition))
+                    Hide();
+            }
         }
 
         private void BuildUI()
         {
             var bg = GetComponent<Image>();
             bg.color = new Color(0f, 0f, 0f, 0.9f);
-            var rect = GetComponent<RectTransform>();
             rect.pivot = new Vector2(0f, 1f);
 
             var layout = gameObject.AddComponent<VerticalLayoutGroup>();
@@ -64,9 +82,9 @@ namespace Inventory
             txt.color = Color.white;
             txt.text = label;
 
-            var rect = btnGO.GetComponent<RectTransform>();
-            rect.sizeDelta = new Vector2(100f, 20f);
-            rect.pivot = new Vector2(0f, 1f);
+            var btnRect = btnGO.GetComponent<RectTransform>();
+            btnRect.sizeDelta = new Vector2(100f, 20f);
+            btnRect.pivot = new Vector2(0f, 1f);
 
             var txtRect = txtGO.GetComponent<RectTransform>();
             txtRect.anchorMin = Vector2.zero;


### PR DESCRIPTION
## Summary
- hide inventory drop menu when clicking outside the menu
- hide bank deposit and withdraw menus when clicking elsewhere

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0eb17dac832ebfdd23c6d80aedcb