### PR TITLE
Persist player attack style

### DIFF
--- a/Assets/Scripts/Player/PlayerCombatLoadout.cs
+++ b/Assets/Scripts/Player/PlayerCombatLoadout.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using Combat;
 using EquipmentSystem;
 using Skills;
+using Core.Save;
 
 namespace Player
 {
@@ -9,9 +10,10 @@ namespace Player
     /// Stores the player's current combat style and exposes aggregated combat stats.
     /// </summary>
     [DisallowMultipleComponent]
-    public class PlayerCombatLoadout : MonoBehaviour
+    public class PlayerCombatLoadout : MonoBehaviour, ISaveable
     {
         [SerializeField] private CombatStyle style = CombatStyle.Accurate;
+        private const string SaveKey = "PlayerCombatStyle";
 
         private EquipmentAggregator equipment;
         private SkillManager skills;
@@ -20,13 +22,25 @@ namespace Player
         public CombatStyle Style
         {
             get => style;
-            set => style = value;
+            set
+            {
+                if (style == value)
+                    return;
+                style = value;
+                Save();
+            }
         }
 
         private void Awake()
         {
             equipment = GetComponent<EquipmentAggregator>();
             skills = GetComponent<SkillManager>();
+            SaveManager.Register(this);
+        }
+
+        private void OnDestroy()
+        {
+            SaveManager.Unregister(this);
         }
 
         private void Update()
@@ -38,13 +52,23 @@ namespace Player
         /// <summary>Cycle combat style in order Accurate → Aggressive → Defensive → Controlled.</summary>
         public void CycleStyle()
         {
-            style = (CombatStyle)(((int)style + 1) % 4);
+            Style = (CombatStyle)(((int)style + 1) % 4);
         }
 
         /// <summary>Get a snapshot of combat stats for the player.</summary>
         public CombatantStats GetCombatantStats()
         {
             return CombatantStats.ForPlayer(skills, equipment, style, DamageType.Melee);
+        }
+
+        public void Save()
+        {
+            SaveManager.Save(SaveKey, style);
+        }
+
+        public void Load()
+        {
+            style = SaveManager.Load<CombatStyle>(SaveKey);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Persist player's chosen combat style using `SaveManager`
- Automatically load and register attack style on startup

## Testing
- `dotnet test` *(fails: MSBUILD: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68bdef619b38832ebabcf26a6b09ba6d