### PR TITLE
Add dynamic follow movement for NPC combat

### DIFF
--- a/Assets/Scripts/NPC/NpcAttackOnClick.cs
+++ b/Assets/Scripts/NPC/NpcAttackOnClick.cs
@@ -38,7 +38,7 @@ namespace NPC
 
             if (Vector2.Distance(playerController.transform.position, transform.position) > CombatMath.MELEE_RANGE)
             {
-                playerMover.MoveTo(transform.position, CombatMath.MELEE_RANGE, AttemptAttack);
+                playerMover.MoveTo(transform, CombatMath.MELEE_RANGE, AttemptAttack);
             }
             else
             {

--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -299,6 +299,13 @@ namespace Player
             moveRoutine = StartCoroutine(MoveToRoutine(target, stopDistance, onComplete));
         }
 
+        public void MoveTo(Transform target, float stopDistance, Action onComplete = null)
+        {
+            if (moveRoutine != null)
+                StopCoroutine(moveRoutine);
+            moveRoutine = StartCoroutine(MoveToRoutine(target, stopDistance, onComplete));
+        }
+
         private IEnumerator MoveToRoutine(Vector2 target, float stopDistance, Action onComplete)
         {
             isAutoMoving = true;
@@ -312,6 +319,22 @@ namespace Player
             isAutoMoving = false;
             moveRoutine = null;
             onComplete?.Invoke();
+        }
+
+        private IEnumerator MoveToRoutine(Transform target, float stopDistance, Action onComplete)
+        {
+            isAutoMoving = true;
+            while (target != null && Vector2.Distance(transform.position, target.position) > stopDistance)
+            {
+                Vector2 dir = ((Vector2)target.position - (Vector2)transform.position).normalized;
+                moveDir = dir;
+                yield return null;
+            }
+            StopMovement();
+            isAutoMoving = false;
+            moveRoutine = null;
+            if (target != null)
+                onComplete?.Invoke();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- Add MoveTo overload that follows a Transform target until in range or lost
- Use new overload when clicking an NPC to attack, allowing dynamic pursuit

## Testing
- `dotnet test` *(fails: MSBUILD error - no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68bb15f5d7a8832e9f84ef295cefca5c