### PR TITLE
Add Cooking skill with recipes and UI integration

### DIFF
--- a/Assets/Scripts/Skills/AdminF2Menu.cs
+++ b/Assets/Scripts/Skills/AdminF2Menu.cs
@@ -27,6 +27,7 @@ namespace Skills
         private string miningLevel = "";
         private string woodcuttingLevel = "";
         private string fishingLevel = "";
+        private string cookingLevel = "";
         private string beastmasterLevel = "";
 
         // Scroll position for the debug menu
@@ -101,6 +102,7 @@ namespace Skills
             miningLevel = skillManager != null ? skillManager.GetLevel(SkillType.Mining).ToString() : "";
             woodcuttingLevel = skillManager != null ? skillManager.GetLevel(SkillType.Woodcutting).ToString() : "";
             fishingLevel = skillManager != null ? skillManager.GetLevel(SkillType.Fishing).ToString() : "";
+            cookingLevel = skillManager != null ? skillManager.GetLevel(SkillType.Cooking).ToString() : "";
             beastmasterLevel = skillManager != null ? skillManager.GetLevel(SkillType.Beastmaster).ToString() : "";
         }
 
@@ -138,6 +140,9 @@ namespace Skills
             GUILayout.Label("Fishing Level");
             fishingLevel = GUILayout.TextField(fishingLevel);
 
+            GUILayout.Label("Cooking Level");
+            cookingLevel = GUILayout.TextField(cookingLevel);
+
             GUILayout.Label("Beastmaster Level");
             beastmasterLevel = GUILayout.TextField(beastmasterLevel);
             if (mergeConfig != null && int.TryParse(beastmasterLevel, out var bmLevel))
@@ -171,6 +176,8 @@ namespace Skills
                     skillManager.DebugSetLevel(SkillType.Woodcutting, wood);
                 if (skillManager != null && int.TryParse(fishingLevel, out var fish))
                     skillManager.DebugSetLevel(SkillType.Fishing, fish);
+                if (skillManager != null && int.TryParse(cookingLevel, out var cook))
+                    skillManager.DebugSetLevel(SkillType.Cooking, cook);
                 if (skillManager != null && int.TryParse(beastmasterLevel, out var bm))
                 {
                     skillManager.DebugSetLevel(SkillType.Beastmaster, bm);

--- a/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
+++ b/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections;
+using UnityEngine;
+using Inventory;
+using Util;
+using UI;
+using BankSystem;
+using Pets;
+using Skills.Outfits;
+using Core.Save;
+
+namespace Skills.Cooking
+{
+    /// <summary>
+    /// Handles the cooking skill including tick based processing of recipes and
+    /// XP awards. Success removes a raw item and adds the cooked result. Failure
+    /// simply removes the raw item.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class CookingSkill : MonoBehaviour, ITickable
+    {
+        [SerializeField] private Inventory.Inventory inventory;
+        [SerializeField] private Transform floatingTextAnchor;
+
+        private SkillManager skills;
+        private CookableRecipe currentRecipe;
+        private int itemsRemaining;
+        private int cookProgress;
+        private const int CookIntervalTicks = 5;
+        private Coroutine tickerCoroutine;
+        private SkillingOutfitProgress cookingOutfit;
+
+        public event Action<CookableRecipe> OnStartCooking;
+        public event Action OnStopCooking;
+        public event Action<string, int> OnFoodCooked;
+        public event Action<int> OnLevelUp;
+
+        public int Level => skills != null ? skills.GetLevel(SkillType.Cooking) : 1;
+        public float Xp => skills != null ? skills.GetXp(SkillType.Cooking) : 0f;
+        public bool IsCooking => currentRecipe != null && itemsRemaining > 0;
+        public float CookProgressNormalized => CookIntervalTicks <= 1 ? 0f : (float)cookProgress / (CookIntervalTicks - 1);
+
+        private void Awake()
+        {
+            if (inventory == null)
+                inventory = GetComponent<Inventory.Inventory>();
+            skills = GetComponent<SkillManager>();
+            cookingOutfit = new SkillingOutfitProgress(new[]
+            {
+                "Cooking Hat",
+                "Cooking Top",
+                "Cooking Pants",
+                "Cooking Boots",
+                "Cooking Gloves"
+            }, "CookingOutfitOwned");
+        }
+
+        private void OnEnable()
+        {
+            TrySubscribeToTicker();
+        }
+
+        private void OnDisable()
+        {
+            if (Ticker.Instance != null)
+                Ticker.Instance.Unsubscribe(this);
+            if (tickerCoroutine != null)
+                StopCoroutine(tickerCoroutine);
+        }
+
+        private void OnDestroy()
+        {
+            SaveManager.Unregister(cookingOutfit);
+        }
+
+        private void TrySubscribeToTicker()
+        {
+            if (Ticker.Instance != null)
+            {
+                Ticker.Instance.Subscribe(this);
+            }
+            else
+            {
+                tickerCoroutine = StartCoroutine(WaitForTicker());
+            }
+        }
+
+        private IEnumerator WaitForTicker()
+        {
+            while (Ticker.Instance == null)
+                yield return null;
+            Ticker.Instance.Subscribe(this);
+        }
+
+        public void StartCooking(CookableRecipe recipe, int quantity)
+        {
+            if (recipe == null || quantity <= 0)
+                return;
+            if (skills != null && skills.GetLevel(SkillType.Cooking) < recipe.requiredLevel)
+                return;
+            currentRecipe = recipe;
+            itemsRemaining = quantity;
+            cookProgress = 0;
+            OnStartCooking?.Invoke(recipe);
+        }
+
+        public void StopCooking()
+        {
+            if (!IsCooking)
+                return;
+            currentRecipe = null;
+            itemsRemaining = 0;
+            cookProgress = 0;
+            OnStopCooking?.Invoke();
+        }
+
+        public void OnTick()
+        {
+            if (!IsCooking)
+                return;
+            cookProgress++;
+            if (cookProgress >= CookIntervalTicks)
+            {
+                cookProgress = 0;
+                AttemptCook();
+            }
+        }
+
+        private void AttemptCook()
+        {
+            if (currentRecipe == null || inventory == null)
+            {
+                StopCooking();
+                return;
+            }
+
+            if (!inventory.RemoveItem(currentRecipe.rawItemId))
+            {
+                StopCooking();
+                return;
+            }
+
+            itemsRemaining--;
+            Transform anchor = floatingTextAnchor != null ? floatingTextAnchor : transform;
+
+            int level = skills != null ? skills.GetLevel(SkillType.Cooking) : 1;
+            float burnChance = currentRecipe.burnChance;
+            if (level > currentRecipe.requiredLevel)
+            {
+                float t = Mathf.InverseLerp(currentRecipe.requiredLevel, currentRecipe.noBurnLevel, level);
+                burnChance = Mathf.Lerp(currentRecipe.burnChance, 0f, t);
+            }
+
+            bool burned = UnityEngine.Random.value < burnChance;
+            if (burned)
+            {
+                FloatingText.Show("Burned", anchor.position);
+            }
+            else
+            {
+                var cookedItem = ItemDatabase.GetItem(currentRecipe.cookedItemId);
+                if (cookedItem == null || !inventory.AddItem(cookedItem, 1))
+                {
+                    FloatingText.Show("Your inventory is full", anchor.position);
+                    StopCooking();
+                    return;
+                }
+
+                int xpGain = currentRecipe.xp;
+                int oldLevel = skills.GetLevel(SkillType.Cooking);
+                int newLevel = skills.AddXP(SkillType.Cooking, xpGain);
+                FloatingText.Show($"+1 {cookedItem.itemName}", anchor.position);
+                StartCoroutine(ShowXpGainDelayed(xpGain, anchor));
+                OnFoodCooked?.Invoke(currentRecipe.cookedItemId, 1);
+                TryAwardCookingOutfitPiece();
+                if (newLevel > oldLevel)
+                {
+                    FloatingText.Show($"Cooking level {newLevel}", anchor.position);
+                    OnLevelUp?.Invoke(newLevel);
+                }
+            }
+
+            if (itemsRemaining <= 0)
+                StopCooking();
+        }
+
+        private IEnumerator ShowXpGainDelayed(int xp, Transform anchor)
+        {
+            yield return new WaitForSeconds(Ticker.TickDuration * 5f);
+            if (anchor != null)
+                FloatingText.Show($"+{xp} XP", anchor.position);
+        }
+
+        public bool CanCook(CookableRecipe recipe, int quantity)
+        {
+            if (inventory == null || recipe == null)
+                return false;
+            return inventory.HasItem(recipe.rawItemId, quantity);
+        }
+
+        private void TryAwardCookingOutfitPiece()
+        {
+            int roll = UnityEngine.Random.Range(0, 2500);
+            if (SkillingOutfitProgress.DebugChance)
+                Debug.Log($"[Cooking] Skilling outfit roll: {roll} (chance 1 in 2500)");
+            if (roll != 0)
+                return;
+
+            var missing = new System.Collections.Generic.List<string>();
+            foreach (var id in cookingOutfit.allPieceIds)
+            {
+                if (!cookingOutfit.owned.Contains(id))
+                    missing.Add(id);
+            }
+            if (missing.Count == 0)
+                return;
+
+            string chosen = missing[UnityEngine.Random.Range(0, missing.Count)];
+            var item = ItemDatabase.GetItem(chosen);
+            bool added = inventory != null && item != null && inventory.AddItem(item);
+            if (!added)
+            {
+                BankUI.Instance?.AddItemToBank(item);
+                PetToastUI.Show("A piece of cooking outfit has been added to your bank");
+            }
+            else
+            {
+                PetToastUI.Show("You've received a piece of cooking outfit");
+            }
+            cookingOutfit.owned.Add(chosen);
+        }
+    }
+}

--- a/Assets/Scripts/Skills/Cooking/Data/CookableRecipe.cs
+++ b/Assets/Scripts/Skills/Cooking/Data/CookableRecipe.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+
+namespace Skills.Cooking
+{
+    /// <summary>
+    /// Defines a recipe for cooking. Maps a raw item to its cooked result and
+    /// contains information about level requirements and burn chance.
+    /// </summary>
+    [CreateAssetMenu(menuName = "Skills/Cooking/Cookable Recipe")]
+    public class CookableRecipe : ScriptableObject
+    {
+        [Tooltip("Item id for the raw food.")]
+        public string rawItemId;
+
+        [Tooltip("Item id for the cooked result.")]
+        public string cookedItemId;
+
+        [Tooltip("Cooking level required to attempt this recipe.")]
+        public int requiredLevel = 1;
+
+        [Tooltip("XP gained on a successful cook.")]
+        public int xp = 0;
+
+        [Range(0f, 1f)]
+        [Tooltip("Chance to burn the food at the required level.")]
+        public float burnChance = 0.0f;
+
+        [Tooltip("Level at which the item can no longer be burned.")]
+        public int noBurnLevel = 99;
+    }
+}

--- a/Assets/Scripts/Skills/SkillType.cs
+++ b/Assets/Scripts/Skills/SkillType.cs
@@ -15,6 +15,7 @@ namespace Skills
         Attack,
         Strength,
         Defence,
-        Fishing
+        Fishing,
+        Cooking
     }
 }

--- a/Assets/Scripts/Skills/SkillsUI.cs
+++ b/Assets/Scripts/Skills/SkillsUI.cs
@@ -28,6 +28,7 @@ namespace Skills
             SkillType.Defence,
             SkillType.Beastmaster,
             SkillType.Fishing,
+            SkillType.Cooking,
             SkillType.Woodcutting,
             SkillType.Mining
         };


### PR DESCRIPTION
## Summary
- extend `SkillType` with new `Cooking` option
- add `CookableRecipe` ScriptableObject and full `CookingSkill` tick loop
- wire Cooking into debug menu and skills UI

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9da3b464832e9c2047dccce2bbd7