### PR TITLE
Add elemental spell damage support

### DIFF
--- a/Assets/Resources/Spells/WindStrike.asset
+++ b/Assets/Resources/Spells/WindStrike.asset
@@ -18,3 +18,4 @@ MonoBehaviour:
   hitEffectPrefab: {fileID: 0}
   maxHit: 4
   icon: {fileID: 21300000, guid: 615f182a766d77c41b8c44f8e0732e3a, type: 3}
+  element: 0

--- a/Assets/Scripts/Combat/CombatEnums.cs
+++ b/Assets/Scripts/Combat/CombatEnums.cs
@@ -14,6 +14,20 @@ namespace Combat
     }
 
     /// <summary>
+    /// Elemental affiliation of a magic spell.
+    /// </summary>
+    public enum SpellElement
+    {
+        Air,
+        Water,
+        Earth,
+        Electric,
+        Ice,
+        Fire,
+        None
+    }
+
+    /// <summary>
     /// Melee combat styles affecting effective levels and XP distribution.
     /// </summary>
     public enum CombatStyle

--- a/Assets/Scripts/Combat/CombatTarget.cs
+++ b/Assets/Scripts/Combat/CombatTarget.cs
@@ -12,6 +12,6 @@ namespace Combat
         DamageType PreferredDefenceType { get; }
         int CurrentHP { get; }
         int MaxHP { get; }
-        void ApplyDamage(int amount, DamageType type, object source);
+        void ApplyDamage(int amount, DamageType type, SpellElement element, object source);
     }
 }

--- a/Assets/Scripts/Magic/SpellDefinition.cs
+++ b/Assets/Scripts/Magic/SpellDefinition.cs
@@ -35,5 +35,8 @@ namespace Magic
 
         [Tooltip("Magic level required to use this spell")]
         public int requiredMagicLevel = 1;
+
+        [Tooltip("Elemental type of this spell")]
+        public SpellElement element = SpellElement.None;
     }
 }

--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -280,7 +280,7 @@ namespace NPC
                 int strEff = CombatMath.GetEffectiveStrength(attacker.StrengthLevel, attacker.Style);
                 int maxHit = CombatMath.GetMaxHit(strEff, attacker.Equip.strength);
                 damage = CombatMath.RollDamage(maxHit);
-                target.ApplyDamage(damage, attacker.DamageType, this);
+                target.ApplyDamage(damage, attacker.DamageType, SpellElement.None, this);
                 var targetName = (target as MonoBehaviour)?.name ?? "target";
                 Debug.Log($"{name} dealt {damage} damage to {targetName}.");
             }

--- a/Assets/Scripts/NPC/Combat/CombatAttacks/GoblinWarChiefSlam.cs
+++ b/Assets/Scripts/NPC/Combat/CombatAttacks/GoblinWarChiefSlam.cs
@@ -26,7 +26,7 @@ namespace NPC
                     if (otherFaction != null && !myFaction.IsEnemy(otherFaction.Faction))
                         continue;
                 }
-                otherTarget.ApplyDamage(slamDamage, DamageType.Melee, owner);
+                otherTarget.ApplyDamage(slamDamage, DamageType.Melee, SpellElement.None, owner);
             }
 
             for (int x = -1; x <= 1; x++)

--- a/Assets/Scripts/NPC/Combat/NpcCombatant.cs
+++ b/Assets/Scripts/NPC/Combat/NpcCombatant.cs
@@ -45,7 +45,7 @@ namespace NPC
         }
 
         /// <summary>Apply damage to this NPC.</summary>
-        public void ApplyDamage(int amount, DamageType type, object source)
+        public void ApplyDamage(int amount, DamageType type, SpellElement element, object source)
         {
             currentHp = Mathf.Max(0, currentHp - amount);
             Debug.Log($"{name} took {amount} damage ({currentHp}/{MaxHP}).");

--- a/Assets/Scripts/NPC/Combat/Projectiles/GroundFlame.cs
+++ b/Assets/Scripts/NPC/Combat/Projectiles/GroundFlame.cs
@@ -43,7 +43,7 @@ namespace NPC
                 foreach (var tgt in targets)
                 {
                     if (tgt != null)
-                        tgt.ApplyDamage(damagePerTick, DamageType.Burn, this);
+                        tgt.ApplyDamage(damagePerTick, DamageType.Burn, SpellElement.Fire, this);
                 }
                 elapsed += CombatMath.TICK_SECONDS;
                 yield return wait;

--- a/Assets/Scripts/Pets/PetCombatController.cs
+++ b/Assets/Scripts/Pets/PetCombatController.cs
@@ -35,7 +35,7 @@ namespace Pets
         public DamageType PreferredDefenceType => DamageType.Melee;
         public int CurrentHP => 1;
         public int MaxHP => 1;
-        public void ApplyDamage(int amount, DamageType type, object source) { }
+        public void ApplyDamage(int amount, DamageType type, SpellElement element, object source) { }
 
         private void Awake()
         {
@@ -216,7 +216,7 @@ namespace Pets
                 object source = this;
                 if (owner != null && owner.TryGetComponent<PlayerCombatTarget>(out var ownerTarget))
                     source = ownerTarget;
-                target.ApplyDamage(dmg, attacker.DamageType, source);
+                target.ApplyDamage(dmg, attacker.DamageType, SpellElement.None, source);
                 var sprite = dmg == maxHit ? maxHitHitsplat : damageHitsplat;
                 FloatingText.Show(dmg.ToString(), target.transform.position, Color.white, null, sprite);
                 if (npc != null)

--- a/Assets/Scripts/Player/PlayerCombatTarget.cs
+++ b/Assets/Scripts/Player/PlayerCombatTarget.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using Combat;
 using UI;
+using System.Collections.Generic;
 
 namespace Player
 {
@@ -14,6 +15,7 @@ namespace Player
         private Sprite damageHitsplat;
         private Sprite zeroHitsplat;
         private Sprite burnHitsplat;
+        private Dictionary<SpellElement, Sprite> elementHitsplats;
 
         private void Awake()
         {
@@ -21,6 +23,15 @@ namespace Player
             damageHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Damage_hitsplat");
             zeroHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Zero_damage_hitsplat");
             burnHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Burn_hitsplat");
+            elementHitsplats = new Dictionary<SpellElement, Sprite>
+            {
+                { SpellElement.Air, Resources.Load<Sprite>("Sprites/HitSplats/Air_hitsplat") },
+                { SpellElement.Water, Resources.Load<Sprite>("Sprites/HitSplats/Water_hitsplat") },
+                { SpellElement.Earth, Resources.Load<Sprite>("Sprites/HitSplats/Earth_hitsplat") },
+                { SpellElement.Electric, Resources.Load<Sprite>("Sprites/HitSplats/Electrocute_hitsplat") },
+                { SpellElement.Ice, Resources.Load<Sprite>("Sprites/HitSplats/Water_hitsplat") },
+                { SpellElement.Fire, burnHitsplat }
+            };
         }
 
         public bool IsAlive => hitpoints.CurrentHp > 0;
@@ -28,14 +39,16 @@ namespace Player
         public int CurrentHP => hitpoints.CurrentHp;
         public int MaxHP => hitpoints.MaxHp;
 
-        public void ApplyDamage(int amount, DamageType type, object source)
+        public void ApplyDamage(int amount, DamageType type, SpellElement element, object source)
         {
             hitpoints.OnEnemyDealtDamage(amount);
             Sprite sprite;
             if (amount == 0)
                 sprite = zeroHitsplat;
-            else if (type == DamageType.Burn && burnHitsplat != null)
+            else if (type == DamageType.Burn)
                 sprite = burnHitsplat;
+            else if (type == DamageType.Magic && elementHitsplats != null && elementHitsplats.TryGetValue(element, out var elemSprite) && elemSprite != null)
+                sprite = elemSprite;
             else
                 sprite = damageHitsplat;
             FloatingText.Show(amount.ToString(), transform.position, Color.white, null, sprite);


### PR DESCRIPTION
## Summary
- introduce `SpellElement` enum and expose an element field on spell definitions
- display element-specific hit splats and propagate spell element through combat damage
- update combat targets and call sites to handle spell elements

## Testing
- `dotnet test` *(fails: Specify a project or solution file. The current working directory does not contain a project or solution file.)*


------
https://chatgpt.com/codex/tasks/task_e_68c1f1b83e54832e89dc62a88cbf001f