### PR TITLE
Ensure attack style selection stays highlighted

### DIFF
--- a/Assets/Scripts/UI/AttackStyleUI.cs
+++ b/Assets/Scripts/UI/AttackStyleUI.cs
@@ -144,8 +144,11 @@ namespace UI
             if (btn == null)
                 return;
             var colors = btn.colors;
-            colors.normalColor = selected ? Color.green : Color.white;
-            colors.highlightedColor = selected ? Color.green : Color.white;
+            var color = selected ? Color.green : Color.white;
+            colors.normalColor = color;
+            colors.highlightedColor = color;
+            colors.selectedColor = color;
+            colors.pressedColor = color;
             btn.colors = colors;
         }
     }


### PR DESCRIPTION
## Summary
- Update attack style UI highlight logic to also set selected and pressed colors, keeping buttons green when selected.

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68bdedef532c832ea926e66e24681838