### PR TITLE
Support spell definitions and projectile-based magic damage

### DIFF
--- a/Assets/Scripts/Magic/FireProjectile.cs
+++ b/Assets/Scripts/Magic/FireProjectile.cs
@@ -1,0 +1,63 @@
+using UnityEngine;
+using Combat;
+
+namespace Magic
+{
+    /// <summary>
+    /// Simple projectile that travels toward a target and applies damage on impact.
+    /// </summary>
+    [RequireComponent(typeof(SpriteRenderer))]
+    public class FireProjectile : MonoBehaviour
+    {
+        public CombatTarget target;
+        public float speed = 8f;
+        public int damage;
+        public int maxHit;
+        public GameObject hitEffectPrefab;
+        public Sprite projectileSprite;
+        public CombatController owner;
+        public CombatStyle style;
+        public DamageType damageType = DamageType.Magic;
+        [SerializeField] private float selfDestructTime = 10f;
+        private float timer;
+
+        private void Awake()
+        {
+            timer = selfDestructTime;
+            var sr = GetComponent<SpriteRenderer>();
+            if (projectileSprite != null)
+                sr.sprite = projectileSprite;
+        }
+
+        private void Update()
+        {
+            if (target == null || !target.IsAlive)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            transform.position = Vector2.MoveTowards(transform.position,
+                target.transform.position, speed * Time.deltaTime);
+
+            if (Vector2.Distance(transform.position, target.transform.position) <= 0.05f)
+            {
+                Impact();
+                return;
+            }
+
+            timer -= Time.deltaTime;
+            if (timer <= 0f)
+                Destroy(gameObject);
+        }
+
+        private void Impact()
+        {
+            if (hitEffectPrefab != null)
+                Instantiate(hitEffectPrefab, transform.position, Quaternion.identity);
+
+            owner?.ApplySpellDamage(target, damage);
+            Destroy(gameObject);
+        }
+    }
+}

--- a/Assets/Scripts/Magic/SpellDefinition.cs
+++ b/Assets/Scripts/Magic/SpellDefinition.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+using Combat;
+
+namespace Magic
+{
+    /// <summary>
+    /// Defines a magic spell, including range, visuals and damage info.
+    /// </summary>
+    [CreateAssetMenu(menuName = "Magic/Spell Definition")]
+    public class SpellDefinition : ScriptableObject
+    {
+        [Tooltip("Display name of the spell")]
+        public string displayName;
+
+        [Tooltip("Maximum range of the spell")]
+        public float range = CombatMath.MELEE_RANGE;
+
+        [Tooltip("Projectile prefab to spawn when casting")]
+        public GameObject projectilePrefab;
+
+        [Tooltip("Prefab to spawn on impact")]
+        public GameObject hitEffectPrefab;
+
+        [Tooltip("Maximum damage this spell can inflict before bonuses")]
+        public int maxHit = 0;
+
+        [Tooltip("Icon used in the spell book")]
+        public Sprite icon;
+    }
+}

--- a/Assets/Scripts/NPC/Combat/NpcAttackOnClick.cs
+++ b/Assets/Scripts/NPC/Combat/NpcAttackOnClick.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using Combat;
 using Player;
+using UI;
 
 namespace NPC
 {
@@ -35,9 +36,10 @@ namespace NPC
                 playerController.TryAttackTarget(combatant);
             }
 
-            if (Vector2.Distance(playerController.transform.position, transform.position) > CombatMath.MELEE_RANGE)
+            float range = MagicUI.GetActiveSpellRange();
+            if (Vector2.Distance(playerController.transform.position, transform.position) > range)
             {
-                playerMover.MoveTo(transform, CombatMath.MELEE_RANGE, AttemptAttack);
+                playerMover.MoveTo(transform, range, AttemptAttack);
             }
             else
             {


### PR DESCRIPTION
## Summary
- add `SpellDefinition` ScriptableObject and `FireProjectile` to handle magic projectiles
- load spells from Resources in `MagicUI` with range helper and dynamic buttons
- extend combat to use spell range, roll damage separately, and apply when projectile hits
- move player within spell range on NPC click

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*


------
https://chatgpt.com/codex/tasks/task_e_68c1b3447020832e854b6904b163a8cb