### PR TITLE
feat: add cooking object

### DIFF
--- a/Assets/Scripts/Skills/Cooking/Core/CookingObject.cs
+++ b/Assets/Scripts/Skills/Cooking/Core/CookingObject.cs
@@ -1,0 +1,112 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using Inventory;
+using Player;
+using UI;
+
+namespace Skills.Cooking
+{
+    /// <summary>
+    /// World object that allows the player to cook items when used.
+    /// The player selects a cookable item in the inventory and then
+    /// clicks this object to begin cooking. Cooking stops if the
+    /// player moves or steps too far away.
+    /// </summary>
+    [RequireComponent(typeof(Collider2D))]
+    public class CookingObject : MonoBehaviour
+    {
+        [SerializeField] private float cancelDistance = 3f;
+
+        private static Dictionary<string, CookableRecipe> recipeLookup;
+
+        private Inventory.Inventory inventory;
+        private CookingSkill cookingSkill;
+        private PlayerMover playerMover;
+        private Transform playerTransform;
+
+        private void Awake()
+        {
+            var playerObj = GameObject.FindGameObjectWithTag("Player");
+            if (playerObj != null)
+            {
+                inventory = playerObj.GetComponent<Inventory.Inventory>();
+                cookingSkill = playerObj.GetComponent<CookingSkill>();
+                playerMover = playerObj.GetComponent<PlayerMover>();
+                playerTransform = playerObj.transform;
+            }
+            EnsureRecipeLookup();
+        }
+
+        private void EnsureRecipeLookup()
+        {
+            if (recipeLookup != null)
+                return;
+            recipeLookup = new Dictionary<string, CookableRecipe>();
+            var recipes = Resources.LoadAll<CookableRecipe>("CookingDatabase");
+            foreach (var r in recipes)
+            {
+                if (r != null && !string.IsNullOrEmpty(r.rawItemId))
+                    recipeLookup[r.rawItemId] = r;
+            }
+        }
+
+        private void Update()
+        {
+            if (cookingSkill != null && cookingSkill.IsCooking)
+            {
+                if (playerMover != null && playerMover.IsMoving)
+                {
+                    cookingSkill.StopCooking();
+                    return;
+                }
+                if (playerTransform != null && Vector3.Distance(playerTransform.position, transform.position) > cancelDistance)
+                    cookingSkill.StopCooking();
+            }
+        }
+
+        private void OnMouseOver()
+        {
+            if (Input.GetMouseButtonDown(0))
+            {
+                if (EventSystem.current != null && EventSystem.current.IsPointerOverGameObject())
+                    return;
+                TryStartCooking();
+            }
+        }
+
+        private void TryStartCooking()
+        {
+            if (inventory == null || cookingSkill == null)
+                return;
+
+            int selected = inventory.selectedIndex;
+            if (selected < 0)
+                return;
+
+            var entry = inventory.GetSlot(selected);
+            if (entry.item == null)
+                return;
+
+            if (!recipeLookup.TryGetValue(entry.item.id, out var recipe))
+            {
+                FloatingText.Show("You can't cook that", transform.position);
+                return;
+            }
+
+            if (cookingSkill.Level < recipe.requiredLevel)
+            {
+                FloatingText.Show($"You need Cooking level {recipe.requiredLevel}", transform.position);
+                return;
+            }
+
+            int quantity = inventory.GetItemCount(entry.item);
+            if (quantity <= 0)
+                return;
+
+            cookingSkill.StartCooking(recipe, quantity);
+            inventory.ClearSelection();
+        }
+    }
+}
+

--- a/Assets/Scripts/Skills/Cooking/Core/CookingObject.cs.meta
+++ b/Assets/Scripts/Skills/Cooking/Core/CookingObject.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5b05df7049a743c5a15e7689a4e9ae31


### PR DESCRIPTION
## Summary
- add CookingObject script to start/stop cooking when using raw items on a range or fire
- load cookable recipes from resources and prevent cooking if requirements unmet

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68bdabca436c832eb092b62b20646c76