### PR TITLE
Ensure NPCs always face their combat target

### DIFF
--- a/Assets/Scripts/NPC/CombatScripts/GoblinWarChief/GoblinWarChiefCombat.cs
+++ b/Assets/Scripts/NPC/CombatScripts/GoblinWarChief/GoblinWarChiefCombat.cs
@@ -21,6 +21,8 @@ namespace NPC
         private PlayerCombatTarget playerTarget;
         private bool hasHitPlayer;
         private Vector2 spawnPosition;
+        private NpcSpriteAnimator spriteAnimator;
+        private SpriteRenderer spriteRenderer;
 
         [SerializeField] private float slamInterval = 10f;
         [SerializeField] private int slamDamage = 10;
@@ -35,6 +37,8 @@ namespace NPC
             wanderer = GetComponent<NpcWanderer>();
             playerTarget = FindObjectOfType<PlayerCombatTarget>();
             spawnPosition = transform.position;
+            spriteAnimator = GetComponent<NpcSpriteAnimator>() ?? GetComponentInChildren<NpcSpriteAnimator>();
+            spriteRenderer = GetComponent<SpriteRenderer>() ?? GetComponentInChildren<SpriteRenderer>();
         }
 
         private void Update()
@@ -59,6 +63,21 @@ namespace NPC
             else if (playerDistFromSpawn > profile.AggroRange || npcDistFromSpawn > profile.AggroRange)
             {
                 BeginAttacking(null);
+            }
+
+            if (currentTarget != null && currentTarget.IsAlive && combatant.IsAlive)
+            {
+                Vector2 diff = currentTarget.transform.position - transform.position;
+                int facingDir;
+                if (Mathf.Abs(diff.x) > Mathf.Abs(diff.y))
+                    facingDir = diff.x < 0f ? 1 : 2;
+                else
+                    facingDir = diff.y < 0f ? 0 : 3;
+
+                if (spriteAnimator != null)
+                    spriteAnimator.SetFacing(facingDir);
+                else if (spriteRenderer != null)
+                    spriteRenderer.flipX = facingDir == 2;
             }
         }
 

--- a/Assets/Scripts/NPC/NpcAttackController.cs
+++ b/Assets/Scripts/NPC/NpcAttackController.cs
@@ -72,6 +72,21 @@ namespace NPC
             {
                 BeginAttacking(null);
             }
+
+            if (currentTarget != null && combatant.IsAlive && currentTarget.IsAlive)
+            {
+                Vector2 diff = currentTarget.transform.position - transform.position;
+                int facingDir;
+                if (Mathf.Abs(diff.x) > Mathf.Abs(diff.y))
+                    facingDir = diff.x < 0f ? 1 : 2;
+                else
+                    facingDir = diff.y < 0f ? 0 : 3;
+
+                if (spriteAnimator != null)
+                    spriteAnimator.SetFacing(facingDir);
+                else if (spriteRenderer != null)
+                    spriteRenderer.flipX = facingDir == 2;
+            }
         }
 
         private IEnumerator AttackRoutine(CombatTarget target)


### PR DESCRIPTION
## Summary
- Turn NPCs toward their current target each frame in `NpcAttackController`
- Make Goblin War Chief face its target during combat using `NpcSpriteAnimator` or `SpriteRenderer`

## Testing
- ⚠️ `dotnet test` *(no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68bb28082f6c832e9996c348db870178