### PR TITLE
Route gathering and hitpoint XP through SkillManager

### DIFF
--- a/Assets/Scripts/Skills/SkillsDebugMenu.cs
+++ b/Assets/Scripts/Skills/SkillsDebugMenu.cs
@@ -1,8 +1,5 @@
 using UnityEngine;
 using Player;
-using Skills.Mining;
-using Skills.Woodcutting;
-using Skills.Fishing;
 using Beastmaster;
 using Pets;
 using BankSystem;
@@ -17,9 +14,6 @@ namespace Skills
     {
         private PlayerHitpoints hitpoints;
         private SkillManager skillManager;
-        private MiningSkill miningSkill;
-        private WoodcuttingSkill woodcuttingSkill;
-        private FishingSkill fishingSkill;
         private IBeastmasterService beastmasterService;
         private MergeConfig mergeConfig;
 
@@ -69,12 +63,6 @@ namespace Skills
                 hitpoints = FindObjectOfType<PlayerHitpoints>();
             if (skillManager == null)
                 skillManager = FindObjectOfType<SkillManager>();
-            if (miningSkill == null)
-                miningSkill = FindObjectOfType<MiningSkill>();
-            if (woodcuttingSkill == null)
-                woodcuttingSkill = FindObjectOfType<WoodcuttingSkill>();
-            if (fishingSkill == null)
-                fishingSkill = FindObjectOfType<FishingSkill>();
             if (beastmasterService == null)
             {
                 foreach (var mb in FindObjectsOfType<MonoBehaviour>())
@@ -92,9 +80,6 @@ namespace Skills
         {
             hitpoints = FindObjectOfType<PlayerHitpoints>();
             skillManager = FindObjectOfType<SkillManager>();
-            miningSkill = FindObjectOfType<MiningSkill>();
-            woodcuttingSkill = FindObjectOfType<WoodcuttingSkill>();
-            fishingSkill = FindObjectOfType<FishingSkill>();
             beastmasterService = null;
             foreach (var mb in FindObjectsOfType<MonoBehaviour>())
             {
@@ -107,14 +92,14 @@ namespace Skills
             if (mergeConfig == null)
                 mergeConfig = Resources.Load<MergeConfig>("MergeConfig");
 
-            hpLevel = hitpoints != null ? hitpoints.Level.ToString() : "";
+            hpLevel = skillManager != null ? skillManager.GetLevel(SkillType.Hitpoints).ToString() : "";
             attackLevel = skillManager != null ? skillManager.GetLevel(SkillType.Attack).ToString() : "";
             strengthLevel = skillManager != null ? skillManager.GetLevel(SkillType.Strength).ToString() : "";
             defenceLevel = skillManager != null ? skillManager.GetLevel(SkillType.Defence).ToString() : "";
-            miningLevel = miningSkill != null ? miningSkill.Level.ToString() : "";
-            woodcuttingLevel = woodcuttingSkill != null ? woodcuttingSkill.Level.ToString() : "";
-            fishingLevel = fishingSkill != null ? fishingSkill.Level.ToString() : "";
-            beastmasterLevel = beastmasterService != null ? beastmasterService.CurrentLevel.ToString() : "";
+            miningLevel = skillManager != null ? skillManager.GetLevel(SkillType.Mining).ToString() : "";
+            woodcuttingLevel = skillManager != null ? skillManager.GetLevel(SkillType.Woodcutting).ToString() : "";
+            fishingLevel = skillManager != null ? skillManager.GetLevel(SkillType.Fishing).ToString() : "";
+            beastmasterLevel = skillManager != null ? skillManager.GetLevel(SkillType.Beastmaster).ToString() : "";
         }
 
         private void OnGUI()
@@ -166,22 +151,29 @@ namespace Skills
 
             if (GUILayout.Button("Apply"))
             {
-                if (hitpoints != null && int.TryParse(hpLevel, out var hp))
-                    hitpoints.DebugSetLevel(hp);
+                if (skillManager != null && int.TryParse(hpLevel, out var hp))
+                {
+                    skillManager.DebugSetLevel(SkillType.Hitpoints, hp);
+                    if (hitpoints != null)
+                        hitpoints.DebugSetCurrentHp(Mathf.Min(hitpoints.CurrentHp, hitpoints.MaxHp));
+                }
                 if (skillManager != null && int.TryParse(attackLevel, out var atk))
                     skillManager.DebugSetLevel(SkillType.Attack, atk);
                 if (skillManager != null && int.TryParse(strengthLevel, out var str))
                     skillManager.DebugSetLevel(SkillType.Strength, str);
                 if (skillManager != null && int.TryParse(defenceLevel, out var def))
                     skillManager.DebugSetLevel(SkillType.Defence, def);
-                if (miningSkill != null && int.TryParse(miningLevel, out var mine))
-                    miningSkill.DebugSetLevel(mine);
-                if (woodcuttingSkill != null && int.TryParse(woodcuttingLevel, out var wood))
-                    woodcuttingSkill.DebugSetLevel(wood);
-                if (fishingSkill != null && int.TryParse(fishingLevel, out var fish))
-                    fishingSkill.DebugSetLevel(fish);
-                if (beastmasterService != null && int.TryParse(beastmasterLevel, out var bm))
-                    beastmasterService.SetLevel(Mathf.Clamp(bm, 1, 99));
+                if (skillManager != null && int.TryParse(miningLevel, out var mine))
+                    skillManager.DebugSetLevel(SkillType.Mining, mine);
+                if (skillManager != null && int.TryParse(woodcuttingLevel, out var wood))
+                    skillManager.DebugSetLevel(SkillType.Woodcutting, wood);
+                if (skillManager != null && int.TryParse(fishingLevel, out var fish))
+                    skillManager.DebugSetLevel(SkillType.Fishing, fish);
+                if (skillManager != null && int.TryParse(beastmasterLevel, out var bm))
+                {
+                    skillManager.DebugSetLevel(SkillType.Beastmaster, bm);
+                    beastmasterService?.SetLevel(Mathf.Clamp(bm, 1, 99));
+                }
 
                 RefreshFields();
             }

--- a/Assets/Scripts/Skills/SkillsUI.cs
+++ b/Assets/Scripts/Skills/SkillsUI.cs
@@ -1,7 +1,7 @@
+using System;
+using System.Text;
 using UnityEngine;
 using UnityEngine.UI;
-using Inventory;
-using Player;
 using UI;
 
 namespace Skills
@@ -14,10 +14,6 @@ namespace Skills
     {
         private GameObject uiRoot;
         private Text skillText;
-        private Mining.MiningSkill miningSkill;
-        private Woodcutting.WoodcuttingSkill woodcuttingSkill;
-        private Fishing.FishingSkill fishingSkill;
-        private PlayerHitpoints hitpoints;
         private SkillManager skillManager;
 
         public static SkillsUI Instance { get; private set; }
@@ -45,10 +41,6 @@ namespace Skills
             Instance = this;
             DontDestroyOnLoad(gameObject);
 
-            miningSkill = FindObjectOfType<Mining.MiningSkill>();
-            woodcuttingSkill = FindObjectOfType<Woodcutting.WoodcuttingSkill>();
-            fishingSkill = FindObjectOfType<Fishing.FishingSkill>();
-            hitpoints = FindObjectOfType<PlayerHitpoints>();
             skillManager = FindObjectOfType<SkillManager>();
             CreateUI();
             if (uiRoot != null)
@@ -120,42 +112,16 @@ namespace Skills
         {
             // Removed O key toggle
 
-            if (uiRoot != null && uiRoot.activeSelf)
+            if (uiRoot != null && uiRoot.activeSelf && skillManager != null)
             {
-                string text = "";
-                if (hitpoints != null)
-                    text += $"Hitpoints Level: {hitpoints.Level}  XP: {hitpoints.Xp:F2}";
-                if (skillManager != null)
+                var sb = new StringBuilder();
+                foreach (SkillType type in Enum.GetValues(typeof(SkillType)))
                 {
-                    if (text.Length > 0)
-                        text += "\n";
-                    text += $"Attack Level: {skillManager.GetLevel(SkillType.Attack)}  XP: {skillManager.GetXp(SkillType.Attack):F2}";
-                    text += "\n";
-                    text += $"Strength Level: {skillManager.GetLevel(SkillType.Strength)}  XP: {skillManager.GetXp(SkillType.Strength):F2}";
-                    text += "\n";
-                    text += $"Defence Level: {skillManager.GetLevel(SkillType.Defence)}  XP: {skillManager.GetXp(SkillType.Defence):F2}";
-                    text += "\n";
-                    text += $"Beastmaster Level: {skillManager.GetLevel(SkillType.Beastmaster)}  XP: {skillManager.GetXp(SkillType.Beastmaster):F2}";
+                    if (sb.Length > 0)
+                        sb.Append('\n');
+                    sb.Append($"{type} Level: {skillManager.GetLevel(type)}  XP: {skillManager.GetXp(type):F2}");
                 }
-                if (miningSkill != null)
-                {
-                    if (text.Length > 0)
-                        text += "\n";
-                    text += $"Mining Level: {miningSkill.Level}  XP: {miningSkill.Xp}";
-                }
-                if (woodcuttingSkill != null)
-                {
-                    if (text.Length > 0)
-                        text += "\n";
-                    text += $"Woodcutting Level: {woodcuttingSkill.Level}  XP: {woodcuttingSkill.Xp}";
-                }
-                if (fishingSkill != null)
-                {
-                    if (text.Length > 0)
-                        text += "\n";
-                    text += $"Fishing Level: {fishingSkill.Level}  XP: {fishingSkill.Xp}";
-                }
-                skillText.text = text;
+                skillText.text = sb.ToString();
             }
         }
 


### PR DESCRIPTION
## Summary
- Centralize mining, woodcutting, fishing and hitpoints XP/level tracking in `SkillManager`
- Simplify skills UI/debug menus to query levels directly from `SkillManager`

## Testing
- `dotnet test` *(fails: Specify a project or solution file. The current working directory does not contain a project or solution file.)*


------
https://chatgpt.com/codex/tasks/task_e_68bc6d861538832e90263b5fca59f4ab