### PR TITLE
Add floating combat text for combat actions

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -5,6 +5,7 @@ using Skills;
 using Player;
 using NPC;
 using Pets;
+using Skills.Mining;
 
 namespace Combat
 {
@@ -137,6 +138,7 @@ namespace Combat
                 int maxHit = CombatMath.GetMaxHit(strEff, attacker.Equip.strength);
                 damage = CombatMath.RollDamage(maxHit);
                 target.ApplyDamage(damage, attacker.DamageType, this);
+                FloatingText.Show(damage.ToString(), target.transform.position, Color.red);
                 AwardXp(damage, attacker.Style);
                 if (!target.IsAlive)
                     OnTargetKilled?.Invoke(target);
@@ -144,6 +146,7 @@ namespace Combat
             }
             else
             {
+                FloatingText.Show("0", target.transform.position, Color.gray);
                 Debug.Log($"Player missed {targetName}.");
             }
             OnAttackLanded?.Invoke(damage, hit);

--- a/Assets/Scripts/Player/PlayerCombatTarget.cs
+++ b/Assets/Scripts/Player/PlayerCombatTarget.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using Combat;
+using Skills.Mining;
 
 namespace Player
 {
@@ -24,6 +25,7 @@ namespace Player
         public void ApplyDamage(int amount, DamageType type, object source)
         {
             hitpoints.OnEnemyDealtDamage(amount);
+            FloatingText.Show(amount.ToString(), transform.position, Color.red);
             Debug.Log($"Player took {amount} damage.");
         }
     }

--- a/Assets/Scripts/Skills/Mining/UI/FloatingText.cs
+++ b/Assets/Scripts/Skills/Mining/UI/FloatingText.cs
@@ -18,39 +18,34 @@ namespace Skills.Mining
         private Camera mainCamera;
         private float remainingLifetime;
 
-        private static FloatingText activeInstance;
-
         public static void Show(string message, Vector3 position, Color? color = null, float? size = null)
         {
-            if (activeInstance == null)
-            {
-                GameObject go = new GameObject("FloatingText", typeof(Canvas));
-                activeInstance = go.AddComponent<FloatingText>();
-                var canvas = go.GetComponent<Canvas>();
-                canvas.renderMode = RenderMode.ScreenSpaceOverlay;
-                go.AddComponent<CanvasScaler>().uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
-                go.AddComponent<GraphicRaycaster>();
+            GameObject go = new GameObject("FloatingText", typeof(Canvas));
+            var instance = go.AddComponent<FloatingText>();
+            var canvas = go.GetComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            go.AddComponent<CanvasScaler>().uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+            go.AddComponent<GraphicRaycaster>();
 
-                var textGO = new GameObject("Text", typeof(Text));
-                textGO.transform.SetParent(go.transform, false);
-                activeInstance.uiText = textGO.GetComponent<Text>();
-                activeInstance.uiText.alignment = TextAnchor.MiddleCenter;
-                activeInstance.uiText.horizontalOverflow = HorizontalWrapMode.Overflow;
-                activeInstance.uiText.verticalOverflow = VerticalWrapMode.Overflow;
-                activeInstance.uiText.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
-                activeInstance.rectTransform = textGO.GetComponent<RectTransform>();
-                activeInstance.mainCamera = Camera.main;
-            }
+            var textGO = new GameObject("Text", typeof(Text));
+            textGO.transform.SetParent(go.transform, false);
+            instance.uiText = textGO.GetComponent<Text>();
+            instance.uiText.alignment = TextAnchor.MiddleCenter;
+            instance.uiText.horizontalOverflow = HorizontalWrapMode.Overflow;
+            instance.uiText.verticalOverflow = VerticalWrapMode.Overflow;
+            instance.uiText.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            instance.rectTransform = textGO.GetComponent<RectTransform>();
+            instance.mainCamera = Camera.main;
 
-            activeInstance.worldPosition = position;
-            if (activeInstance.mainCamera == null)
-                activeInstance.mainCamera = Camera.main;
-            activeInstance.rectTransform.position = activeInstance.mainCamera.WorldToScreenPoint(position);
-            activeInstance.uiText.text = message;
-            activeInstance.uiText.color = color ?? Color.white;
-            float finalSize = size ?? activeInstance.textSize;
-            activeInstance.uiText.fontSize = Mathf.RoundToInt(64 * finalSize);
-            activeInstance.remainingLifetime = activeInstance.lifetime;
+            instance.worldPosition = position;
+            if (instance.mainCamera == null)
+                instance.mainCamera = Camera.main;
+            instance.rectTransform.position = instance.mainCamera.WorldToScreenPoint(position);
+            instance.uiText.text = message;
+            instance.uiText.color = color ?? Color.white;
+            float finalSize = size ?? instance.textSize;
+            instance.uiText.fontSize = Mathf.RoundToInt(64 * finalSize);
+            instance.remainingLifetime = instance.lifetime;
         }
 
         private void Awake()
@@ -71,10 +66,5 @@ namespace Skills.Mining
                 Destroy(gameObject);
         }
 
-        private void OnDestroy()
-        {
-            if (activeInstance == this)
-                activeInstance = null;
-        }
     }
 }


### PR DESCRIPTION
## Summary
- show damage and miss values during combat via FloatingText
- display player damage taken using floating text
- allow multiple floating texts concurrently by removing singleton pattern

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1979a8cc832e87d9c4521ad9babe