### PR TITLE
Add spell speed to SpellDefinition

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -232,6 +232,7 @@ namespace Combat
                     proj.owner = this;
                     proj.style = attacker.Style;
                     proj.damageType = attacker.DamageType;
+                    proj.speed = MagicUI.ActiveSpell.speed;
                     if (MagicUI.ActiveSpell.hitEffectPrefab != null)
                         proj.hitEffectPrefab = MagicUI.ActiveSpell.hitEffectPrefab;
                 }

--- a/Assets/Scripts/Magic/SpellDefinition.cs
+++ b/Assets/Scripts/Magic/SpellDefinition.cs
@@ -15,6 +15,9 @@ namespace Magic
         [Tooltip("Maximum range of the spell")]
         public float range = CombatMath.MELEE_RANGE;
 
+        [Tooltip("Projectile travel speed for this spell")]
+        public float speed = 8f;
+
         [Tooltip("Projectile prefab to spawn when casting")]
         public GameObject projectilePrefab;
 


### PR DESCRIPTION
## Summary
- add configurable projectile speed to SpellDefinition
- pass spell speed to projectiles when casting

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c2e25634832e8adcecef839cf09c