### PR TITLE
feat: add skilling outfit chance debug option

### DIFF
--- a/Assets/Scripts/Skills/AdminF2Menu.cs
+++ b/Assets/Scripts/Skills/AdminF2Menu.cs
@@ -4,6 +4,7 @@ using Beastmaster;
 using Pets;
 using BankSystem;
 using Skills.Fishing;
+using Skills.Outfits;
 
 namespace Skills
 {
@@ -207,6 +208,11 @@ namespace Skills
             if (GUILayout.Button(BycatchManager.DebugBycatchRolls ? "Disable Bycatch Debug" : "Enable Bycatch Debug"))
             {
                 BycatchManager.DebugBycatchRolls = !BycatchManager.DebugBycatchRolls;
+            }
+
+            if (GUILayout.Button(SkillingOutfitProgress.DebugChance ? "Disable Skilling Outfit Chance" : "Enable Skilling Outfit Chance"))
+            {
+                SkillingOutfitProgress.DebugChance = !SkillingOutfitProgress.DebugChance;
             }
 
             if (GUILayout.Button("Open Bank"))

--- a/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
@@ -434,7 +434,10 @@ namespace Skills.Fishing
 
         private void TryAwardFishingOutfitPiece()
         {
-            if (UnityEngine.Random.Range(0, 2500) != 0)
+            int roll = UnityEngine.Random.Range(0, 2500);
+            if (SkillingOutfitProgress.DebugChance)
+                Debug.Log($"[Fishing] Skilling outfit roll: {roll} (chance 1 in 2500)");
+            if (roll != 0)
                 return;
 
             var missing = new List<string>();

--- a/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
@@ -306,7 +306,10 @@ namespace Skills.Mining
 
         private void TryAwardMiningOutfitPiece()
         {
-            if (UnityEngine.Random.Range(0, 2500) != 0)
+            int roll = UnityEngine.Random.Range(0, 2500);
+            if (SkillingOutfitProgress.DebugChance)
+                Debug.Log($"[Mining] Skilling outfit roll: {roll} (chance 1 in 2500)");
+            if (roll != 0)
                 return;
 
             var missing = new List<string>();

--- a/Assets/Scripts/Skills/Outfits/SkillingOutfitProgress.cs
+++ b/Assets/Scripts/Skills/Outfits/SkillingOutfitProgress.cs
@@ -9,6 +9,12 @@ namespace Skills.Outfits
     /// </summary>
     public class SkillingOutfitProgress : ISaveable
     {
+        /// <summary>
+        /// When enabled, skilling outfit roll attempts will be logged to the console.
+        /// Controlled via the F2 debug menu.
+        /// </summary>
+        public static bool DebugChance { get; set; }
+
         public readonly string[] allPieceIds;
         public HashSet<string> owned;
         public readonly string saveKey;

--- a/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
@@ -305,7 +305,10 @@ namespace Skills.Woodcutting
 
         private void TryAwardWoodcuttingOutfitPiece()
         {
-            if (UnityEngine.Random.Range(0, 2500) != 0)
+            int roll = UnityEngine.Random.Range(0, 2500);
+            if (SkillingOutfitProgress.DebugChance)
+                Debug.Log($"[Woodcutting] Skilling outfit roll: {roll} (chance 1 in 2500)");
+            if (roll != 0)
                 return;
 
             var missing = new List<string>();


### PR DESCRIPTION
## Summary
- add debug toggle for skilling outfit rolls
- log roll and chance in mining, woodcutting, and fishing skills
- expose skilling outfit chance toggle in F2 admin menu

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4d8fd5d8832ea98ce17a27e49507