### PR TITLE
Add configurable fade timer for spell hit effects

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -233,6 +233,7 @@ namespace Combat
                     proj.style = attacker.Style;
                     proj.damageType = attacker.DamageType;
                     proj.speed = MagicUI.ActiveSpell.speed;
+                    proj.hitFadeTime = MagicUI.ActiveSpell.hitFadeTime;
                     if (MagicUI.ActiveSpell.hitEffectPrefab != null)
                         proj.hitEffectPrefab = MagicUI.ActiveSpell.hitEffectPrefab;
                 }

--- a/Assets/Scripts/Magic/FireProjectile.cs
+++ b/Assets/Scripts/Magic/FireProjectile.cs
@@ -14,6 +14,7 @@ namespace Magic
         public int damage;
         public int maxHit;
         public GameObject hitEffectPrefab;
+        public float hitFadeTime = 0.5f;
         public Sprite projectileSprite;
         public CombatController owner;
         public CombatStyle style;
@@ -54,7 +55,12 @@ namespace Magic
         private void Impact()
         {
             if (hitEffectPrefab != null)
-                Instantiate(hitEffectPrefab, transform.position, Quaternion.identity);
+            {
+                var hitObj = Instantiate(hitEffectPrefab, transform.position, Quaternion.identity);
+                var effect = hitObj.GetComponent<HitEffect>();
+                if (effect != null)
+                    effect.Initialize(hitFadeTime);
+            }
 
             owner?.ApplySpellDamage(target, damage);
             Destroy(gameObject);

--- a/Assets/Scripts/Magic/HitEffect.cs
+++ b/Assets/Scripts/Magic/HitEffect.cs
@@ -1,0 +1,43 @@
+using UnityEngine;
+
+namespace Magic
+{
+    /// <summary>
+    /// Fades a sprite renderer over time and destroys the game object when done.
+    /// </summary>
+    [RequireComponent(typeof(SpriteRenderer))]
+    public class HitEffect : MonoBehaviour
+    {
+        private SpriteRenderer sr;
+        private float fadeTime = 0.5f;
+        private float timer;
+
+        private void Awake()
+        {
+            sr = GetComponent<SpriteRenderer>();
+        }
+
+        public void Initialize(float time)
+        {
+            fadeTime = time;
+            timer = time;
+        }
+
+        private void Update()
+        {
+            if (fadeTime <= 0f)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            timer -= Time.deltaTime;
+            var color = sr.color;
+            color.a = Mathf.Clamp01(timer / fadeTime);
+            sr.color = color;
+
+            if (timer <= 0f)
+                Destroy(gameObject);
+        }
+    }
+}

--- a/Assets/Scripts/Magic/SpellDefinition.cs
+++ b/Assets/Scripts/Magic/SpellDefinition.cs
@@ -24,6 +24,9 @@ namespace Magic
         [Tooltip("Prefab to spawn on impact")]
         public GameObject hitEffectPrefab;
 
+        [Tooltip("Time for the hit effect to fade out")]
+        public float hitFadeTime = 0.5f;
+
         [Tooltip("Maximum damage this spell can inflict before bonuses")]
         public int maxHit = 0;
 


### PR DESCRIPTION
## Summary
- allow spells to configure how long hit effects fade out
- propagate hit fade timer to projectiles and apply fading logic
- add HitEffect component to handle sprite fade and self-destruction

## Testing
- `dotnet test` *(fails: specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d532c268832ebef9df082da03619