### PR TITLE
feat: add magic level requirements for spells

### DIFF
--- a/Assets/Scripts/Magic/SpellDefinition.cs
+++ b/Assets/Scripts/Magic/SpellDefinition.cs
@@ -32,5 +32,8 @@ namespace Magic
 
         [Tooltip("Icon used in the spell book")]
         public Sprite icon;
+
+        [Tooltip("Magic level required to use this spell")]
+        public int requiredMagicLevel = 1;
     }
 }

--- a/Assets/Scripts/UI/MagicUI.cs
+++ b/Assets/Scripts/UI/MagicUI.cs
@@ -5,6 +5,7 @@ using Player;
 using System;
 using System.Collections.Generic;
 using Magic;
+using Skills;
 
 namespace UI
 {
@@ -152,6 +153,15 @@ namespace UI
         {
             if (loadout == null)
                 loadout = FindObjectOfType<PlayerCombatLoadout>();
+
+            // Check for magic level requirement before selecting the spell
+            var skills = loadout != null ? loadout.GetComponent<SkillManager>() : null;
+            if (skills != null && skills.GetLevel(SkillType.Magic) < spell.requiredMagicLevel)
+            {
+                var anchor = loadout.transform.Find("FloatingTextAnchor") ?? loadout.transform;
+                FloatingText.Show($"You need a Magic level of {spell.requiredMagicLevel} to use this spell", anchor.position);
+                return;
+            }
 
             if (ActiveSpell == spell)
             {


### PR DESCRIPTION
## Summary
- add required magic level to spell definitions
- block selecting spells if player lacks magic level and show floating text

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c1eca78214832e89113e86c863e761