### PR TITLE
Credit pet damage to players

### DIFF
--- a/Assets/Scripts/Pets/PetCombatController.cs
+++ b/Assets/Scripts/Pets/PetCombatController.cs
@@ -5,6 +5,7 @@ using EquipmentSystem;
 using NPC;
 using Skills;
 using UI;
+using Player;
 
 namespace Pets
 {
@@ -212,7 +213,10 @@ namespace Pets
                 if (definition != null && definition.maxHitPerBeastmasterLevel != 0f)
                     maxHit = Mathf.RoundToInt(maxHit * (1f + definition.maxHitPerBeastmasterLevel * beastmasterLevel));
                 int dmg = CombatMath.RollDamage(maxHit);
-                target.ApplyDamage(dmg, attacker.DamageType, this);
+                object source = this;
+                if (owner != null && owner.TryGetComponent<PlayerCombatTarget>(out var ownerTarget))
+                    source = ownerTarget;
+                target.ApplyDamage(dmg, attacker.DamageType, source);
                 var sprite = dmg == maxHit ? maxHitHitsplat : damageHitsplat;
                 FloatingText.Show(dmg.ToString(), target.transform.position, Color.white, null, sprite);
                 if (npc != null)


### PR DESCRIPTION
## Summary
- forward pet attack credit to pet's owner when available
- attribute pet damage to player drops when owner is a player

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5a80be68832eb147a9f237d48cdb