### PR TITLE
Allow deselecting active spell

### DIFF
--- a/Assets/Scripts/UI/MagicUI.cs
+++ b/Assets/Scripts/UI/MagicUI.cs
@@ -150,11 +150,21 @@ namespace UI
 
         private void SelectSpell(SpellDefinition spell)
         {
-            ActiveSpell = spell;
-            LastSelectedSpell = spell;
             if (loadout == null)
                 loadout = FindObjectOfType<PlayerCombatLoadout>();
-            loadout?.SetDamageType(DamageType.Magic);
+
+            if (ActiveSpell == spell)
+            {
+                ClearActiveSpell();
+                loadout?.SetDamageType(DamageType.Melee);
+            }
+            else
+            {
+                ActiveSpell = spell;
+                LastSelectedSpell = spell;
+                loadout?.SetDamageType(DamageType.Magic);
+            }
+
             UpdateSelection();
         }
 


### PR DESCRIPTION
## Summary
- Allow deselecting an already selected spell by clearing active spell and resetting combat loadout to melee
- Only update active spell/last selected spell when selecting a new spell
- Always refresh UI selection state

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c1eab89160832eb252c2dd42bbeae9