### PR TITLE
Add spawn radius control to spectral clone ambush

### DIFF
--- a/Assets/Scripts/NPC/Combat/CombatAttacks/SpectralCloneAmbush.cs
+++ b/Assets/Scripts/NPC/Combat/CombatAttacks/SpectralCloneAmbush.cs
@@ -20,12 +20,14 @@ namespace NPC
         /// <param name="clonePrefabs">Array of possible clone prefabs.</param>
         /// <param name="cloneCount">Number of clones to spawn.</param>
         /// <param name="cloneLifespan">Lifetime in seconds for each clone.</param>
+        /// <param name="spawnRadius">Radius around the target to spawn clones.</param>
         /// <param name="realCloneDamage">Damage dealt by the real clone.</param>
         /// <param name="onCloneDestroyed">Callback invoked whenever a clone is destroyed or expires.</param>
         /// <param name="onAllClonesGone">Callback invoked once all clones are gone.</param>
         public static void Perform(BaseNpcCombat owner, CombatTarget target,
             GameObject[] clonePrefabs, int cloneCount, float cloneLifespan,
-            int realCloneDamage, Action<GameObject> onCloneDestroyed = null,
+            float spawnRadius = 1f, int realCloneDamage = 0,
+            Action<GameObject> onCloneDestroyed = null,
             Action onAllClonesGone = null)
         {
             if (owner == null || target == null || clonePrefabs == null ||
@@ -33,14 +35,14 @@ namespace NPC
                 return;
 
             owner.StartCoroutine(SpawnClones(owner, target, clonePrefabs,
-                cloneCount, cloneLifespan, realCloneDamage,
+                cloneCount, cloneLifespan, spawnRadius, realCloneDamage,
                 onCloneDestroyed, onAllClonesGone));
         }
 
         private static IEnumerator SpawnClones(BaseNpcCombat owner, CombatTarget target,
             GameObject[] clonePrefabs, int cloneCount, float cloneLifespan,
-            int realCloneDamage, Action<GameObject> onCloneDestroyed,
-            Action onAllClonesGone)
+            float spawnRadius, int realCloneDamage,
+            Action<GameObject> onCloneDestroyed, Action onAllClonesGone)
         {
             var managerGO = new GameObject("SpectralCloneManager");
             var manager = managerGO.AddComponent<CloneManager>();
@@ -56,7 +58,10 @@ namespace NPC
                 if (prefab == null)
                     continue;
 
-                Vector2 spawnPos = (Vector2)target.transform.position + UnityEngine.Random.insideUnitCircle;
+                float angle = i * Mathf.PI * 2f / cloneCount;
+                angle += UnityEngine.Random.Range(-0.1f, 0.1f);
+                Vector2 spawnPos = (Vector2)target.transform.position +
+                    new Vector2(Mathf.Cos(angle), Mathf.Sin(angle)) * spawnRadius;
                 var clone = UnityEngine.Object.Instantiate(prefab, spawnPos, Quaternion.identity);
                 var controller = clone.AddComponent<SpectralClone>();
                 controller.manager = manager;

--- a/Assets/Scripts/NPC/Combat/CombatScripts/GoblinWarmage2/GoblinWarmage2Combat.cs
+++ b/Assets/Scripts/NPC/Combat/CombatScripts/GoblinWarmage2/GoblinWarmage2Combat.cs
@@ -14,6 +14,7 @@ namespace NPC
         [SerializeField] private float ambushInterval = 15f;
         [SerializeField] private int cloneCount = 3;
         [SerializeField] private float cloneLifespan = 6f;
+        [SerializeField] private float spawnRadius = 1f;
         [SerializeField] private int realCloneDamage = 4;
         [SerializeField] private GameObject[] clonePrefabs;
 
@@ -33,7 +34,7 @@ namespace NPC
                 if (target == null || !target.IsAlive || !combatant.IsAlive)
                     break;
                 SpectralCloneAmbush.Perform(this, target, clonePrefabs, cloneCount,
-                    cloneLifespan, realCloneDamage);
+                    cloneLifespan, spawnRadius, realCloneDamage);
             }
         }
     }


### PR DESCRIPTION
## Summary
- allow specifying clone spawn radius in SpectralCloneAmbush
- spawn clones using evenly spaced polar coordinates for ring formation
- expose spawn radius on GoblinWarmage2 combat and forward to ambush routine

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5f6306ec832e910ed15ce43bb0f8