### PR TITLE
Return final damage from ApplyDamage

### DIFF
--- a/Assets/Scripts/Combat/CombatTarget.cs
+++ b/Assets/Scripts/Combat/CombatTarget.cs
@@ -12,6 +12,6 @@ namespace Combat
         DamageType PreferredDefenceType { get; }
         int CurrentHP { get; }
         int MaxHP { get; }
-        void ApplyDamage(int amount, DamageType type, SpellElement element, object source);
+        int ApplyDamage(int amount, DamageType type, SpellElement element, object source);
     }
 }

--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -280,9 +280,9 @@ namespace NPC
                 int strEff = CombatMath.GetEffectiveStrength(attacker.StrengthLevel, attacker.Style);
                 int maxHit = CombatMath.GetMaxHit(strEff, attacker.Equip.strength);
                 damage = CombatMath.RollDamage(maxHit);
-                target.ApplyDamage(damage, attacker.DamageType, SpellElement.None, this);
+                int finalDamage = target.ApplyDamage(damage, attacker.DamageType, SpellElement.None, this);
                 var targetName = (target as MonoBehaviour)?.name ?? "target";
-                Debug.Log($"{name} dealt {damage} damage to {targetName}.");
+                Debug.Log($"{name} dealt {finalDamage} damage to {targetName}.");
             }
             else
             {

--- a/Assets/Scripts/NPC/Combat/NpcCombatant.cs
+++ b/Assets/Scripts/NPC/Combat/NpcCombatant.cs
@@ -45,7 +45,7 @@ namespace NPC
         }
 
         /// <summary>Apply damage to this NPC.</summary>
-        public void ApplyDamage(int amount, DamageType type, SpellElement element, object source)
+        public int ApplyDamage(int amount, DamageType type, SpellElement element, object source)
         {
             int finalAmount = amount;
             if (profile != null && profile.elementalModifiers != null)
@@ -110,6 +110,8 @@ namespace NPC
                 if (profile != null && profile.RespawnSeconds > 0f)
                     StartCoroutine(RespawnRoutine());
             }
+
+            return finalAmount;
         }
 
         /// <summary>Get combat stats for this NPC.</summary>

--- a/Assets/Scripts/Pets/PetCombatController.cs
+++ b/Assets/Scripts/Pets/PetCombatController.cs
@@ -35,7 +35,7 @@ namespace Pets
         public DamageType PreferredDefenceType => DamageType.Melee;
         public int CurrentHP => 1;
         public int MaxHP => 1;
-        public void ApplyDamage(int amount, DamageType type, SpellElement element, object source) { }
+        public int ApplyDamage(int amount, DamageType type, SpellElement element, object source) { return 0; }
 
         private void Awake()
         {
@@ -216,15 +216,15 @@ namespace Pets
                 object source = this;
                 if (owner != null && owner.TryGetComponent<PlayerCombatTarget>(out var ownerTarget))
                     source = ownerTarget;
-                target.ApplyDamage(dmg, attacker.DamageType, SpellElement.None, source);
-                var sprite = dmg == maxHit ? maxHitHitsplat : damageHitsplat;
-                FloatingText.Show(dmg.ToString(), target.transform.position, Color.white, null, sprite);
+                int finalDamage = target.ApplyDamage(dmg, attacker.DamageType, SpellElement.None, source);
+                var sprite = finalDamage == maxHit ? maxHitHitsplat : damageHitsplat;
+                FloatingText.Show(finalDamage.ToString(), target.transform.position, Color.white, null, sprite);
                 if (npc != null)
                 {
                     var npcAttack = npc.GetComponent<NpcAttackController>();
                     npcAttack?.BeginAttacking(this);
                 }
-                BeastmasterXp.TryGrantFromPetDamage(owner != null ? owner.gameObject : null, dmg);
+                BeastmasterXp.TryGrantFromPetDamage(owner != null ? owner.gameObject : null, finalDamage);
             }
             else
             {

--- a/Assets/Scripts/Player/PlayerCombatTarget.cs
+++ b/Assets/Scripts/Player/PlayerCombatTarget.cs
@@ -39,7 +39,7 @@ namespace Player
         public int CurrentHP => hitpoints.CurrentHp;
         public int MaxHP => hitpoints.MaxHp;
 
-        public void ApplyDamage(int amount, DamageType type, SpellElement element, object source)
+        public int ApplyDamage(int amount, DamageType type, SpellElement element, object source)
         {
             hitpoints.OnEnemyDealtDamage(amount);
             Sprite sprite;
@@ -58,6 +58,7 @@ namespace Player
                 sprite = damageHitsplat;
             FloatingText.Show(amount.ToString(), transform.position, textColor, null, sprite);
             Debug.Log($"Player took {amount} damage.");
+            return amount;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Extend `CombatTarget.ApplyDamage` to return actual damage dealt
- Propagate new return value through NPC, player and pet combat targets
- Track final damage in combat controller and NPC combat logic for hitsplats, XP and logging

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c1fcb03190832e85340389da5c4cbf