### PR TITLE
Prevent null coroutine stop in NPC combat cleanup

### DIFF
--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -101,7 +101,8 @@ namespace NPC
                     threatLevels.Remove(t);
                     if (activeAttacks.TryGetValue(t, out var c))
                     {
-                        StopCoroutine(c);
+                        if (c != null)
+                            StopCoroutine(c);
                         activeAttacks.Remove(t);
                         wanderer?.ExitCombat(t.transform);
                     }


### PR DESCRIPTION
## Summary
- avoid `NullReferenceException` when removing expired targets by null-checking coroutine before stopping

## Testing
- ⚠️ `dotnet build` *(no project or solution file)*
- ⚠️ `unity -version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2854cc428832eab85ad543158a64e