### PR TITLE
feat: add item search and eating delay

### DIFF
--- a/Assets/Scripts/Inventory/InventoryDebugMenu.cs
+++ b/Assets/Scripts/Inventory/InventoryDebugMenu.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 #if UNITY_EDITOR
 using UnityEditor;
@@ -29,6 +30,7 @@ namespace Inventory
         private bool visible;
         private ItemData amountItem;
         private string amountText = "1";
+        private string searchText = string.Empty;
 
         private void Awake()
         {
@@ -81,11 +83,15 @@ namespace Inventory
             const float height = 300f;
             Rect area = new Rect(10f, 10f, width, height);
             GUILayout.BeginArea(area, GUI.skin.box);
+
+            GUILayout.Label("Search:");
+            searchText = GUILayout.TextField(searchText);
+
             scroll = GUILayout.BeginScrollView(scroll);
 
             foreach (var item in allItems)
             {
-                if (item != null)
+                if (item != null && (string.IsNullOrEmpty(searchText) || item.name.IndexOf(searchText, StringComparison.OrdinalIgnoreCase) >= 0))
                 {
                     Rect rect = GUILayoutUtility.GetRect(new GUIContent(item.name), GUI.skin.button);
                     if (Event.current.type == EventType.MouseDown && Event.current.button == 1 && rect.Contains(Event.current.mousePosition))

--- a/Assets/Scripts/Player/PlayerEat.cs
+++ b/Assets/Scripts/Player/PlayerEat.cs
@@ -10,6 +10,8 @@ namespace Player
     public class PlayerEat : MonoBehaviour
     {
         private PlayerHitpoints hitpoints;
+        private float nextEatTime;
+        private const float EatDelay = 0.6f; // Delay between eating actions in seconds
 
         private void Awake()
         {
@@ -26,7 +28,11 @@ namespace Player
             if (item == null || hitpoints == null || item.healAmount <= 0)
                 return false;
 
+            if (Time.time < nextEatTime)
+                return false;
+
             hitpoints.Heal(item.healAmount);
+            nextEatTime = Time.time + EatDelay;
             return true;
         }
     }


### PR DESCRIPTION
## Summary
- add text search to F1 inventory debug menu
- prevent rapid food consumption with 0.6s cooldown

## Testing
- `dotnet test` *(fails: no project or solution file found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb74a95fc832e9f1e407acf1e575b