### PR TITLE
Fix consumables being selected instead of eaten

### DIFF
--- a/Assets/Scripts/Inventory/InventorySlot.cs
+++ b/Assets/Scripts/Inventory/InventorySlot.cs
@@ -76,6 +76,14 @@ namespace Inventory
             if (eventData.button == PointerEventData.InputButton.Left)
             {
                 var entry = inventory.GetSlot(index);
+
+                // Consumable items should be eaten immediately instead of being selected.
+                if (entry.item != null && entry.item.healAmount > 0)
+                {
+                    inventory.UseItem(index);
+                    return;
+                }
+
                 if (inventory.selectedIndex < 0)
                 {
                     if (entry.item != null)


### PR DESCRIPTION
## Summary
- consume food items immediately on left click rather than selecting them

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*
- `dotnet build` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb88d6744832ebaf73fbc0c350026