### PR TITLE
Add health utilities to F2 debug menu

### DIFF
--- a/Assets/Scripts/Player/PlayerHitpoints.cs
+++ b/Assets/Scripts/Player/PlayerHitpoints.cs
@@ -187,6 +187,16 @@ namespace Player
             OnHealthChanged?.Invoke(currentHp, MaxHp);
         }
 
+        /// <summary>
+        /// Debug helper to directly set the current hitpoints. Optionally bypasses
+        /// the max hitpoint clamp, allowing values such as 99999 for godmode.
+        /// </summary>
+        public void DebugSetCurrentHp(int hp, bool clampToMax = true)
+        {
+            currentHp = clampToMax ? Mathf.Clamp(hp, 0, MaxHp) : Mathf.Max(0, hp);
+            OnHealthChanged?.Invoke(currentHp, MaxHp);
+        }
+
 #if UNITY_EDITOR
         public void DebugDealDamage(int dmg)
         {

--- a/Assets/Scripts/Skills/SkillsDebugMenu.cs
+++ b/Assets/Scripts/Skills/SkillsDebugMenu.cs
@@ -186,6 +186,21 @@ namespace Skills
                 RefreshFields();
             }
 
+            if (GUILayout.Button("Restore Health"))
+            {
+                hitpoints?.DebugSetCurrentHp(hitpoints.MaxHp);
+            }
+
+            if (GUILayout.Button("Godmode"))
+            {
+                hitpoints?.DebugSetCurrentHp(99999, false);
+            }
+
+            if (GUILayout.Button("Godmode Off"))
+            {
+                hitpoints?.DebugSetCurrentHp(hitpoints.MaxHp);
+            }
+
             if (GUILayout.Button("Reset Merge Timer"))
             {
                 PetMergeController.Instance?.ResetMergeTimer();


### PR DESCRIPTION
## Summary
- add `Restore Health` button to F2 debug menu
- add `Godmode` and `Godmode Off` actions
- support setting current HP directly for debug

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68bb63405d94832eb51c892b8f1a78f1