### PR TITLE
feat: allow ordering of spellbook entries

### DIFF
--- a/Assets/Resources/Spells/EarthStrike.asset
+++ b/Assets/Resources/Spells/EarthStrike.asset
@@ -22,3 +22,4 @@ MonoBehaviour:
   icon: {fileID: 21300000, guid: 57958148222d9bc4996853cb7ac07452, type: 3}
   requiredMagicLevel: 9
   element: 2
+  loadOrder: 2

--- a/Assets/Resources/Spells/ElectricStrike.asset
+++ b/Assets/Resources/Spells/ElectricStrike.asset
@@ -22,3 +22,4 @@ MonoBehaviour:
   icon: {fileID: 21300000, guid: 72c6399e42241534681e9ce227d7744f, type: 3}
   requiredMagicLevel: 10
   element: 3
+  loadOrder: 4

--- a/Assets/Resources/Spells/FireStrike.asset
+++ b/Assets/Resources/Spells/FireStrike.asset
@@ -22,3 +22,4 @@ MonoBehaviour:
   icon: {fileID: 21300000, guid: 72c6399e42241534681e9ce227d7744f, type: 3}
   requiredMagicLevel: 1
   element: 5
+  loadOrder: 3

--- a/Assets/Resources/Spells/WaterStrike.asset
+++ b/Assets/Resources/Spells/WaterStrike.asset
@@ -22,3 +22,4 @@ MonoBehaviour:
   icon: {fileID: 21300000, guid: 5f817161ba2b33042b53b924ed8db0f5, type: 3}
   requiredMagicLevel: 5
   element: 1
+  loadOrder: 1

--- a/Assets/Resources/Spells/WindStrike.asset
+++ b/Assets/Resources/Spells/WindStrike.asset
@@ -22,3 +22,4 @@ MonoBehaviour:
   icon: {fileID: 21300000, guid: 615f182a766d77c41b8c44f8e0732e3a, type: 3}
   requiredMagicLevel: 1
   element: 0
+  loadOrder: 0

--- a/Assets/Scripts/Magic/SpellDefinition.cs
+++ b/Assets/Scripts/Magic/SpellDefinition.cs
@@ -38,5 +38,8 @@ namespace Magic
 
         [Tooltip("Elemental type of this spell")]
         public SpellElement element = SpellElement.None;
+
+        [Tooltip("Order that spells appear in the spell book")]
+        public int loadOrder = 0;
     }
 }

--- a/Assets/Scripts/UI/MagicUI.cs
+++ b/Assets/Scripts/UI/MagicUI.cs
@@ -69,6 +69,7 @@ namespace UI
             var loaded = Resources.LoadAll<SpellDefinition>("Spells");
             if (loaded != null)
                 spells.AddRange(loaded);
+            spells.Sort((a, b) => a.loadOrder.CompareTo(b.loadOrder));
             // Don't automatically select a spell on load. This allows melee
             // range to be used at spawn when no magic weapon is equipped.
             if (spells.Count > 0 && LastSelectedSpell == null)


### PR DESCRIPTION
## Summary
- add configurable `loadOrder` to `SpellDefinition`
- sort spells by `loadOrder` when building the spellbook UI
- assign load order values to existing spell assets

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c27724fd08832ea5772c2737013118