### PR TITLE
Make air hitsplat text black for visibility

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -207,11 +207,16 @@ namespace Combat
             {
                 target.ApplyDamage(damage, type, element, this);
                 Sprite sprite;
+                Color textColor = Color.white;
                 if (type == DamageType.Magic && elementHitsplats != null && elementHitsplats.TryGetValue(element, out var elemSprite) && elemSprite != null)
+                {
                     sprite = elemSprite;
+                    if (element == SpellElement.Air)
+                        textColor = Color.black;
+                }
                 else
                     sprite = damage == maxHit ? maxHitHitsplat : damageHitsplat;
-                FloatingText.Show(damage.ToString(), target.transform.position, Color.white, null, sprite);
+                FloatingText.Show(damage.ToString(), target.transform.position, textColor, null, sprite);
                 AwardXp(damage, style, type);
                 if (!target.IsAlive)
                     OnTargetKilled?.Invoke(target);

--- a/Assets/Scripts/Player/PlayerCombatTarget.cs
+++ b/Assets/Scripts/Player/PlayerCombatTarget.cs
@@ -43,15 +43,20 @@ namespace Player
         {
             hitpoints.OnEnemyDealtDamage(amount);
             Sprite sprite;
+            Color textColor = Color.white;
             if (amount == 0)
                 sprite = zeroHitsplat;
             else if (type == DamageType.Burn)
                 sprite = burnHitsplat;
             else if (type == DamageType.Magic && elementHitsplats != null && elementHitsplats.TryGetValue(element, out var elemSprite) && elemSprite != null)
+            {
                 sprite = elemSprite;
+                if (element == SpellElement.Air)
+                    textColor = Color.black;
+            }
             else
                 sprite = damageHitsplat;
-            FloatingText.Show(amount.ToString(), transform.position, Color.white, null, sprite);
+            FloatingText.Show(amount.ToString(), transform.position, textColor, null, sprite);
             Debug.Log($"Player took {amount} damage.");
         }
     }


### PR DESCRIPTION
## Summary
- draw air hitsplat damage text in black instead of white

## Testing
- `dotnet test` *(fails: could not find any project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f4ff80e4832eaa583fa59bf61632