### PR TITLE
Add preventConcurrent gating to spectral clone ambush

### DIFF
--- a/Assets/Scripts/NPC/Combat/CombatAttacks/SpectralCloneAmbush.cs
+++ b/Assets/Scripts/NPC/Combat/CombatAttacks/SpectralCloneAmbush.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Reflection;
 using UnityEngine;
 using Combat;
@@ -12,6 +13,8 @@ namespace NPC
     /// </summary>
     public static class SpectralCloneAmbush
     {
+        private static readonly Dictionary<BaseNpcCombat, CloneManager> activeManagers =
+            new Dictionary<BaseNpcCombat, CloneManager>();
         /// <summary>
         /// Spawns spectral clones that surround a target. One random clone performs
         /// the real strike. All clones self-destruct after a lifespan.
@@ -25,31 +28,41 @@ namespace NPC
         /// <param name="realCloneDamage">Damage dealt by the real clone.</param>
         /// <param name="onCloneDestroyed">Callback invoked whenever a clone is destroyed or expires.</param>
         /// <param name="onAllClonesGone">Callback invoked once all clones are gone.</param>
+        /// <param name="preventConcurrent">If true, prevents multiple concurrent ambushes by the same owner.</param>
         public static void Perform(BaseNpcCombat owner, CombatTarget target,
             GameObject[] clonePrefabs, int cloneCount, float cloneLifespan,
             float spawnRadius = 1f, int realCloneDamage = 0,
             Action<GameObject> onCloneDestroyed = null,
-            Action onAllClonesGone = null)
+            Action onAllClonesGone = null,
+            bool preventConcurrent = false)
         {
             if (owner == null || target == null || clonePrefabs == null ||
                 clonePrefabs.Length == 0 || cloneCount <= 0)
                 return;
 
+            if (preventConcurrent && activeManagers.ContainsKey(owner))
+                return;
+
             owner.StartCoroutine(SpawnClones(owner, target, clonePrefabs,
                 cloneCount, cloneLifespan, spawnRadius, realCloneDamage,
-                onCloneDestroyed, onAllClonesGone));
+                onCloneDestroyed, onAllClonesGone, preventConcurrent));
         }
 
         private static IEnumerator SpawnClones(BaseNpcCombat owner, CombatTarget target,
             GameObject[] clonePrefabs, int cloneCount, float cloneLifespan,
             float spawnRadius, int realCloneDamage,
-            Action<GameObject> onCloneDestroyed, Action onAllClonesGone)
+            Action<GameObject> onCloneDestroyed, Action onAllClonesGone,
+            bool preventConcurrent)
         {
             var managerGO = new GameObject("SpectralCloneManager");
             var manager = managerGO.AddComponent<CloneManager>();
             manager.expectedCount = cloneCount;
             manager.onCloneDestroyed = onCloneDestroyed;
             manager.onAllClonesGone = onAllClonesGone;
+            manager.owner = owner;
+            manager.preventConcurrent = preventConcurrent;
+            if (preventConcurrent)
+                activeManagers[owner] = manager;
 
             int realIndex = UnityEngine.Random.Range(0, cloneCount);
 
@@ -97,6 +110,8 @@ namespace NPC
             public int expectedCount;
             public Action<GameObject> onCloneDestroyed;
             public Action onAllClonesGone;
+            public BaseNpcCombat owner;
+            public bool preventConcurrent;
             private int goneCount;
 
             public void CloneGone(GameObject clone)
@@ -106,6 +121,10 @@ namespace NPC
                 if (goneCount >= expectedCount)
                 {
                     onAllClonesGone?.Invoke();
+                    if (preventConcurrent && owner != null)
+                    {
+                        activeManagers.Remove(owner);
+                    }
                     Destroy(gameObject);
                 }
             }

--- a/Assets/Scripts/NPC/Combat/CombatScripts/GoblinWarmage2/GoblinWarmage2Combat.cs
+++ b/Assets/Scripts/NPC/Combat/CombatScripts/GoblinWarmage2/GoblinWarmage2Combat.cs
@@ -40,7 +40,8 @@ namespace NPC
                 clonesActive = true;
                 SpectralCloneAmbush.Perform(this, target, clonePrefabs, cloneCount,
                     cloneLifespan, spawnRadius, realCloneDamage,
-                    onAllClonesGone: () => clonesActive = false);
+                    onAllClonesGone: () => clonesActive = false,
+                    preventConcurrent: true);
             }
         }
     }


### PR DESCRIPTION
## Summary
- allow SpectralCloneAmbush.Perform/SpawnClones to gate concurrent ambushes
- track active ambush managers per owner and clean up after clones vanish
- enable GoblinWarmage2 to prevent concurrent ambushes automatically

## Testing
- ⚠️ `dotnet build` *(no project found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6782c480832e865158dbe5094da9