### PR TITLE
Add Burn damage type and hitsplat

### DIFF
--- a/Assets/Scripts/Combat/CombatEnums.cs
+++ b/Assets/Scripts/Combat/CombatEnums.cs
@@ -9,7 +9,8 @@ namespace Combat
     {
         Melee,
         Ranged,
-        Magic
+        Magic,
+        Burn
     }
 
     /// <summary>

--- a/Assets/Scripts/NPC/Combat/Projectiles/MeteorProjectile.cs
+++ b/Assets/Scripts/NPC/Combat/Projectiles/MeteorProjectile.cs
@@ -92,7 +92,7 @@ namespace NPC
                     {
                         var tgt = h.GetComponent<CombatTarget>();
                         if (tgt != null)
-                            tgt.ApplyDamage(damagePerTick, DamageType.Magic, this);
+                            tgt.ApplyDamage(damagePerTick, DamageType.Burn, this);
                     }
                     elapsed += CombatMath.TICK_SECONDS;
                     yield return wait;

--- a/Assets/Scripts/Player/PlayerCombatTarget.cs
+++ b/Assets/Scripts/Player/PlayerCombatTarget.cs
@@ -13,12 +13,14 @@ namespace Player
         private PlayerHitpoints hitpoints;
         private Sprite damageHitsplat;
         private Sprite zeroHitsplat;
+        private Sprite burnHitsplat;
 
         private void Awake()
         {
             hitpoints = GetComponent<PlayerHitpoints>();
             damageHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Damage_hitsplat");
             zeroHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Zero_damage_hitsplat");
+            burnHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Burn_hitsplat");
         }
 
         public bool IsAlive => hitpoints.CurrentHp > 0;
@@ -29,7 +31,13 @@ namespace Player
         public void ApplyDamage(int amount, DamageType type, object source)
         {
             hitpoints.OnEnemyDealtDamage(amount);
-            var sprite = amount == 0 ? zeroHitsplat : damageHitsplat;
+            Sprite sprite;
+            if (amount == 0)
+                sprite = zeroHitsplat;
+            else if (type == DamageType.Burn && burnHitsplat != null)
+                sprite = burnHitsplat;
+            else
+                sprite = damageHitsplat;
             FloatingText.Show(amount.ToString(), transform.position, Color.white, null, sprite);
             Debug.Log($"Player took {amount} damage.");
         }


### PR DESCRIPTION
## Summary
- add Burn damage type to combat enum
- make meteor barrage burn area deal Burn damage
- show burn hitsplat when player takes burn damage

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68bb51067b08832e87db0e35c2f1c849