### PR TITLE
Ignore chase distance when pruning NPC threats

### DIFF
--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -94,7 +94,7 @@ namespace NPC
                 if (!remove)
                 {
                     float targetDist = Vector2.Distance(t.transform.position, transform.position);
-                    remove = targetDist > profile.AggroRange || npcChaseDist > profile.AggroRange;
+                    remove = targetDist > profile.AggroRange;
                 }
                 if (remove)
                 {
@@ -110,8 +110,9 @@ namespace NPC
 
             if (threatLevels.Count == 0 &&
                 activeAttacks.Count == 0 &&
-                Vector2.Distance(transform.position, spawnPosition) > profile.AggroRange)
+                npcChaseDist > profile.AggroRange)
             {
+                // Without targets, send the NPC back toward its spawn when it has wandered too far.
                 ResetCombatState();
             }
             else if (activeAttacks.Count == 0)


### PR DESCRIPTION
## Summary
- Allow NPCs to retain aggro beyond their spawn's chase distance
- Document idle return logic to send NPCs back to spawn when out of range

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c280ece404832ead6bdbefa1076b66