### PR TITLE
Fix ambiguous Random reference in SpectralCloneAmbush

### DIFF
--- a/Assets/Scripts/NPC/Combat/CombatAttacks/SpectralCloneAmbush.cs
+++ b/Assets/Scripts/NPC/Combat/CombatAttacks/SpectralCloneAmbush.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using Combat;
 using UnityEngine;
+using Random = UnityEngine.Random;
 
 namespace NPC
 {
@@ -104,7 +105,7 @@ namespace NPC
             for (int i = 0; i < cloneCount; i++)
             {
                 Vector2 pos = (Vector2)target.transform.position + Random.insideUnitCircle * spawnRadius;
-                GameObject prefab = clonePrefabs[UnityEngine.Random.Range(0, clonePrefabs.Length)];
+                GameObject prefab = clonePrefabs[Random.Range(0, clonePrefabs.Length)];
                 SpawnClone(prefab, pos, Quaternion.identity);
             }
 


### PR DESCRIPTION
## Summary
- alias UnityEngine.Random to avoid System.Random ambiguity
- use Random alias when picking clone prefabs

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8a83b8b0832e99ef4164821e74a4