### PR TITLE
Rename Cooking Hat to Chefs Hat

### DIFF
--- a/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
+++ b/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
@@ -50,7 +50,7 @@ namespace Skills.Cooking
             skills = GetComponent<SkillManager>();
             cookingOutfit = new SkillingOutfitProgress(new[]
             {
-                "Cooking Hat",
+                "Chefs Hat",
                 "Cooking Top",
                 "Cooking Pants",
                 "Cooking Boots",


### PR DESCRIPTION
## Summary
- rename Cooking Hat to Chefs Hat in Cooking skill outfit list

## Testing
- `dotnet test` (fails: MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)

------
https://chatgpt.com/codex/tasks/task_e_68bedc41f198832e842185198da663ab