### PR TITLE
Ensure EventSystem exists for interface tab buttons

### DIFF
--- a/Assets/Scripts/UI/InterfaceTabButtons.cs
+++ b/Assets/Scripts/UI/InterfaceTabButtons.cs
@@ -31,6 +31,10 @@ namespace UI
 
         private void CreateUI()
         {
+            if (UnityEngine.EventSystems.EventSystem.current == null)
+                new GameObject("EventSystem", typeof(UnityEngine.EventSystems.EventSystem),
+                               typeof(UnityEngine.EventSystems.StandaloneInputModule));
+
             var canvas = gameObject.AddComponent<Canvas>();
             canvas.renderMode = RenderMode.ScreenSpaceOverlay;
 


### PR DESCRIPTION
## Summary
- ensure an EventSystem is created before building interface tab buttons

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68bc85954f5c832eb26a75f4a7ba1040