### PR TITLE
Face target before resolving combat attacks

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -26,6 +26,7 @@ namespace Combat
         private EquipmentAggregator equipment;
         private Player.PlayerCombatLoadout loadout;
         private PlayerCombatBinder combatBinder;
+        private PlayerMover mover;
         private Coroutine attackRoutine;
         private CombatTarget currentTarget;
         private float nextAttackTime;
@@ -47,6 +48,7 @@ namespace Combat
             equipment = GetComponent<EquipmentAggregator>() ?? GetComponentInParent<EquipmentAggregator>() ?? GetComponentInChildren<EquipmentAggregator>();
             loadout = GetComponent<Player.PlayerCombatLoadout>() ?? GetComponentInParent<Player.PlayerCombatLoadout>() ?? GetComponentInChildren<Player.PlayerCombatLoadout>();
             combatBinder = GetComponent<PlayerCombatBinder>() ?? GetComponentInParent<PlayerCombatBinder>() ?? GetComponentInChildren<PlayerCombatBinder>();
+            mover = GetComponent<PlayerMover>() ?? GetComponentInParent<PlayerMover>() ?? GetComponentInChildren<PlayerMover>();
 
             if (skills == null)
                 Debug.LogWarning("CombatController could not find a SkillManager; damage will use level 1 stats.", this);
@@ -118,6 +120,7 @@ namespace Combat
             {
                 if (Vector2.Distance(transform.position, target.transform.position) > MagicUI.GetActiveSpellRange())
                     break;
+                mover?.FaceTarget(target.transform);
                 OnAttackStart?.Invoke();
                 ResolveAttack(target);
                 // If the target died from the attack, exit immediately so listeners are notified

--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -220,6 +220,11 @@ namespace Player
 
             // Drive Animator (kept for future use and for state visibility)
             bool isMoving = moveDir.sqrMagnitude > 0f;
+            RefreshAnimator(isMoving);
+        }
+
+        private void RefreshAnimator(bool isMoving)
+        {
             anim.SetBool("IsMoving", isMoving);
             anim.SetInteger("Dir", facingDir);
 
@@ -301,12 +306,25 @@ namespace Player
                 if (sr.sprite != desired)
                     sr.sprite = desired;
             }
-            // --------------------------------------------------------------------------------------
         }
 
         void FixedUpdate()
         {
             rb.linearVelocity = moveDir * moveSpeed;
+        }
+
+        public void FaceTarget(Transform target)
+        {
+            if (target == null)
+                return;
+
+            Vector2 dir = (Vector2)target.position - (Vector2)transform.position;
+            if (Mathf.Abs(dir.x) > Mathf.Abs(dir.y))
+                facingDir = dir.x < 0 ? 1 : 2;
+            else
+                facingDir = dir.y < 0 ? 0 : 3;
+
+            RefreshAnimator(moveDir.sqrMagnitude > 0f);
         }
 
         public void MoveTo(Vector2 target, float stopDistance, Action onComplete = null)


### PR DESCRIPTION
## Summary
- add PlayerMover.FaceTarget to compute direction and refresh animation
- cache PlayerMover on CombatController and use to orient before OnAttackStart

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e75ef15c832e9d6bf07dd45018fd