### PR TITLE
Track weapon changes to update damage type

### DIFF
--- a/Assets/Scripts/UI/MagicUI.cs
+++ b/Assets/Scripts/UI/MagicUI.cs
@@ -25,6 +25,8 @@ namespace UI
         /// <summary>Maximum hit for the active spell.</summary>
         public static int ActiveSpellMaxHit => ActiveSpell != null ? ActiveSpell.maxHit : 0;
 
+        public static void ClearActiveSpell() => ActiveSpell = null;
+
         /// <summary>Range for the active spell or melee range if none.</summary>
         public static float GetActiveSpellRange() =>
             ActiveSpell != null ? ActiveSpell.range : CombatMath.MELEE_RANGE;


### PR DESCRIPTION
## Summary
- add ClearActiveSpell API in MagicUI
- react to weapon changes in PlayerCombatLoadout to update damage type and clear spell selection
- remove per-frame equipment checks

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e10840b0832e8b238c221c57fd5e