### PR TITLE
Add burn chance calculation for cooking

### DIFF
--- a/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
+++ b/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
@@ -126,6 +126,15 @@ namespace Skills.Cooking
             }
         }
 
+        public static float CalculateBurnChance(int level, CookableRecipe recipe)
+        {
+            if (level >= recipe.noBurnLevel)
+                return 0f;
+            float relative = (recipe.noBurnLevel - level) /
+                             (float)(recipe.noBurnLevel - recipe.requiredLevel);
+            return recipe.burnChance * Mathf.Clamp01(relative);
+        }
+
         private void AttemptCook()
         {
             if (currentRecipe == null || inventory == null)
@@ -144,12 +153,7 @@ namespace Skills.Cooking
             Transform anchor = floatingTextAnchor != null ? floatingTextAnchor : transform;
 
             int level = skills != null ? skills.GetLevel(SkillType.Cooking) : 1;
-            float burnChance = currentRecipe.burnChance;
-            if (level > currentRecipe.requiredLevel)
-            {
-                float t = Mathf.InverseLerp(currentRecipe.requiredLevel, currentRecipe.noBurnLevel, level);
-                burnChance = Mathf.Lerp(currentRecipe.burnChance, 0f, t);
-            }
+            float burnChance = CalculateBurnChance(level, currentRecipe);
 
             bool burned = UnityEngine.Random.value < burnChance;
             if (burned)

--- a/Assets/Scripts/Skills/Cooking/Data/CookableRecipe.cs
+++ b/Assets/Scripts/Skills/Cooking/Data/CookableRecipe.cs
@@ -4,7 +4,8 @@ namespace Skills.Cooking
 {
     /// <summary>
     /// Defines a recipe for cooking. Maps a raw item to its cooked result and
-    /// contains information about level requirements and burn chance.
+    /// contains information about level requirements and burn chance at the
+    /// minimum required level.
     /// </summary>
     [CreateAssetMenu(menuName = "Skills/Cooking/Cookable Recipe")]
     public class CookableRecipe : ScriptableObject
@@ -22,7 +23,7 @@ namespace Skills.Cooking
         public int xp = 0;
 
         [Range(0f, 1f)]
-        [Tooltip("Chance to burn the food at the required level.")]
+        [Tooltip("Chance to burn the food at the minimum required level.")]
         public float burnChance = 0.0f;
 
         [Tooltip("Level at which the item can no longer be burned.")]

--- a/Assets/Tests/CookingSkillTests.cs
+++ b/Assets/Tests/CookingSkillTests.cs
@@ -1,0 +1,45 @@
+using NUnit.Framework;
+using Skills.Cooking;
+using UnityEngine;
+
+public class CookingSkillTests
+{
+    private static CookableRecipe CreateRecipe(int required, int noBurn, float burn)
+    {
+        var recipe = ScriptableObject.CreateInstance<CookableRecipe>();
+        recipe.requiredLevel = required;
+        recipe.noBurnLevel = noBurn;
+        recipe.burnChance = burn;
+        return recipe;
+    }
+
+    [Test]
+    public void BurnChanceEqualsRecipeAtRequiredLevel()
+    {
+        var recipe = CreateRecipe(5, 10, 0.4f);
+        float chance = CookingSkill.CalculateBurnChance(5, recipe);
+        Assert.AreEqual(recipe.burnChance, chance);
+    }
+
+    [Test]
+    public void BurnChanceZeroAtOrAboveNoBurnLevel()
+    {
+        var recipe = CreateRecipe(5, 10, 0.4f);
+        Assert.AreEqual(0f, CookingSkill.CalculateBurnChance(10, recipe));
+        Assert.AreEqual(0f, CookingSkill.CalculateBurnChance(11, recipe));
+    }
+
+    [Test]
+    public void BurnChanceStrictlyDecreasesBetweenLevels()
+    {
+        var recipe = CreateRecipe(1, 5, 0.6f);
+        float previous = CookingSkill.CalculateBurnChance(1, recipe);
+        for (int level = 2; level < 5; level++)
+        {
+            float chance = CookingSkill.CalculateBurnChance(level, recipe);
+            Assert.Less(chance, previous);
+            previous = chance;
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- refactor cooking burn chance calculation into a dedicated method following OSRS logic
- clarify that burnChance is evaluated at the minimum required level
- add unit tests for burn chance at required, no-burn, and intermediate levels

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*


------
https://chatgpt.com/codex/tasks/task_e_68bda3dfbefc832e81ffd7da55f16209