### PR TITLE
Restore Perform method for spectral clone ambush

### DIFF
--- a/Assets/Scripts/NPC/Combat/CombatAttacks/SpectralCloneAmbush.cs
+++ b/Assets/Scripts/NPC/Combat/CombatAttacks/SpectralCloneAmbush.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using Combat;
 
 namespace NPC
 {
@@ -16,6 +18,17 @@ namespace NPC
         [SerializeField] bool blockSpawnUntilAllClonesDead = false;
 
         readonly List<GameObject> activeClones = new List<GameObject>();
+
+        /// <summary>
+        /// Optional callback invoked when all spawned clones have been destroyed.
+        /// </summary>
+        public Action onAllClonesGone;
+
+        // Owner used for tracking concurrent ambushes
+        BaseNpcCombat owner;
+
+        static readonly Dictionary<BaseNpcCombat, SpectralCloneAmbush> activeAmbushes =
+            new Dictionary<BaseNpcCombat, SpectralCloneAmbush>();
 
         /// <summary>
         /// Spawn a clone from the given prefab.
@@ -64,6 +77,69 @@ namespace NPC
         public void OnCloneDeath(GameObject clone)
         {
             activeClones.Remove(clone);
+            if (activeClones.Count == 0)
+            {
+                onAllClonesGone?.Invoke();
+                if (owner != null)
+                    activeAmbushes.Remove(owner);
+                Destroy(gameObject);
+            }
+        }
+
+        /// <summary>
+        /// Spawns spectral clones around the target. A random clone deals real
+        /// damage while the rest are decoys.
+        /// </summary>
+        public static void Perform(BaseNpcCombat owner, CombatTarget target,
+            GameObject[] clonePrefabs, int cloneCount, float cloneLifespan,
+            float spawnRadius, int realCloneDamage, Action onAllClonesGone = null,
+            bool preventConcurrent = false)
+        {
+            if (owner == null || target == null || clonePrefabs == null ||
+                clonePrefabs.Length == 0 || cloneCount <= 0)
+                return;
+
+            if (preventConcurrent && activeAmbushes.ContainsKey(owner))
+                return;
+
+            owner.StartCoroutine(SpawnClones(owner, target, clonePrefabs, cloneCount,
+                cloneLifespan, spawnRadius, realCloneDamage, onAllClonesGone,
+                preventConcurrent));
+        }
+
+        static IEnumerator SpawnClones(BaseNpcCombat owner, CombatTarget target,
+            GameObject[] clonePrefabs, int cloneCount, float cloneLifespan,
+            float spawnRadius, int realCloneDamage, Action onAllClonesGone,
+            bool preventConcurrent)
+        {
+            var go = new GameObject("SpectralCloneAmbush");
+            var ambush = go.AddComponent<SpectralCloneAmbush>();
+            ambush.owner = owner;
+            ambush.despawnAfterTime = cloneLifespan > 0f;
+            ambush.despawnDelay = cloneLifespan;
+            ambush.onAllClonesGone = onAllClonesGone;
+            if (preventConcurrent)
+                activeAmbushes[owner] = ambush;
+
+            int realIndex = UnityEngine.Random.Range(0, cloneCount);
+
+            for (int i = 0; i < cloneCount; i++)
+            {
+                var prefab = clonePrefabs[UnityEngine.Random.Range(0, clonePrefabs.Length)];
+                if (prefab == null)
+                    continue;
+
+                float angle = i * Mathf.PI * 2f / cloneCount;
+                Vector2 pos = (Vector2)target.transform.position +
+                    new Vector2(Mathf.Cos(angle), Mathf.Sin(angle)) * spawnRadius;
+                var clone = ambush.SpawnClone(prefab, pos, Quaternion.identity);
+                if (clone != null && i == realIndex && realCloneDamage > 0)
+                {
+                    target.ApplyDamage(realCloneDamage, DamageType.Magic, owner);
+                }
+            }
+
+            yield break;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add static `Perform` to `SpectralCloneAmbush` for spawning and tracking spectral clones
- invoke callback when clones end and support preventing concurrent ambushes

## Testing
- `dotnet build` *(fails: project or solution file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7e68d1b0832e90a928f628d3282a