### PR TITLE
Reset NPC combat state when out of aggro range

### DIFF
--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -47,7 +47,7 @@ namespace NPC
             npcFacing = GetComponent<NpcFacing>();
         }
 
-        public void ResetCombatState()
+        public virtual void ResetCombatState()
         {
             foreach (var routine in activeAttacks.Values)
             {
@@ -106,8 +106,17 @@ namespace NPC
                     }
                 }
             }
-            if (activeAttacks.Count == 0)
+
+            if (threatLevels.Count == 0 &&
+                activeAttacks.Count == 0 &&
+                Vector2.Distance(transform.position, spawnPosition) > profile.AggroRange)
+            {
+                ResetCombatState(); // updates spawnPosition to current location
+            }
+            else if (activeAttacks.Count == 0)
+            {
                 SetCombatState(false);
+            }
 
             var potentials = new List<CombatTarget>();
 


### PR DESCRIPTION
## Summary
- reset NPC combat state when all threats vanish beyond aggro range
- allow subclasses to override ResetCombatState

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c279e9f41c832e9459744220430aea