### PR TITLE
Keep NPC engaged when players re-enter aggro range

### DIFF
--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -211,7 +211,8 @@ namespace NPC
                 float distance = Vector2.Distance(target.transform.position, transform.position);
                 var profile = combatant.Profile;
                 float chaseDist = Vector2.Distance(transform.position, spawnPosition);
-                if (chaseDist > profile.AggroRange || distance > profile.AggroRange)
+                if (distance > profile.AggroRange ||
+                    (chaseDist > profile.AggroRange && distance > CombatMath.MELEE_RANGE))
                     break;
 
                 if (distance <= CombatMath.MELEE_RANGE)


### PR DESCRIPTION
## Summary
- Adjust attack routine break condition so NPCs resume attacking when targets return to melee range

## Testing
- `dotnet test` *(fails: project or solution file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2836d26cc832ead8eeee8687e2a85