### PR TITLE
Fix CookingSkill item quantity check

### DIFF
--- a/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
+++ b/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
@@ -195,7 +195,10 @@ namespace Skills.Cooking
         {
             if (inventory == null || recipe == null)
                 return false;
-            return inventory.HasItem(recipe.rawItemId, quantity);
+            var item = ItemDatabase.GetItem(recipe.rawItemId);
+            if (item == null)
+                return false;
+            return inventory.GetItemCount(item) >= quantity;
         }
 
         private void TryAwardCookingOutfitPiece()


### PR DESCRIPTION
## Summary
- Fix CanCook to verify required item quantity using ItemDatabase and inventory counts

## Testing
- `dotnet build` (fails: MSBUILD : error MSB1003: Specify a project or solution file)


------
https://chatgpt.com/codex/tasks/task_e_68bd9fbad6a4832e9a823cb75c47dbdb