### PR TITLE
Add movement helper and NPC click-to-move combat

### DIFF
--- a/Assets/Scripts/NPC/NpcAttackOnClick.cs
+++ b/Assets/Scripts/NPC/NpcAttackOnClick.cs
@@ -22,13 +22,27 @@ namespace NPC
             var playerController = FindObjectOfType<CombatController>();
             if (playerController == null)
                 return;
-            if (Vector2.Distance(playerController.transform.position, transform.position) > CombatMath.MELEE_RANGE)
+            var playerMover = playerController.GetComponent<PlayerMover>();
+            if (playerMover == null)
                 return;
-            if (playerController.TryAttackTarget(combatant))
+
+            void AttemptAttack()
             {
-                var npcAttack = GetComponent<NpcAttackController>();
-                var playerTarget = playerController.GetComponent<PlayerCombatTarget>();
-                npcAttack?.BeginAttacking(playerTarget);
+                if (playerController.TryAttackTarget(combatant))
+                {
+                    var npcAttack = GetComponent<NpcAttackController>();
+                    var playerTarget = playerController.GetComponent<PlayerCombatTarget>();
+                    npcAttack?.BeginAttacking(playerTarget);
+                }
+            }
+
+            if (Vector2.Distance(playerController.transform.position, transform.position) > CombatMath.MELEE_RANGE)
+            {
+                playerMover.MoveTo(transform.position, CombatMath.MELEE_RANGE, AttemptAttack);
+            }
+            else
+            {
+                AttemptAttack();
             }
         }
     }


### PR DESCRIPTION
## Summary
- add coroutine-driven MoveTo and StopMovement to PlayerMover
- trigger player movement towards NPC and attack on click

## Testing
- `dotnet test` *(fails: MSB1003 Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68bb130c7414832e93a67da1283ba363