### PR TITLE
Fix NPC health bar fade

### DIFF
--- a/Assets/Scripts/NPC/Combat/NpcHealthHUD.cs
+++ b/Assets/Scripts/NPC/Combat/NpcHealthHUD.cs
@@ -117,7 +117,7 @@ namespace NPC
             float t = 0f;
             while (t < fadeDuration)
             {
-                t += Time.deltaTime;
+                t += Time.unscaledDeltaTime;
                 canvasGroup.alpha = Mathf.Lerp(start, target, t / fadeDuration);
                 yield return null;
             }


### PR DESCRIPTION
## Summary
- Ensure NPC health bars fade regardless of time scale by using unscaled delta time

## Testing
- `dotnet test` *(fails: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68c1432de0fc832eaa103fb651b8e2b4