### PR TITLE
Integrate hitsplat sprites with combat floating text

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -28,6 +28,10 @@ namespace Combat
         private Coroutine attackRoutine;
         private CombatTarget currentTarget;
 
+        private Sprite damageHitsplat;
+        private Sprite zeroHitsplat;
+        private Sprite maxHitHitsplat;
+
         private void Awake()
         {
             // Grab required components from this object, falling back to parent/children so the
@@ -42,6 +46,10 @@ namespace Combat
                 Debug.LogWarning("CombatController could not find a SkillManager; damage will use level 1 stats.", this);
             if (equipment == null)
                 Debug.LogWarning("CombatController could not find an EquipmentAggregator; equipment bonuses will be ignored.", this);
+
+            damageHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Damage_hitsplat");
+            zeroHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Zero_damage_hitsplat");
+            maxHitHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Damage_hitsplat_maxhit");
         }
 
         /// <summary>
@@ -138,7 +146,8 @@ namespace Combat
                 int maxHit = CombatMath.GetMaxHit(strEff, attacker.Equip.strength);
                 damage = CombatMath.RollDamage(maxHit);
                 target.ApplyDamage(damage, attacker.DamageType, this);
-                FloatingText.Show(damage.ToString(), target.transform.position, Color.red);
+                var sprite = damage == maxHit ? maxHitHitsplat : damageHitsplat;
+                FloatingText.Show(damage.ToString(), target.transform.position, Color.white, null, sprite);
                 AwardXp(damage, attacker.Style);
                 if (!target.IsAlive)
                     OnTargetKilled?.Invoke(target);
@@ -146,7 +155,7 @@ namespace Combat
             }
             else
             {
-                FloatingText.Show("0", target.transform.position, Color.gray);
+                FloatingText.Show("0", target.transform.position, Color.white, null, zeroHitsplat);
                 Debug.Log($"Player missed {targetName}.");
             }
             OnAttackLanded?.Invoke(damage, hit);

--- a/Assets/Scripts/Player/PlayerCombatTarget.cs
+++ b/Assets/Scripts/Player/PlayerCombatTarget.cs
@@ -11,10 +11,14 @@ namespace Player
     public class PlayerCombatTarget : MonoBehaviour, CombatTarget
     {
         private PlayerHitpoints hitpoints;
+        private Sprite damageHitsplat;
+        private Sprite zeroHitsplat;
 
         private void Awake()
         {
             hitpoints = GetComponent<PlayerHitpoints>();
+            damageHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Damage_hitsplat");
+            zeroHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Zero_damage_hitsplat");
         }
 
         public bool IsAlive => hitpoints.CurrentHp > 0;
@@ -25,7 +29,8 @@ namespace Player
         public void ApplyDamage(int amount, DamageType type, object source)
         {
             hitpoints.OnEnemyDealtDamage(amount);
-            FloatingText.Show(amount.ToString(), transform.position, Color.red);
+            var sprite = amount == 0 ? zeroHitsplat : damageHitsplat;
+            FloatingText.Show(amount.ToString(), transform.position, Color.white, null, sprite);
             Debug.Log($"Player took {amount} damage.");
         }
     }

--- a/Assets/Scripts/Skills/Mining/UI/FloatingText.cs
+++ b/Assets/Scripts/Skills/Mining/UI/FloatingText.cs
@@ -18,7 +18,7 @@ namespace Skills.Mining
         private Camera mainCamera;
         private float remainingLifetime;
 
-        public static void Show(string message, Vector3 position, Color? color = null, float? size = null)
+        public static void Show(string message, Vector3 position, Color? color = null, float? size = null, Sprite background = null)
         {
             GameObject go = new GameObject("FloatingText", typeof(Canvas));
             var instance = go.AddComponent<FloatingText>();
@@ -27,14 +27,26 @@ namespace Skills.Mining
             go.AddComponent<CanvasScaler>().uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
             go.AddComponent<GraphicRaycaster>();
 
+            GameObject parentGO = go;
+
+            if (background != null)
+            {
+                var imageGO = new GameObject("Background", typeof(Image));
+                imageGO.transform.SetParent(go.transform, false);
+                var image = imageGO.GetComponent<Image>();
+                image.sprite = background;
+                image.SetNativeSize();
+                parentGO = imageGO;
+            }
+
             var textGO = new GameObject("Text", typeof(Text));
-            textGO.transform.SetParent(go.transform, false);
+            textGO.transform.SetParent(parentGO.transform, false);
             instance.uiText = textGO.GetComponent<Text>();
             instance.uiText.alignment = TextAnchor.MiddleCenter;
             instance.uiText.horizontalOverflow = HorizontalWrapMode.Overflow;
             instance.uiText.verticalOverflow = VerticalWrapMode.Overflow;
             instance.uiText.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
-            instance.rectTransform = textGO.GetComponent<RectTransform>();
+            instance.rectTransform = background != null ? parentGO.GetComponent<RectTransform>() : textGO.GetComponent<RectTransform>();
             instance.mainCamera = Camera.main;
 
             instance.worldPosition = position;


### PR DESCRIPTION
## Summary
- extend FloatingText to optionally render a sprite behind the text
- show white text with hitsplat backgrounds for combat damage and misses
- display hit indicators for player damage using hitsplat sprites

## Testing
- `dotnet build` *(fails: project or solution file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1e21b57c832ea4e046a50e3564da