### PR TITLE
Use flame trigger for meteor burn damage

### DIFF
--- a/Assets/Prefabs/NPCS/NPC_GOBLIN_WARMAGE.prefab
+++ b/Assets/Prefabs/NPCS/NPC_GOBLIN_WARMAGE.prefab
@@ -364,6 +364,5 @@ MonoBehaviour:
   burnDuration: 5
   meteorPrefab: {fileID: 6111494187698877684, guid: ec39911e4d64dec46878ae62d069d0b7, type: 3}
   burnPrefab: {fileID: 6111494187698877684, guid: 9e9effd4291159241bc8f42d478e4569, type: 3}
-  impactRadius: 1.5
   dropHeight: 8
   meteorSpeed: 8

--- a/Assets/Scripts/NPC/Combat/CombatAttacks/MeteorShowerBarrage.cs
+++ b/Assets/Scripts/NPC/Combat/CombatAttacks/MeteorShowerBarrage.cs
@@ -25,27 +25,26 @@ namespace NPC
         /// <param name="burnDuration">Duration of the burning ground.</param>
         /// <param name="meteorPrefab">Prefab used for meteor projectiles.</param>
         /// <param name="burnPrefab">Prefab used for the burning ground effect.</param>
-        /// <param name="impactRadius">Radius for impact damage and burning ground.</param>
         /// <param name="dropHeight">Height above the ground to spawn meteors.</param>
         /// <param name="meteorSpeed">Speed at which meteors fall.</param>
         public static void Perform(BaseNpcCombat owner, CombatTarget target,
             int meteorCount, float spreadRadius, int impactDamage,
             int burnDamagePerTick, float burnDuration,
             GameObject meteorPrefab, GameObject burnPrefab,
-            float impactRadius = 1.5f, float dropHeight = 8f, float meteorSpeed = 8f)
+            float dropHeight = 8f, float meteorSpeed = 8f)
         {
             if (owner == null || target == null || meteorCount <= 0)
                 return;
 
             owner.StartCoroutine(SpawnMeteors(owner, target, meteorCount, spreadRadius,
                 impactDamage, burnDamagePerTick, burnDuration, meteorPrefab, burnPrefab,
-                impactRadius, dropHeight, meteorSpeed));
+                dropHeight, meteorSpeed));
         }
 
         private static IEnumerator SpawnMeteors(BaseNpcCombat owner, CombatTarget target,
             int meteorCount, float spreadRadius, int impactDamage,
             int burnDamagePerTick, float burnDuration,
-            GameObject meteorPrefab, GameObject burnPrefab, float impactRadius,
+            GameObject meteorPrefab, GameObject burnPrefab,
             float dropHeight, float meteorSpeed)
         {
             for (int i = 0; i < meteorCount; i++)
@@ -62,7 +61,6 @@ namespace NPC
                     proj.burnDamagePerTick = burnDamagePerTick;
                     proj.burnDuration = burnDuration;
                     proj.burnPrefab = burnPrefab;
-                    proj.impactRadius = impactRadius;
                     proj.speed = meteorSpeed;
                     proj.owner = owner;
                 }

--- a/Assets/Scripts/NPC/Combat/CombatScripts/GoblinWarmage/GoblinWarmageCombat.cs
+++ b/Assets/Scripts/NPC/Combat/CombatScripts/GoblinWarmage/GoblinWarmageCombat.cs
@@ -19,7 +19,6 @@ namespace NPC
         [SerializeField] private float burnDuration = 5f;
         [SerializeField] private GameObject meteorPrefab;
         [SerializeField] private GameObject burnPrefab;
-        [SerializeField] private float impactRadius = 1.5f;
         [SerializeField] private float dropHeight = 8f;
         [SerializeField] private float meteorSpeed = 8f;
 
@@ -40,7 +39,7 @@ namespace NPC
                     break;
                 MeteorShowerBarrage.Perform(this, target, meteorCount, spreadRadius,
                     impactDamage, burnDamagePerTick, burnDuration,
-                    meteorPrefab, burnPrefab, impactRadius, dropHeight, meteorSpeed);
+                    meteorPrefab, burnPrefab, dropHeight, meteorSpeed);
             }
         }
     }

--- a/Assets/Scripts/NPC/Combat/Projectiles/GroundFlame.cs
+++ b/Assets/Scripts/NPC/Combat/Projectiles/GroundFlame.cs
@@ -1,0 +1,55 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Combat;
+
+namespace NPC
+{
+    /// <summary>
+    /// Handles periodic damage to targets standing on burning ground.
+    /// </summary>
+    public class GroundFlame : MonoBehaviour
+    {
+        public int damagePerTick;
+        public float duration;
+
+        private readonly HashSet<CombatTarget> targets = new HashSet<CombatTarget>();
+
+        private void Start()
+        {
+            StartCoroutine(BurnRoutine());
+        }
+
+        private void OnTriggerEnter2D(Collider2D other)
+        {
+            var tgt = other.GetComponent<CombatTarget>();
+            if (tgt != null)
+                targets.Add(tgt);
+        }
+
+        private void OnTriggerExit2D(Collider2D other)
+        {
+            var tgt = other.GetComponent<CombatTarget>();
+            if (tgt != null)
+                targets.Remove(tgt);
+        }
+
+        private IEnumerator BurnRoutine()
+        {
+            float elapsed = 0f;
+            var wait = new WaitForSeconds(CombatMath.TICK_SECONDS);
+            while (elapsed < duration)
+            {
+                foreach (var tgt in targets)
+                {
+                    if (tgt != null)
+                        tgt.ApplyDamage(damagePerTick, DamageType.Burn, this);
+                }
+                elapsed += CombatMath.TICK_SECONDS;
+                yield return wait;
+            }
+
+            Destroy(gameObject);
+        }
+    }
+}

--- a/Assets/Scripts/NPC/Combat/Projectiles/GroundFlame.cs.meta
+++ b/Assets/Scripts/NPC/Combat/Projectiles/GroundFlame.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8876728a984446078d2af97dc69c5831
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/NPC/Combat/Projectiles/MeteorProjectile.cs
+++ b/Assets/Scripts/NPC/Combat/Projectiles/MeteorProjectile.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using UnityEngine;
 using Combat;
 
@@ -14,7 +13,6 @@ namespace NPC
         public int burnDamagePerTick;
         public float burnDuration;
         public GameObject burnPrefab;
-        public float impactRadius = 1.5f;
         public float speed = 8f;
         public BaseNpcCombat owner;
         [SerializeField] private float selfDestructTime = 10f;
@@ -42,20 +40,8 @@ namespace NPC
 
         private void Impact()
         {
-            ApplyAreaDamage();
             SpawnBurningGround();
             Destroy(gameObject);
-        }
-
-        private void ApplyAreaDamage()
-        {
-            var hits = Physics2D.OverlapCircleAll(target, impactRadius);
-            foreach (var h in hits)
-            {
-                var tgt = h.GetComponent<CombatTarget>();
-                if (tgt != null)
-                    tgt.ApplyDamage(impactDamage, DamageType.Magic, owner);
-            }
         }
 
         private void SpawnBurningGround()
@@ -63,42 +49,12 @@ namespace NPC
             if (burnPrefab != null && burnDuration > 0f && burnDamagePerTick > 0)
             {
                 var burnObj = Instantiate(burnPrefab, target, Quaternion.identity);
-                var burn = burnObj.AddComponent<BurningGround>();
-                burn.damagePerTick = burnDamagePerTick;
-                burn.duration = burnDuration;
-                burn.radius = impactRadius;
-            }
-        }
-
-        private class BurningGround : MonoBehaviour
-        {
-            public int damagePerTick;
-            public float duration;
-            public float radius;
-
-            private void Start()
-            {
-                StartCoroutine(BurnRoutine());
-            }
-
-            private IEnumerator BurnRoutine()
-            {
-                float elapsed = 0f;
-                var wait = new WaitForSeconds(CombatMath.TICK_SECONDS);
-                while (elapsed < duration)
+                var flame = burnObj.GetComponent<GroundFlame>();
+                if (flame != null)
                 {
-                    var hits = Physics2D.OverlapCircleAll(transform.position, radius);
-                    foreach (var h in hits)
-                    {
-                        var tgt = h.GetComponent<CombatTarget>();
-                        if (tgt != null)
-                            tgt.ApplyDamage(damagePerTick, DamageType.Burn, this);
-                    }
-                    elapsed += CombatMath.TICK_SECONDS;
-                    yield return wait;
+                    flame.damagePerTick = burnDamagePerTick;
+                    flame.duration = burnDuration;
                 }
-
-                Destroy(gameObject);
             }
         }
     }


### PR DESCRIPTION
## Summary
- Remove area-based meteor impact and rely on trigger-based ground flame
- Add `GroundFlame` component that damages overlapping targets on tick
- Drop unused impact radius parameters from meteor barrage and warmage config

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5776c518832eae7824870f3459af