### PR TITLE
Set custom skills display order in UI

### DIFF
--- a/Assets/Scripts/Skills/SkillsUI.cs
+++ b/Assets/Scripts/Skills/SkillsUI.cs
@@ -115,7 +115,18 @@ namespace Skills
             if (uiRoot != null && uiRoot.activeSelf && skillManager != null)
             {
                 var sb = new StringBuilder();
-                foreach (SkillType type in Enum.GetValues(typeof(SkillType)))
+                var displayOrder = new[]
+                {
+                    SkillType.Hitpoints,
+                    SkillType.Attack,
+                    SkillType.Strength,
+                    SkillType.Defence,
+                    SkillType.Beastmaster,
+                    SkillType.Fishing,
+                    SkillType.Woodcutting,
+                    SkillType.Mining
+                };
+                foreach (var type in displayOrder)
                 {
                     if (sb.Length > 0)
                         sb.Append('\n');


### PR DESCRIPTION
## Summary
- Display skills in a fixed order in SkillsUI

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68bc74aec88c832e8252fcea9caa69a2