### PR TITLE
Limit screen shake to nearby slam attacks

### DIFF
--- a/Assets/Scripts/NPC/Combat/CombatAttacks/GoblinWarChiefSlam.cs
+++ b/Assets/Scripts/NPC/Combat/CombatAttacks/GoblinWarChiefSlam.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using UnityEngine;
 using Combat;
+using Player;
 
 namespace NPC
 {
@@ -42,7 +43,13 @@ namespace NPC
                 }
             }
 
-            owner.StartCoroutine(ScreenShake(shakeDuration, shakeMagnitude));
+            var playerMover = Object.FindObjectOfType<PlayerMover>();
+            if (playerMover != null)
+            {
+                float shakeRadius = slamRange + 2f;
+                if (Vector2.Distance(owner.transform.position, playerMover.transform.position) <= shakeRadius)
+                    owner.StartCoroutine(ScreenShake(shakeDuration, shakeMagnitude));
+            }
         }
 
         private static IEnumerator FadeOutDust(GameObject dust)


### PR DESCRIPTION
## Summary
- Shake screen only if player is within slam damage radius plus 2 tiles

## Testing
- `dotnet test` *(fails: MSB1003 - no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68bfeac132b4832e9a2cf24ec59284a7