### PR TITLE
NPC begins combat approach early and faces player while closing distance

### DIFF
--- a/Assets/Scripts/NPC/NpcAttackController.cs
+++ b/Assets/Scripts/NPC/NpcAttackController.cs
@@ -83,6 +83,18 @@ namespace NPC
                    Vector2.Distance(target.transform.position, transform.position) > CombatMath.MELEE_RANGE)
             {
                 // Poll each frame until the target is close enough or combat ends.
+                Vector2 diff = target.transform.position - transform.position;
+                int facingDir;
+                if (Mathf.Abs(diff.x) > Mathf.Abs(diff.y))
+                    facingDir = diff.x < 0f ? 1 : 2;
+                else
+                    facingDir = diff.y < 0f ? 0 : 3;
+
+                if (spriteAnimator != null)
+                    spriteAnimator.SetFacing(facingDir);
+                else if (spriteRenderer != null)
+                    spriteRenderer.flipX = facingDir == 2;
+
                 yield return null;
             }
 

--- a/Assets/Scripts/NPC/NpcAttackOnClick.cs
+++ b/Assets/Scripts/NPC/NpcAttackOnClick.cs
@@ -26,14 +26,13 @@ namespace NPC
             if (playerMover == null)
                 return;
 
+            var npcAttack = GetComponent<NpcAttackController>();
+            var playerTarget = playerController.GetComponent<PlayerCombatTarget>();
+            npcAttack?.BeginAttacking(playerTarget);
+
             void AttemptAttack()
             {
-                if (playerController.TryAttackTarget(combatant))
-                {
-                    var npcAttack = GetComponent<NpcAttackController>();
-                    var playerTarget = playerController.GetComponent<PlayerCombatTarget>();
-                    npcAttack?.BeginAttacking(playerTarget);
-                }
+                playerController.TryAttackTarget(combatant);
             }
 
             if (Vector2.Distance(playerController.transform.position, transform.position) > CombatMath.MELEE_RANGE)


### PR DESCRIPTION
## Summary
- Start NPC attack behavior immediately on click so it moves toward the player while approach
- Update NPC sprite facing during approach to track the player

## Testing
- `dotnet test` *(fails: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68bb25bf0974832eab42f56b63c9a66e