### PR TITLE
Expose combat state and sync NPC HUD

### DIFF
--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -27,6 +27,7 @@ namespace NPC
         protected readonly Dictionary<CombatTarget, Coroutine> activeAttacks = new();
 
         private bool inCombat;
+        public bool InCombat => inCombat;
         public event System.Action<bool> OnCombatStateChanged;
 
         private void SetCombatState(bool state)

--- a/Assets/Scripts/NPC/Combat/NpcHealthHUD.cs
+++ b/Assets/Scripts/NPC/Combat/NpcHealthHUD.cs
@@ -20,6 +20,7 @@ namespace NPC
         [SerializeField] private float heightOffset = 1.5f;
         [SerializeField] private float fadeDuration = 0.25f;
         private Coroutine fadeRoutine;
+        private bool isVisible;
 
         private void Awake()
         {
@@ -31,6 +32,9 @@ namespace NPC
                 combat.OnCombatStateChanged += HandleCombatStateChanged;
             CreateHud();
             canvas.gameObject.SetActive(false);
+            bool inCombat = combat != null && combat.InCombat;
+            HandleCombatStateChanged(inCombat);
+            isVisible = inCombat;
         }
 
         private void CreateHud()
@@ -148,6 +152,16 @@ namespace NPC
             }
             if (combat != null)
                 combat.OnCombatStateChanged -= HandleCombatStateChanged;
+        }
+
+        private void Update()
+        {
+            bool inCombat = combat != null && combat.InCombat;
+            if (inCombat != isVisible)
+            {
+                HandleCombatStateChanged(inCombat);
+                isVisible = inCombat;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- expose in-combat status on BaseNpcCombat via a public property
- sync NpcHealthHUD visibility on Awake
- add defensive Update to keep HUD visibility in sync with combat state

## Testing
- `dotnet test` *(fails: MSBUILD error MSB1003 - no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ae6cac74832ea5567dcbd4265176