### PR TITLE
Preserve NPC spawn position across combat resets

### DIFF
--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -47,7 +47,7 @@ namespace NPC
             npcFacing = GetComponent<NpcFacing>();
         }
 
-        public virtual void ResetCombatState()
+        public virtual void ResetCombatState(bool resetSpawnPosition = false)
         {
             foreach (var routine in activeAttacks.Values)
             {
@@ -57,7 +57,8 @@ namespace NPC
             activeAttacks.Clear();
             threatLevels.Clear();
             hasHitPlayer = false;
-            spawnPosition = transform.position;
+            if (resetSpawnPosition)
+                spawnPosition = transform.position;
             wanderer?.ExitCombat();
             SetCombatState(false);
         }
@@ -111,7 +112,7 @@ namespace NPC
                 activeAttacks.Count == 0 &&
                 Vector2.Distance(transform.position, spawnPosition) > profile.AggroRange)
             {
-                ResetCombatState(); // updates spawnPosition to current location
+                ResetCombatState();
             }
             else if (activeAttacks.Count == 0)
             {

--- a/Assets/Scripts/NPC/Combat/NpcCombatant.cs
+++ b/Assets/Scripts/NPC/Combat/NpcCombatant.cs
@@ -126,7 +126,7 @@ namespace NPC
             currentHp = profile != null ? profile.HitpointsLevel : 1;
             if (collider2D) collider2D.enabled = true;
             if (spriteRenderer) spriteRenderer.enabled = true;
-            GetComponent<BaseNpcCombat>()?.ResetCombatState();
+            GetComponent<BaseNpcCombat>()?.ResetCombatState(true);
             ResetDamageCounters();
             OnHealthChanged?.Invoke(currentHp, MaxHP);
         }


### PR DESCRIPTION
## Summary
- keep NPC spawn location stable unless explicitly relocated
- allow respawn logic to set a new spawn position when needed

## Testing
- `dotnet build` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c27de27058832e951ffc49b007611b