### PR TITLE
Combine XP into single drop for Cook All

### DIFF
--- a/Assets/Scripts/UI/PetLevelBarContextMenuExtender.cs
+++ b/Assets/Scripts/UI/PetLevelBarContextMenuExtender.cs
@@ -6,6 +6,7 @@ using Beastmaster;
 using Inventory;
 using Skills;
 using Skills.Cooking;
+using UI;
 using Object = UnityEngine.Object;
 
 namespace Pets
@@ -164,6 +165,8 @@ namespace Pets
             if (inventory == null)
                 return;
 
+            int totalXp = 0;
+
             for (int i = 0; i < inventory.size; i++)
             {
                 var entry = inventory.GetSlot(i);
@@ -180,8 +183,19 @@ namespace Pets
                 inventory.RemoveItem(entry.item, qty);
                 inventory.AddItem(cookedItem, qty);
 
-                if (skills != null && recipe.xp > 0)
-                    skills.AddXP(SkillType.Cooking, recipe.xp * qty);
+                if (recipe.xp > 0)
+                    totalXp += recipe.xp * qty;
+            }
+
+            if (skills != null && totalXp > 0)
+            {
+                skills.AddXP(SkillType.Cooking, totalXp);
+
+                Transform anchor = player.transform;
+                var anchorChild = player.transform.Find("FloatingTextAnchor");
+                if (anchorChild != null)
+                    anchor = anchorChild;
+                FloatingText.Show($"+{totalXp} XP", anchor.position);
             }
         }
 


### PR DESCRIPTION
## Summary
- add FloatingText dependency for pet Cook All menu
- accumulate total XP from cooked items and show as one floating text drop

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68bde65953d8832e9f40166ea21b545d