### PR TITLE
feat: add interaction collider for Mr Frying Pan

### DIFF
--- a/Assets/Scripts/Pets/PetSpawner.cs
+++ b/Assets/Scripts/Pets/PetSpawner.cs
@@ -154,6 +154,16 @@ namespace Pets
 
             if (def.id == "Mr Frying Pan")
             {
+                // Add a collider that can receive mouse events for cooking interaction.
+                var interactCol = go.AddComponent<BoxCollider2D>();
+                interactCol.isTrigger = false;
+
+                // Optionally place on a layer that does not collide with the environment
+                // so pathfinding remains unaffected.
+                int interactionLayer = LayerMask.NameToLayer("PetInteraction");
+                if (interactionLayer >= 0)
+                    interactCol.gameObject.layer = interactionLayer;
+
                 go.AddComponent<CookingObject>();
             }
 


### PR DESCRIPTION
## Summary
- add dedicated interaction collider to Mr Frying Pan so mouse clicks work
- keep optional layer assignment to avoid environment collisions

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc1b537c8832e827ac4fc6dba0558