### PR TITLE
Use component-based meteor projectiles

### DIFF
--- a/Assets/Scripts/NPC/Combat/CombatAttacks/MeteorShowerBarrage.cs
+++ b/Assets/Scripts/NPC/Combat/CombatAttacks/MeteorShowerBarrage.cs
@@ -52,86 +52,22 @@ namespace NPC
             {
                 Vector2 groundPos = (Vector2)target.transform.position + Random.insideUnitCircle * spreadRadius;
                 Vector2 spawnPos = groundPos + Vector2.up * dropHeight;
-                GameObject meteor = null;
+
                 if (meteorPrefab != null)
-                    meteor = Object.Instantiate(meteorPrefab, spawnPos, Quaternion.identity);
-
-                owner.StartCoroutine(MeteorFall(meteor, groundPos, impactDamage,
-                    burnDamagePerTick, burnDuration, burnPrefab, impactRadius,
-                    meteorSpeed, owner));
-
-                yield return new WaitForSeconds(0.1f);
-            }
-        }
-
-        private static IEnumerator MeteorFall(GameObject meteor, Vector2 groundPos,
-            int impactDamage, int burnDamagePerTick, float burnDuration,
-            GameObject burnPrefab, float impactRadius, float meteorSpeed,
-            BaseNpcCombat owner)
-        {
-            while (meteor != null && Vector2.Distance(meteor.transform.position, groundPos) > 0.05f)
-            {
-                meteor.transform.position = Vector2.MoveTowards(meteor.transform.position,
-                    groundPos, meteorSpeed * Time.deltaTime);
-                yield return null;
-            }
-
-            if (meteor != null)
-                Object.Destroy(meteor);
-
-            ApplyAreaDamage(groundPos, impactRadius, impactDamage, owner);
-
-            if (burnPrefab != null && burnDuration > 0f && burnDamagePerTick > 0)
-            {
-                var burnObj = Object.Instantiate(burnPrefab, groundPos, Quaternion.identity);
-                var burn = burnObj.AddComponent<BurningGround>();
-                burn.damagePerTick = burnDamagePerTick;
-                burn.duration = burnDuration;
-                burn.radius = impactRadius;
-            }
-        }
-
-        private static void ApplyAreaDamage(Vector2 center, float radius, int damage,
-            BaseNpcCombat owner)
-        {
-            var hits = Physics2D.OverlapCircleAll(center, radius);
-            foreach (var h in hits)
-            {
-                var tgt = h.GetComponent<CombatTarget>();
-                if (tgt != null)
-                    tgt.ApplyDamage(damage, DamageType.Magic, owner);
-            }
-        }
-
-        private class BurningGround : MonoBehaviour
-        {
-            public int damagePerTick;
-            public float duration;
-            public float radius;
-
-            private void Start()
-            {
-                StartCoroutine(BurnRoutine());
-            }
-
-            private IEnumerator BurnRoutine()
-            {
-                float elapsed = 0f;
-                var wait = new WaitForSeconds(CombatMath.TICK_SECONDS);
-                while (elapsed < duration)
                 {
-                    var hits = Physics2D.OverlapCircleAll(transform.position, radius);
-                    foreach (var h in hits)
-                    {
-                        var tgt = h.GetComponent<CombatTarget>();
-                        if (tgt != null)
-                            tgt.ApplyDamage(damagePerTick, DamageType.Magic, this);
-                    }
-                    elapsed += CombatMath.TICK_SECONDS;
-                    yield return wait;
+                    var meteor = Object.Instantiate(meteorPrefab, spawnPos, Quaternion.identity);
+                    var proj = meteor.AddComponent<MeteorProjectile>();
+                    proj.target = groundPos;
+                    proj.impactDamage = impactDamage;
+                    proj.burnDamagePerTick = burnDamagePerTick;
+                    proj.burnDuration = burnDuration;
+                    proj.burnPrefab = burnPrefab;
+                    proj.impactRadius = impactRadius;
+                    proj.speed = meteorSpeed;
+                    proj.owner = owner;
                 }
 
-                Object.Destroy(gameObject);
+                yield return new WaitForSeconds(0.1f);
             }
         }
     }

--- a/Assets/Scripts/NPC/Combat/Projectiles.meta
+++ b/Assets/Scripts/NPC/Combat/Projectiles.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 82ddc2bde6064eaab7aedb649c594520
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/NPC/Combat/Projectiles/MeteorProjectile.cs
+++ b/Assets/Scripts/NPC/Combat/Projectiles/MeteorProjectile.cs
@@ -1,0 +1,105 @@
+using System.Collections;
+using UnityEngine;
+using Combat;
+
+namespace NPC
+{
+    /// <summary>
+    /// Handles meteor movement toward a target position and applies impact effects.
+    /// </summary>
+    public class MeteorProjectile : MonoBehaviour
+    {
+        public Vector2 target;
+        public int impactDamage;
+        public int burnDamagePerTick;
+        public float burnDuration;
+        public GameObject burnPrefab;
+        public float impactRadius = 1.5f;
+        public float speed = 8f;
+        public BaseNpcCombat owner;
+        [SerializeField] private float selfDestructTime = 10f;
+        private float timer;
+
+        private void Awake()
+        {
+            timer = selfDestructTime;
+        }
+
+        private void Update()
+        {
+            transform.position = Vector2.MoveTowards(transform.position, target, speed * Time.deltaTime);
+
+            if (Vector2.Distance(transform.position, target) <= 0.05f)
+            {
+                Impact();
+                return;
+            }
+
+            timer -= Time.deltaTime;
+            if (timer <= 0f)
+                Destroy(gameObject);
+        }
+
+        private void Impact()
+        {
+            ApplyAreaDamage();
+            SpawnBurningGround();
+            Destroy(gameObject);
+        }
+
+        private void ApplyAreaDamage()
+        {
+            var hits = Physics2D.OverlapCircleAll(target, impactRadius);
+            foreach (var h in hits)
+            {
+                var tgt = h.GetComponent<CombatTarget>();
+                if (tgt != null)
+                    tgt.ApplyDamage(impactDamage, DamageType.Magic, owner);
+            }
+        }
+
+        private void SpawnBurningGround()
+        {
+            if (burnPrefab != null && burnDuration > 0f && burnDamagePerTick > 0)
+            {
+                var burnObj = Instantiate(burnPrefab, target, Quaternion.identity);
+                var burn = burnObj.AddComponent<BurningGround>();
+                burn.damagePerTick = burnDamagePerTick;
+                burn.duration = burnDuration;
+                burn.radius = impactRadius;
+            }
+        }
+
+        private class BurningGround : MonoBehaviour
+        {
+            public int damagePerTick;
+            public float duration;
+            public float radius;
+
+            private void Start()
+            {
+                StartCoroutine(BurnRoutine());
+            }
+
+            private IEnumerator BurnRoutine()
+            {
+                float elapsed = 0f;
+                var wait = new WaitForSeconds(CombatMath.TICK_SECONDS);
+                while (elapsed < duration)
+                {
+                    var hits = Physics2D.OverlapCircleAll(transform.position, radius);
+                    foreach (var h in hits)
+                    {
+                        var tgt = h.GetComponent<CombatTarget>();
+                        if (tgt != null)
+                            tgt.ApplyDamage(damagePerTick, DamageType.Magic, this);
+                    }
+                    elapsed += CombatMath.TICK_SECONDS;
+                    yield return wait;
+                }
+
+                Destroy(gameObject);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/NPC/Combat/Projectiles/MeteorProjectile.cs.meta
+++ b/Assets/Scripts/NPC/Combat/Projectiles/MeteorProjectile.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7e8a854058234000ad35c8ffb108e840


### PR DESCRIPTION
## Summary
- Replace coroutine-driven meteor fall with `MeteorProjectile` component
- Spawn meteors with configured damage and burn parameters
- Add self-destructing projectile that applies area damage and burning ground on impact

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4f512870832ebf23048440a6cc25