### PR TITLE
Fix duplicated ore name when prospecting rocks

### DIFF
--- a/Assets/Scripts/Skills/Mining/Core/MineableRock.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MineableRock.cs
@@ -93,7 +93,7 @@ namespace Skills.Mining
 
             FloatingText.Show("Prospecting...", requester.position);
             yield return new WaitForSeconds(Ticker.TickDuration * 2f);
-            FloatingText.Show($"This rock contains {rockDef.Ore.DisplayName} ore.", requester.position);
+            FloatingText.Show($"This rock contains {rockDef.Ore.DisplayName} here", requester.position);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Remove extra "ore" from prospecting floating text

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68bb11c17074832e835e83945824c7d4