### PR TITLE
fix: prevent melee from using magic range on spawn

### DIFF
--- a/Assets/Scripts/UI/MagicUI.cs
+++ b/Assets/Scripts/UI/MagicUI.cs
@@ -68,11 +68,10 @@ namespace UI
             var loaded = Resources.LoadAll<SpellDefinition>("Spells");
             if (loaded != null)
                 spells.AddRange(loaded);
-            if (spells.Count > 0)
-            {
-                ActiveSpell = spells[0];
-                LastSelectedSpell = ActiveSpell;
-            }
+            // Don't automatically select a spell on load. This allows melee
+            // range to be used at spawn when no magic weapon is equipped.
+            if (spells.Count > 0 && LastSelectedSpell == null)
+                LastSelectedSpell = spells[0];
         }
 
         private void CreateUI()


### PR DESCRIPTION
## Summary
- avoid auto-selecting a spell when the game starts so melee attacks use melee range until a spell is chosen

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e8f535f4832eb3aaffac8ecdd411