### PR TITLE
Add cooking XP bonus to items and cooking skill

### DIFF
--- a/Assets/Scripts/Inventory/Equipment.cs
+++ b/Assets/Scripts/Inventory/Equipment.cs
@@ -286,6 +286,7 @@ namespace Inventory
             AppendBonus(item.fishingXpBonusMultiplier, "Fishing XP");
             AppendBonus(item.woodcuttingXpBonusMultiplier, "Woodcutting XP");
             AppendBonus(item.miningXpBonusMultiplier, "Mining XP");
+            AppendBonus(item.cookingXpBonusMultiplier, "Cooking XP");
 
             tooltipBonusText.text = sb.ToString();
 

--- a/Assets/Scripts/Inventory/ItemData.cs
+++ b/Assets/Scripts/Inventory/ItemData.cs
@@ -105,6 +105,10 @@ namespace Inventory
         [Tooltip("Additional mining XP multiplier (0.025 = +2.5% XP).")]
         public float miningXpBonusMultiplier = 0f;
 
+        [Header("Cooking Bonuses")]
+        [Tooltip("Additional cooking XP multiplier (0.025 = +2.5% XP).")]
+        public float cookingXpBonusMultiplier = 0f;
+
         [Header("Requirements")]
         public SkillRequirement[] skillRequirements;
 

--- a/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
+++ b/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
@@ -20,6 +20,7 @@ namespace Skills.Cooking
     public class CookingSkill : MonoBehaviour, ITickable
     {
         [SerializeField] private Inventory.Inventory inventory;
+        [SerializeField] private Equipment equipment;
         [SerializeField] private Transform floatingTextAnchor;
 
         private SkillManager skills;
@@ -44,6 +45,8 @@ namespace Skills.Cooking
         {
             if (inventory == null)
                 inventory = GetComponent<Inventory.Inventory>();
+            if (equipment == null)
+                equipment = GetComponent<Equipment>();
             skills = GetComponent<SkillManager>();
             cookingOutfit = new SkillingOutfitProgress(new[]
             {
@@ -170,7 +173,19 @@ namespace Skills.Cooking
                     return;
                 }
 
-                int xpGain = currentRecipe.xp;
+                float xpBonus = 0f;
+                if (equipment != null)
+                {
+                    foreach (EquipmentSlot slot in Enum.GetValues(typeof(EquipmentSlot)))
+                    {
+                        if (slot == EquipmentSlot.None)
+                            continue;
+                        var entry = equipment.GetEquipped(slot);
+                        if (entry.item != null)
+                            xpBonus += entry.item.cookingXpBonusMultiplier;
+                    }
+                }
+                int xpGain = Mathf.RoundToInt(currentRecipe.xp * (1f + xpBonus));
                 int oldLevel = skills.GetLevel(SkillType.Cooking);
                 int newLevel = skills.AddXP(SkillType.Cooking, xpGain);
                 FloatingText.Show($"+1 {cookedItem.itemName}", anchor.position);


### PR DESCRIPTION
## Summary
- add "Cooking Bonuses" header and cooking XP bonus multiplier to item definitions
- apply cooking XP bonuses from equipped items when awarding cooking experience
- show cooking XP bonuses on equipment tooltips

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*


------
https://chatgpt.com/codex/tasks/task_e_68bdb0023344832eb330cadae4001c0b