### PR TITLE
Track active spectral clone ambush

### DIFF
--- a/Assets/Scripts/NPC/Combat/CombatScripts/GoblinWarmage2/GoblinWarmage2Combat.cs
+++ b/Assets/Scripts/NPC/Combat/CombatScripts/GoblinWarmage2/GoblinWarmage2Combat.cs
@@ -18,6 +18,8 @@ namespace NPC
         [SerializeField] private int realCloneDamage = 4;
         [SerializeField] private GameObject[] clonePrefabs;
 
+        private bool clonesActive = false;
+
         public override void BeginAttacking(CombatTarget target)
         {
             base.BeginAttacking(target);
@@ -33,8 +35,12 @@ namespace NPC
                 yield return wait;
                 if (target == null || !target.IsAlive || !combatant.IsAlive)
                     break;
+                if (clonesActive)
+                    continue;
+                clonesActive = true;
                 SpectralCloneAmbush.Perform(this, target, clonePrefabs, cloneCount,
-                    cloneLifespan, spawnRadius, realCloneDamage);
+                    cloneLifespan, spawnRadius, realCloneDamage,
+                    onAllClonesGone: () => clonesActive = false);
             }
         }
     }


### PR DESCRIPTION
## Summary
- prevent stacking spectral clone ambushes by tracking active clones
- reset clone ambush flag when clones disappear

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*


------
https://chatgpt.com/codex/tasks/task_e_68bc2e33978c832ea860b9ef49eefaaf