### PR TITLE
Reset NPC combat state on respawn

### DIFF
--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -35,6 +35,20 @@ namespace NPC
             npcFacing = GetComponent<NpcFacing>();
         }
 
+        public void ResetCombatState()
+        {
+            foreach (var routine in activeAttacks.Values)
+            {
+                if (routine != null)
+                    StopCoroutine(routine);
+            }
+            activeAttacks.Clear();
+            threatLevels.Clear();
+            hasHitPlayer = false;
+            spawnPosition = transform.position;
+            wanderer?.ExitCombat();
+        }
+
         public void AddThreat(CombatTarget target, float amount)
         {
             if (target == null)

--- a/Assets/Scripts/NPC/Combat/NpcCombatant.cs
+++ b/Assets/Scripts/NPC/Combat/NpcCombatant.cs
@@ -78,6 +78,7 @@ namespace NPC
             currentHp = profile != null ? profile.HitpointsLevel : 1;
             if (collider2D) collider2D.enabled = true;
             if (spriteRenderer) spriteRenderer.enabled = true;
+            GetComponent<BaseNpcCombat>()?.ResetCombatState();
             OnHealthChanged?.Invoke(currentHp, MaxHP);
         }
     }


### PR DESCRIPTION
## Summary
- add `ResetCombatState` to `BaseNpcCombat` to clear threats and reset combat flags
- reset combat state when NPC respawns

## Testing
- `dotnet test` *(fails: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68bf559cd5cc832e86f0363ee8cb89f0