### PR TITLE
Stop weapon sprite lingering on dead enemies

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -83,6 +83,12 @@ namespace Combat
                     break;
                 OnAttackStart?.Invoke();
                 ResolveAttack(target);
+                // If the target died from the attack, exit immediately so listeners are notified
+                // without waiting for the next attack interval. This prevents lingering HUD elements
+                // like the weapon sprite from staying visible after the enemy is dead.
+                if (!target.IsAlive)
+                    break;
+
                 float interval = equipment != null ? equipment.GetCombinedStats().attackSpeedTicks * CombatMath.TICK_SECONDS : 4 * CombatMath.TICK_SECONDS;
                 yield return new WaitForSeconds(interval);
             }


### PR DESCRIPTION
## Summary
- exit the attack coroutine immediately when a target dies so weapon HUD sprite disappears right away

## Testing
- `dotnet test` *(fails: no project or solution file found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb17bb246c832e881d39b3c62e230e