### PR TITLE
Ensure NPC health HUD is excluded from minimap rendering

### DIFF
--- a/Assets/Scripts/NPC/Combat/NpcHealthHUD.cs
+++ b/Assets/Scripts/NPC/Combat/NpcHealthHUD.cs
@@ -88,6 +88,15 @@ namespace NPC
             textRect.anchorMax = Vector2.one;
             textRect.offsetMin = Vector2.zero;
             textRect.offsetMax = Vector2.zero;
+
+            SetLayerRecursively(go, LayerMask.NameToLayer("UI"));
+        }
+
+        private void SetLayerRecursively(GameObject obj, int layer)
+        {
+            obj.layer = layer;
+            foreach (Transform child in obj.transform)
+                SetLayerRecursively(child.gameObject, layer);
         }
 
         private void HandleHealthChanged(int current, int max)


### PR DESCRIPTION
## Summary
- Set the NPC health HUD canvas and its children to the UI layer to prevent rendering on minimap cameras
- Added helper to recursively assign the UI layer to the HUD hierarchy

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c1dde96ef8832e8b5feb6f35ec3b9f