### PR TITLE
Ensure passive NPCs resume combat after re-aggro

### DIFF
--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -94,7 +94,7 @@ namespace NPC
         protected virtual void Update()
         {
             var profile = combatant.Profile;
-            if (profile == null || !profile.IsAggressive)
+            if (profile == null || (!profile.IsAggressive && threatLevels.Count == 0))
                 return;
 
             if (playerTarget == null)

--- a/Assets/Scripts/NPC/Combat/NpcCombatant.cs
+++ b/Assets/Scripts/NPC/Combat/NpcCombatant.cs
@@ -94,6 +94,7 @@ namespace NPC
                 var combat = GetComponent<BaseNpcCombat>();
                 combat?.AddThreat(combatSource, finalAmount);
                 combat?.RecordDamageFrom(combatSource);
+                combat?.BeginAttacking(combatSource);
             }
             else
             {


### PR DESCRIPTION
## Summary
- Start NPC combat routines immediately after taking damage
- Let non-aggressive NPCs process threat updates so they re-engage attackers

## Testing
- `dotnet test` *(fails: MSB1003 - no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a107a65c832ea7f1fd54364b4b45