### PR TITLE
Restore last selected magic spell when equipping weapons

### DIFF
--- a/Assets/Scripts/Player/PlayerCombatLoadout.cs
+++ b/Assets/Scripts/Player/PlayerCombatLoadout.cs
@@ -99,7 +99,11 @@ namespace Player
             if (weapon != null)
             {
                 if (weapon.combat.Magic > 0)
+                {
                     damageType = DamageType.Magic;
+                    if (MagicUI.ActiveSpell == null)
+                        MagicUI.RestoreLastSpell();
+                }
                 else if (weapon.combat.Range > 0)
                     damageType = DamageType.Ranged;
                 else

--- a/Assets/Scripts/UI/MagicUI.cs
+++ b/Assets/Scripts/UI/MagicUI.cs
@@ -22,10 +22,18 @@ namespace UI
         public static SpellDefinition ActiveSpell { get; private set; }
             = null;
 
+        /// <summary>Most recently selected spell.</summary>
+        public static SpellDefinition LastSelectedSpell { get; private set; } = null;
+
         /// <summary>Maximum hit for the active spell.</summary>
         public static int ActiveSpellMaxHit => ActiveSpell != null ? ActiveSpell.maxHit : 0;
 
-        public static void ClearActiveSpell() => ActiveSpell = null;
+        public static void ClearActiveSpell()
+        {
+            ActiveSpell = null;
+            var instance = FindObjectOfType<MagicUI>();
+            instance?.UpdateSelection();
+        }
 
         /// <summary>Range for the active spell or melee range if none.</summary>
         public static float GetActiveSpellRange() =>
@@ -61,7 +69,10 @@ namespace UI
             if (loaded != null)
                 spells.AddRange(loaded);
             if (spells.Count > 0)
+            {
                 ActiveSpell = spells[0];
+                LastSelectedSpell = ActiveSpell;
+            }
         }
 
         private void CreateUI()
@@ -141,6 +152,7 @@ namespace UI
         private void SelectSpell(SpellDefinition spell)
         {
             ActiveSpell = spell;
+            LastSelectedSpell = spell;
             if (loadout == null)
                 loadout = FindObjectOfType<PlayerCombatLoadout>();
             loadout?.SetDamageType(DamageType.Magic);
@@ -164,6 +176,16 @@ namespace UI
             colors.selectedColor = color;
             colors.pressedColor = color;
             btn.colors = colors;
+        }
+
+        /// <summary>Restore the last selected spell and update UI highlighting.</summary>
+        public static void RestoreLastSpell()
+        {
+            if (LastSelectedSpell == null)
+                return;
+            ActiveSpell = LastSelectedSpell;
+            var instance = FindObjectOfType<MagicUI>();
+            instance?.UpdateSelection();
         }
     }
 }


### PR DESCRIPTION
## Summary
- Track the last selected spell in `MagicUI` and expose it for restoration
- Preserve last spell when clearing active spell and add helper to restore and re-highlight it
- On magic weapon equip, `PlayerCombatLoadout` restores the previously selected spell if none is active

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e4b207ec832e8cd1d261d8f40ff2