### PR TITLE
Fix NPC combat break condition when away from spawn

### DIFF
--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -211,9 +211,7 @@ namespace NPC
             {
                 float distance = Vector2.Distance(target.transform.position, transform.position);
                 var profile = combatant.Profile;
-                float chaseDist = Vector2.Distance(transform.position, spawnPosition);
-                if (distance > profile.AggroRange ||
-                    (chaseDist > profile.AggroRange && distance > CombatMath.MELEE_RANGE))
+                if (distance > profile.AggroRange)
                     break;
 
                 if (distance <= CombatMath.MELEE_RANGE)


### PR DESCRIPTION
## Summary
- prevent NPC attack routine from cancelling when far from spawn if player remains within aggro range
- keep combat re-entry logic so BeginAttacking/NpcWanderer.EnterCombat still trigger when re-engaging

## Testing
- `npm test` *(fails: no package.json)*
- `dotnet test` *(fails: no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c289e67170832eaceddd56c02b134d