### PR TITLE
Add cooking pet interaction and drop logic

### DIFF
--- a/Assets/Game/Items/Mr Frying Pan.asset
+++ b/Assets/Game/Items/Mr Frying Pan.asset
@@ -12,10 +12,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c72479de709848e3ab024450652154e5, type: 3}
   m_Name: Mr Frying Pan
   m_EditorClassIdentifier: 
-  id: Beaver
-  displayName: Beaver
-  pickupItem: {fileID: 11400000, guid: 3b674f19bfa4e544984c23e5298e4f86, type: 2}
-  hasInventory: 1
+  id: Mr Frying Pan
+  displayName: Mr Frying Pan
+  pickupItem: {fileID: 11400000, guid: 9eef420767d12684680b8c0d496c17a7, type: 2}
+  hasInventory: 0
   sprite: {fileID: 0}
   pixelsPerUnit: 64
   evolutionTiers: []

--- a/Assets/Resources/PetDropTables/DefaultPetDrops.asset
+++ b/Assets/Resources/PetDropTables/DefaultPetDrops.asset
@@ -68,3 +68,8 @@ MonoBehaviour:
     sourceId: fishing
     requiredBeastmasterLevel: 0
     bonusDropMultiplier: 0
+  - pet: {fileID: 11400000, guid: ddaa914d2373ccf478f8aebb7ea2829d, type: 2}
+    oneInN: 10000
+    sourceId: cooking
+    requiredBeastmasterLevel: 0
+    bonusDropMultiplier: 0

--- a/Assets/Scripts/Pets/PetSpawner.cs
+++ b/Assets/Scripts/Pets/PetSpawner.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 using UnityEngine.AI;
 using Util;
+using Skills.Cooking;
 
 namespace Pets
 {
@@ -149,6 +150,11 @@ namespace Pets
                 agent.updateUpAxis = false;
                 var combat = go.AddComponent<PetCombatController>();
                 combat.definition = def;
+            }
+
+            if (def.id == "Mr Frying Pan")
+            {
+                go.AddComponent<CookingObject>();
             }
 
             return go;

--- a/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
+++ b/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
@@ -191,6 +191,8 @@ namespace Skills.Cooking
                 FloatingText.Show($"+1 {cookedItem.itemName}", anchor.position);
                 StartCoroutine(ShowXpGainDelayed(xpGain, anchor));
                 OnFoodCooked?.Invoke(currentRecipe.cookedItemId, 1);
+                int petChance = Mathf.Max(5000, 10000 - (level - 1) * 100);
+                PetDropSystem.TryRollPet("cooking", anchor.position, skills, petChance, out _);
                 TryAwardCookingOutfitPiece();
                 if (newLevel > oldLevel)
                 {


### PR DESCRIPTION
## Summary
- allow cooking pet to be used as a portable cooking source
- roll for the cooking pet on successful cooking actions
- configure cooking pet definition and drop table entry
- scale cooking pet drop chance from 1/10000 at level 1 down to 1/5000 at higher levels

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbaa74bcc832eb89903258052e92e