### PR TITLE
Fix pet interaction trigger and pointer-based cooking

### DIFF
--- a/Assets/Scripts/Pets/PetSpawner.cs
+++ b/Assets/Scripts/Pets/PetSpawner.cs
@@ -156,13 +156,18 @@ namespace Pets
             {
                 // Add a collider that can receive mouse events for cooking interaction.
                 var interactCol = go.AddComponent<BoxCollider2D>();
-                interactCol.isTrigger = false;
+                interactCol.isTrigger = true;
 
                 // Optionally place on a layer that does not collide with the environment
                 // so pathfinding remains unaffected.
                 int interactionLayer = LayerMask.NameToLayer("PetInteraction");
                 if (interactionLayer >= 0)
+                {
                     interactCol.gameObject.layer = interactionLayer;
+                    int playerLayer = LayerMask.NameToLayer("Player");
+                    if (playerLayer >= 0)
+                        Physics2D.IgnoreLayerCollision(interactionLayer, playerLayer);
+                }
 
                 go.AddComponent<CookingObject>();
             }

--- a/Assets/Scripts/Skills/Cooking/Core/CookingObject.cs
+++ b/Assets/Scripts/Skills/Cooking/Core/CookingObject.cs
@@ -14,7 +14,7 @@ namespace Skills.Cooking
     /// player moves or steps too far away.
     /// </summary>
     [RequireComponent(typeof(Collider2D))]
-    public class CookingObject : MonoBehaviour
+    public class CookingObject : MonoBehaviour, IPointerClickHandler
     {
         [SerializeField] private float cancelDistance = 3f;
 
@@ -36,6 +36,10 @@ namespace Skills.Cooking
                 playerTransform = playerObj.transform;
             }
             EnsureRecipeLookup();
+
+            var mainCam = Camera.main;
+            if (mainCam != null && mainCam.GetComponent<Physics2DRaycaster>() == null)
+                mainCam.gameObject.AddComponent<Physics2DRaycaster>();
         }
 
         private void EnsureRecipeLookup()
@@ -65,12 +69,10 @@ namespace Skills.Cooking
             }
         }
 
-        private void OnMouseOver()
+        public void OnPointerClick(PointerEventData eventData)
         {
-            if (Input.GetMouseButtonDown(0))
+            if (eventData.button == PointerEventData.InputButton.Left)
             {
-                if (EventSystem.current != null && EventSystem.current.IsPointerOverGameObject())
-                    return;
                 TryStartCooking();
             }
         }


### PR DESCRIPTION
## Summary
- Allow Mr Frying Pan pet interaction collider to be a trigger and ignore player collisions
- Use IPointerClickHandler for cooking objects and ensure camera has Physics2DRaycaster

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc4d7541c832ea30dde3de5d954f6