### PR TITLE
Add cookable fish recipes

### DIFF
--- a/Assets/Resources/CookingDatabase/Cooked Anchovy.asset
+++ b/Assets/Resources/CookingDatabase/Cooked Anchovy.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42d004d8aff4099428895062bf31fbe1, type: 3}
+  m_Name: Cooked Anchovy
+  m_EditorClassIdentifier:
+  rawItemId: Raw Anchovy
+  cookedItemId: Cooked Anchovy
+  requiredLevel: 2
+  xp: 22
+  burnChance: 0.4
+  noBurnLevel: 32

--- a/Assets/Resources/CookingDatabase/Cooked Anchovy.asset.meta
+++ b/Assets/Resources/CookingDatabase/Cooked Anchovy.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 60486f8515524b2e8c6fef30a3c97b20
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/CookingDatabase/Cooked Bass.asset
+++ b/Assets/Resources/CookingDatabase/Cooked Bass.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42d004d8aff4099428895062bf31fbe1, type: 3}
+  m_Name: Cooked Bass
+  m_EditorClassIdentifier:
+  rawItemId: Raw Bass
+  cookedItemId: Cooked Bass
+  requiredLevel: 30
+  xp: 135
+  burnChance: 0.4
+  noBurnLevel: 50

--- a/Assets/Resources/CookingDatabase/Cooked Bass.asset.meta
+++ b/Assets/Resources/CookingDatabase/Cooked Bass.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4e1ac047a43c4bc88941c6df328507d6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/CookingDatabase/Cooked Carp.asset
+++ b/Assets/Resources/CookingDatabase/Cooked Carp.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42d004d8aff4099428895062bf31fbe1, type: 3}
+  m_Name: Cooked Carp
+  m_EditorClassIdentifier:
+  rawItemId: Raw Carp
+  cookedItemId: Cooked Carp
+  requiredLevel: 37
+  xp: 180
+  burnChance: 0.4
+  noBurnLevel: 55

--- a/Assets/Resources/CookingDatabase/Cooked Carp.asset.meta
+++ b/Assets/Resources/CookingDatabase/Cooked Carp.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 808ba3c55b084ef49d07b47a183a5010
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/CookingDatabase/Cooked Catfish.asset
+++ b/Assets/Resources/CookingDatabase/Cooked Catfish.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42d004d8aff4099428895062bf31fbe1, type: 3}
+  m_Name: Cooked Catfish
+  m_EditorClassIdentifier:
+  rawItemId: Raw Catfish
+  cookedItemId: Cooked Catfish
+  requiredLevel: 22
+  xp: 97
+  burnChance: 0.4
+  noBurnLevel: 45

--- a/Assets/Resources/CookingDatabase/Cooked Catfish.asset.meta
+++ b/Assets/Resources/CookingDatabase/Cooked Catfish.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f064074b2ef8402e918cf8ee2caa2b02
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/CookingDatabase/Cooked Crayfish.asset
+++ b/Assets/Resources/CookingDatabase/Cooked Crayfish.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42d004d8aff4099428895062bf31fbe1, type: 3}
+  m_Name: Cooked Crayfish
+  m_EditorClassIdentifier:
+  rawItemId: Raw Crayfish
+  cookedItemId: Cooked Crayfish
+  requiredLevel: 12
+  xp: 52
+  burnChance: 0.4
+  noBurnLevel: 39

--- a/Assets/Resources/CookingDatabase/Cooked Crayfish.asset.meta
+++ b/Assets/Resources/CookingDatabase/Cooked Crayfish.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8341bd2ef20e409f8bd02379918b3c3d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/CookingDatabase/Cooked Eel.asset
+++ b/Assets/Resources/CookingDatabase/Cooked Eel.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42d004d8aff4099428895062bf31fbe1, type: 3}
+  m_Name: Cooked Eel
+  m_EditorClassIdentifier:
+  rawItemId: Raw Eel
+  cookedItemId: Cooked Eel
+  requiredLevel: 27
+  xp: 120
+  burnChance: 0.4
+  noBurnLevel: 48

--- a/Assets/Resources/CookingDatabase/Cooked Eel.asset.meta
+++ b/Assets/Resources/CookingDatabase/Cooked Eel.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ccbb278dc1c14310a66dc2de5558fbff
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/CookingDatabase/Cooked Herring.asset
+++ b/Assets/Resources/CookingDatabase/Cooked Herring.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42d004d8aff4099428895062bf31fbe1, type: 3}
+  m_Name: Cooked Herring
+  m_EditorClassIdentifier:
+  rawItemId: Raw Herring
+  cookedItemId: Cooked Herring
+  requiredLevel: 7
+  xp: 37
+  burnChance: 0.4
+  noBurnLevel: 36

--- a/Assets/Resources/CookingDatabase/Cooked Herring.asset.meta
+++ b/Assets/Resources/CookingDatabase/Cooked Herring.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 28f6f46767f14b068a0001ab55a68841
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/CookingDatabase/Cooked Lobster.asset
+++ b/Assets/Resources/CookingDatabase/Cooked Lobster.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42d004d8aff4099428895062bf31fbe1, type: 3}
+  m_Name: Cooked Lobster
+  m_EditorClassIdentifier:
+  rawItemId: Raw Lobster
+  cookedItemId: Cooked Lobster
+  requiredLevel: 40
+  xp: 180
+  burnChance: 0.4
+  noBurnLevel: 56

--- a/Assets/Resources/CookingDatabase/Cooked Lobster.asset.meta
+++ b/Assets/Resources/CookingDatabase/Cooked Lobster.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3e8f848c1f01471aa3c7891d2955ea5c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/CookingDatabase/Cooked Mackerel.asset
+++ b/Assets/Resources/CookingDatabase/Cooked Mackerel.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42d004d8aff4099428895062bf31fbe1, type: 3}
+  m_Name: Cooked Mackerel
+  m_EditorClassIdentifier:
+  rawItemId: Raw Mackerel
+  cookedItemId: Cooked Mackerel
+  requiredLevel: 32
+  xp: 150
+  burnChance: 0.4
+  noBurnLevel: 51

--- a/Assets/Resources/CookingDatabase/Cooked Mackerel.asset.meta
+++ b/Assets/Resources/CookingDatabase/Cooked Mackerel.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ed300163b6ad47edac87cb4d71e5a171
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/CookingDatabase/Cooked Minnow.asset
+++ b/Assets/Resources/CookingDatabase/Cooked Minnow.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42d004d8aff4099428895062bf31fbe1, type: 3}
+  m_Name: Cooked Minnow
+  m_EditorClassIdentifier:
+  rawItemId: Raw Minnow
+  cookedItemId: Cooked Minnow
+  requiredLevel: 3
+  xp: 27
+  burnChance: 0.4
+  noBurnLevel: 33

--- a/Assets/Resources/CookingDatabase/Cooked Minnow.asset.meta
+++ b/Assets/Resources/CookingDatabase/Cooked Minnow.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2e6dc471404c459ea975c84dd505e3dd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/CookingDatabase/Cooked Monkfish.asset
+++ b/Assets/Resources/CookingDatabase/Cooked Monkfish.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42d004d8aff4099428895062bf31fbe1, type: 3}
+  m_Name: Cooked Monkfish
+  m_EditorClassIdentifier:
+  rawItemId: Raw Monkfish
+  cookedItemId: Cooked Monkfish
+  requiredLevel: 50
+  xp: 225
+  burnChance: 0.4
+  noBurnLevel: 62

--- a/Assets/Resources/CookingDatabase/Cooked Monkfish.asset.meta
+++ b/Assets/Resources/CookingDatabase/Cooked Monkfish.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4eca541458a043cc92fe1fd7ed25a4bc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/CookingDatabase/Cooked Perch.asset
+++ b/Assets/Resources/CookingDatabase/Cooked Perch.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42d004d8aff4099428895062bf31fbe1, type: 3}
+  m_Name: Cooked Perch
+  m_EditorClassIdentifier:
+  rawItemId: Raw Perch
+  cookedItemId: Cooked Perch
+  requiredLevel: 17
+  xp: 82
+  burnChance: 0.4
+  noBurnLevel: 42

--- a/Assets/Resources/CookingDatabase/Cooked Perch.asset.meta
+++ b/Assets/Resources/CookingDatabase/Cooked Perch.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 19c88c4d238f48b2ba40b04d22200167
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/CookingDatabase/Cooked Pike.asset
+++ b/Assets/Resources/CookingDatabase/Cooked Pike.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42d004d8aff4099428895062bf31fbe1, type: 3}
+  m_Name: Cooked Pike
+  m_EditorClassIdentifier:
+  rawItemId: Raw Pike
+  cookedItemId: Cooked Pike
+  requiredLevel: 20
+  xp: 90
+  burnChance: 0.4
+  noBurnLevel: 44

--- a/Assets/Resources/CookingDatabase/Cooked Pike.asset.meta
+++ b/Assets/Resources/CookingDatabase/Cooked Pike.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 43ca47497ca146f9b565cd0e9be58249
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/CookingDatabase/Cooked Salmon.asset
+++ b/Assets/Resources/CookingDatabase/Cooked Salmon.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42d004d8aff4099428895062bf31fbe1, type: 3}
+  m_Name: Cooked Salmon
+  m_EditorClassIdentifier:
+  rawItemId: Raw Salmon
+  cookedItemId: Cooked Salmon
+  requiredLevel: 25
+  xp: 105
+  burnChance: 0.4
+  noBurnLevel: 47

--- a/Assets/Resources/CookingDatabase/Cooked Salmon.asset.meta
+++ b/Assets/Resources/CookingDatabase/Cooked Salmon.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 11cb270a4f104fc2ba89a6c64ad916ab
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/CookingDatabase/Cooked Sardine.asset
+++ b/Assets/Resources/CookingDatabase/Cooked Sardine.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42d004d8aff4099428895062bf31fbe1, type: 3}
+  m_Name: Cooked Sardine
+  m_EditorClassIdentifier:
+  rawItemId: Raw Sardine
+  cookedItemId: Cooked Sardine
+  requiredLevel: 5
+  xp: 30
+  burnChance: 0.4
+  noBurnLevel: 35

--- a/Assets/Resources/CookingDatabase/Cooked Sardine.asset.meta
+++ b/Assets/Resources/CookingDatabase/Cooked Sardine.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5308c4658d2048fc963b6a8b5d186fb5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/CookingDatabase/Cooked Shrimp.asset
+++ b/Assets/Resources/CookingDatabase/Cooked Shrimp.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42d004d8aff4099428895062bf31fbe1, type: 3}
+  m_Name: Cooked Shrimp
+  m_EditorClassIdentifier:
+  rawItemId: Raw Shrimp
+  cookedItemId: Cooked Shrimp
+  requiredLevel: 1
+  xp: 15
+  burnChance: 0.4
+  noBurnLevel: 30

--- a/Assets/Resources/CookingDatabase/Cooked Shrimp.asset.meta
+++ b/Assets/Resources/CookingDatabase/Cooked Shrimp.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ebe893536d9448339e1f7badb1d781dc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/CookingDatabase/Cooked Snapper.asset
+++ b/Assets/Resources/CookingDatabase/Cooked Snapper.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42d004d8aff4099428895062bf31fbe1, type: 3}
+  m_Name: Cooked Snapper
+  m_EditorClassIdentifier:
+  rawItemId: Raw Red Snapper
+  cookedItemId: Cooked Snapper
+  requiredLevel: 42
+  xp: 195
+  burnChance: 0.4
+  noBurnLevel: 58

--- a/Assets/Resources/CookingDatabase/Cooked Snapper.asset.meta
+++ b/Assets/Resources/CookingDatabase/Cooked Snapper.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f135117d900649519aa679d66ca350a3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/CookingDatabase/Cooked Squid.asset
+++ b/Assets/Resources/CookingDatabase/Cooked Squid.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42d004d8aff4099428895062bf31fbe1, type: 3}
+  m_Name: Cooked Squid
+  m_EditorClassIdentifier:
+  rawItemId: Raw Squid
+  cookedItemId: Cooked Squid
+  requiredLevel: 52
+  xp: 240
+  burnChance: 0.4
+  noBurnLevel: 64

--- a/Assets/Resources/CookingDatabase/Cooked Squid.asset.meta
+++ b/Assets/Resources/CookingDatabase/Cooked Squid.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3732ca3e91c1451b9634665d21d9435d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/CookingDatabase/Cooked Sturgeon.asset
+++ b/Assets/Resources/CookingDatabase/Cooked Sturgeon.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42d004d8aff4099428895062bf31fbe1, type: 3}
+  m_Name: Cooked Sturgeon
+  m_EditorClassIdentifier:
+  rawItemId: Raw Sturgeon
+  cookedItemId: Cooked Sturgeon
+  requiredLevel: 47
+  xp: 225
+  burnChance: 0.4
+  noBurnLevel: 61

--- a/Assets/Resources/CookingDatabase/Cooked Sturgeon.asset.meta
+++ b/Assets/Resources/CookingDatabase/Cooked Sturgeon.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a3d9a8ad0fd347a08cdd4aab889d18d5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/CookingDatabase/Cooked Swordfish.asset
+++ b/Assets/Resources/CookingDatabase/Cooked Swordfish.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42d004d8aff4099428895062bf31fbe1, type: 3}
+  m_Name: Cooked Swordfish
+  m_EditorClassIdentifier:
+  rawItemId: Raw Swordfish
+  cookedItemId: Cooked Swordfish
+  requiredLevel: 45
+  xp: 210
+  burnChance: 0.4
+  noBurnLevel: 59

--- a/Assets/Resources/CookingDatabase/Cooked Swordfish.asset.meta
+++ b/Assets/Resources/CookingDatabase/Cooked Swordfish.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cf79fb3107d1405ebc2b20fe233fa052
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/CookingDatabase/Cooked Trout.asset
+++ b/Assets/Resources/CookingDatabase/Cooked Trout.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42d004d8aff4099428895062bf31fbe1, type: 3}
+  m_Name: Cooked Trout
+  m_EditorClassIdentifier:
+  rawItemId: Raw Trout
+  cookedItemId: Cooked Trout
+  requiredLevel: 15
+  xp: 75
+  burnChance: 0.4
+  noBurnLevel: 41

--- a/Assets/Resources/CookingDatabase/Cooked Trout.asset.meta
+++ b/Assets/Resources/CookingDatabase/Cooked Trout.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3a585dd1dd36477198ca56b25db523da
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/CookingDatabase/Cooked Tuna.asset
+++ b/Assets/Resources/CookingDatabase/Cooked Tuna.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42d004d8aff4099428895062bf31fbe1, type: 3}
+  m_Name: Cooked Tuna
+  m_EditorClassIdentifier:
+  rawItemId: Raw Tuna
+  cookedItemId: Cooked Tuna
+  requiredLevel: 35
+  xp: 165
+  burnChance: 0.4
+  noBurnLevel: 53

--- a/Assets/Resources/CookingDatabase/Cooked Tuna.asset.meta
+++ b/Assets/Resources/CookingDatabase/Cooked Tuna.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3b11a3beb8d746af8458b6adc38ad7d9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/CookingDatabase/Cooked Whitefish.asset
+++ b/Assets/Resources/CookingDatabase/Cooked Whitefish.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42d004d8aff4099428895062bf31fbe1, type: 3}
+  m_Name: Cooked Whitefish
+  m_EditorClassIdentifier:
+  rawItemId: Raw Whitefish
+  cookedItemId: Cooked Whitefish
+  requiredLevel: 10
+  xp: 45
+  burnChance: 0.4
+  noBurnLevel: 38

--- a/Assets/Resources/CookingDatabase/Cooked Whitefish.asset.meta
+++ b/Assets/Resources/CookingDatabase/Cooked Whitefish.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 579a9c234cd14e3c9349cdb781043910
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add `CookableRecipe` assets for 23 fish in `Resources/CookingDatabase`
- include level requirements, XP, and burn data for each recipe

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68bda5efaa50832eb7421d754e24285b