### PR TITLE
Allow fishing spot selection through UI overlays

### DIFF
--- a/Assets/Scripts/Skills/Fishing/Core/FisherController.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FisherController.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.EventSystems;
 using Inventory;
 using Player;
 using UI;
@@ -53,17 +52,15 @@ namespace Skills.Fishing
 
         private void Update()
         {
-            bool pointerOverUI = EventSystem.current != null && EventSystem.current.IsPointerOverGameObject();
-
             if (Time.time >= nextInteractionTime)
             {
-                if (Input.GetMouseButtonDown(0) && !pointerOverUI)
+                if (Input.GetMouseButtonDown(0))
                 {
                     var spot = GetSpotUnderCursor();
                     if (spot != null)
                         TryStartFishing(spot);
                 }
-                else if (Input.GetMouseButtonDown(1) && !pointerOverUI)
+                else if (Input.GetMouseButtonDown(1))
                 {
                     var spot = GetSpotUnderCursor();
                     if (spot != null)


### PR DESCRIPTION
## Summary
- Allow FisherController to react to mouse clicks even when UI overlaps the cursor by removing `pointerOverUI` guard

## Testing
- `mcs Assets/Scripts/Skills/Fishing/Core/FisherController.cs` *(fails: Unity assemblies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bea92e1dd4832ebc5aa1c00fbd5cd3