### PR TITLE
Fix compile issues in skills scripts

### DIFF
--- a/Assets/Scripts/Skills/SkillsDebugMenu.cs
+++ b/Assets/Scripts/Skills/SkillsDebugMenu.cs
@@ -3,6 +3,7 @@ using Player;
 using Beastmaster;
 using Pets;
 using BankSystem;
+using Skills.Fishing;
 
 namespace Skills
 {

--- a/Assets/Scripts/Skills/SkillsUI.cs
+++ b/Assets/Scripts/Skills/SkillsUI.cs
@@ -98,10 +98,10 @@ namespace Skills
             UIManager.Instance.OpenWindow(this);
             if (uiRoot != null)
             {
-                var inv = Object.FindObjectOfType<Inventory.Inventory>();
+                var inv = UnityEngine.Object.FindObjectOfType<Inventory.Inventory>();
                 if (inv != null && inv.IsOpen)
                     inv.CloseUI();
-                var eq = Object.FindObjectOfType<Inventory.Equipment>();
+                var eq = UnityEngine.Object.FindObjectOfType<Inventory.Equipment>();
                 if (eq != null && eq.IsOpen)
                     eq.CloseUI();
                 uiRoot.SetActive(true);


### PR DESCRIPTION
## Summary
- add missing reference to `BycatchManager` in debug menu
- specify `UnityEngine.Object` to avoid ambiguous type in skills UI

## Testing
- `dotnet build` *(fails: MSB1003 Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68bc70c6e3d4832eadbb3b8fb79237d0