### PR TITLE
Display hit splats for pet attacks

### DIFF
--- a/Assets/Scripts/Pets/PetCombatController.cs
+++ b/Assets/Scripts/Pets/PetCombatController.cs
@@ -4,6 +4,7 @@ using Combat;
 using EquipmentSystem;
 using NPC;
 using Skills;
+using Skills.Mining;
 
 namespace Pets
 {
@@ -25,6 +26,10 @@ namespace Pets
         private CombatTarget currentTarget;
         private Coroutine attackRoutine;
 
+        private Sprite damageHitsplat;
+        private Sprite zeroHitsplat;
+        private Sprite maxHitHitsplat;
+
         public bool IsAlive => true;
         public DamageType PreferredDefenceType => DamageType.Melee;
         public int CurrentHP => 1;
@@ -43,6 +48,10 @@ namespace Pets
                 col.isTrigger = true;
             if (TryGetComponent<Collider2D>(out var col2d))
                 col2d.isTrigger = true;
+
+            damageHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Damage_hitsplat");
+            zeroHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Zero_damage_hitsplat");
+            maxHitHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Damage_hitsplat_maxhit");
         }
 
         /// <summary>Returns true if this pet has combat capabilities.</summary>
@@ -204,12 +213,18 @@ namespace Pets
                     maxHit = Mathf.RoundToInt(maxHit * (1f + definition.maxHitPerBeastmasterLevel * beastmasterLevel));
                 int dmg = CombatMath.RollDamage(maxHit);
                 target.ApplyDamage(dmg, attacker.DamageType, this);
+                var sprite = dmg == maxHit ? maxHitHitsplat : damageHitsplat;
+                FloatingText.Show(dmg.ToString(), target.transform.position, Color.white, null, sprite);
                 if (npc != null)
                 {
                     var npcAttack = npc.GetComponent<NpcAttackController>();
                     npcAttack?.BeginAttacking(this);
                 }
                 BeastmasterXp.TryGrantFromPetDamage(owner != null ? owner.gameObject : null, dmg);
+            }
+            else
+            {
+                FloatingText.Show("0", target.transform.position, Color.white, null, zeroHitsplat);
             }
         }
 


### PR DESCRIPTION
## Summary
- load hit splat sprites for pet combat controller
- show floating hit splats when a pet damages or misses a target

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68bb67698444832e8cc74d746e79327f