### PR TITLE
Propagate player combat target for spell threat

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -205,7 +205,8 @@ namespace Combat
             string targetName = targetMb != null ? targetMb.name : "target";
             if (hit)
             {
-                int finalDamage = target.ApplyDamage(damage, type, element, this);
+                var source = GetComponent<Player.PlayerCombatTarget>();
+                int finalDamage = target.ApplyDamage(damage, type, element, source);
                 Sprite sprite;
                 Color textColor = Color.white;
                 if (finalDamage == 0)

--- a/Assets/Scripts/NPC/Combat/NpcCombatant.cs
+++ b/Assets/Scripts/NPC/Combat/NpcCombatant.cs
@@ -94,6 +94,10 @@ namespace NPC
                 var combat = GetComponent<BaseNpcCombat>();
                 combat?.AddThreat(combatSource, finalAmount);
             }
+            else
+            {
+                npcDamage += finalAmount;
+            }
             var killedByPlayer = creditedToPlayer;
             if (currentHp <= 0)
             {


### PR DESCRIPTION
## Summary
- Send the player's `PlayerCombatTarget` component as the damage source so NPCs can track threat from spells
- Handle null damage sources in `NpcCombatant` by counting damage without adding threat

## Testing
- `dotnet test` *(fails: MSB1003 no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c297b96f98832eb53131cde04bca25