### PR TITLE
Stop movement and combat routines when player dies

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -85,6 +85,23 @@ namespace Combat
             return true;
         }
 
+        /// <summary>
+        /// Stops any ongoing attack routine and clears the current target.
+        /// </summary>
+        public void CancelCombat()
+        {
+            if (attackRoutine != null)
+            {
+                StopCoroutine(attackRoutine);
+                attackRoutine = null;
+            }
+            if (currentTarget != null)
+            {
+                OnCombatTargetChanged?.Invoke(null);
+                currentTarget = null;
+            }
+        }
+
         private IEnumerator AttackRoutine(CombatTarget target)
         {
             currentTarget = target;

--- a/Assets/Scripts/Player/PlayerRespawnSystem.cs
+++ b/Assets/Scripts/Player/PlayerRespawnSystem.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using Core;
 using World;
+using Combat;
 
 namespace Player
 {
@@ -14,6 +15,8 @@ namespace Player
         public static PlayerRespawnSystem Instance { get; private set; }
 
         private PlayerHitpoints hitpoints;
+        private PlayerMover playerMover;
+        private CombatController combatController;
         private bool isRespawning;
 
         private void Awake()
@@ -52,7 +55,18 @@ namespace Player
                 hitpoints.OnHealthChanged -= HandleHealthChanged;
 
             var playerObj = GameObject.FindGameObjectWithTag("Player");
-            hitpoints = playerObj != null ? playerObj.GetComponent<PlayerHitpoints>() : null;
+            if (playerObj != null)
+            {
+                hitpoints = playerObj.GetComponent<PlayerHitpoints>();
+                playerMover = playerObj.GetComponent<PlayerMover>();
+                combatController = playerObj.GetComponent<CombatController>();
+            }
+            else
+            {
+                hitpoints = null;
+                playerMover = null;
+                combatController = null;
+            }
             if (hitpoints != null)
                 hitpoints.OnHealthChanged += HandleHealthChanged;
         }
@@ -60,7 +74,11 @@ namespace Player
         private void HandleHealthChanged(int current, int max)
         {
             if (!isRespawning && current <= 0)
+            {
+                playerMover?.StopMovement();
+                combatController?.CancelCombat();
                 StartCoroutine(RespawnRoutine());
+            }
         }
 
         private IEnumerator RespawnRoutine()


### PR DESCRIPTION
## Summary
- track PlayerMover and CombatController in PlayerRespawnSystem
- stop movement and cancel combat routines on player death
- expose CancelCombat on CombatController

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c139a87278832eac38d76cd1995726