### PR TITLE
Track recent attackers for NPC aggro

### DIFF
--- a/Assets/Scripts/Combat/NpcCombatProfile.cs
+++ b/Assets/Scripts/Combat/NpcCombatProfile.cs
@@ -36,6 +36,9 @@ namespace Combat
         [Tooltip("Maximum distance in tiles before an aggressive NPC loses aggro.")]
         public float AggroRange = 5f;
 
+        [Tooltip("Seconds to keep aggro on a target after it moves beyond AggroRange.")]
+        public float AggroTimeoutSeconds = 5f;
+
         [Tooltip("Maximum number of targets this NPC can attack at once.")]
         public int MaxConcurrentTargets = 1;
 

--- a/Assets/Scripts/NPC/Combat/NpcCombatant.cs
+++ b/Assets/Scripts/NPC/Combat/NpcCombatant.cs
@@ -93,6 +93,7 @@ namespace NPC
                 }
                 var combat = GetComponent<BaseNpcCombat>();
                 combat?.AddThreat(combatSource, finalAmount);
+                combat?.RecordDamageFrom(combatSource);
             }
             else
             {


### PR DESCRIPTION
## Summary
- remember last time each target dealt damage and keep aggro briefly beyond range
- only drop targets once they stay outside AggroRange past a configurable timeout
- expose `AggroTimeoutSeconds` in NPC combat profiles for per-NPC tuning

## Testing
- `dotnet test` *(fails: no project or solution file)*


------
https://chatgpt.com/codex/tasks/task_e_68c29d021134832eb20ba5637708ec6e