### PR TITLE
Reengage NPCs when damaged during retreat

### DIFF
--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -20,6 +20,7 @@ namespace NPC
         protected PlayerCombatTarget playerTarget;
         protected bool hasHitPlayer;
         protected Vector2 spawnPosition;
+        public Vector2 SpawnPosition => spawnPosition;
         protected NpcFacing npcFacing;
         protected Coroutine spriteSwapRoutine;
 
@@ -207,6 +208,21 @@ namespace NPC
                 if (closest != null)
                     npcFacing?.FaceTarget(closest.transform);
             }
+        }
+
+        public virtual void ReengageFromRetreat(CombatTarget target)
+        {
+            if (target == null)
+                return;
+            spawnPosition = transform.position;
+            wanderer?.SetOrigin(spawnPosition);
+            wanderer?.EnterCombat(target.transform);
+            if (!activeAttacks.ContainsKey(target))
+            {
+                var routine = StartCoroutine(AttackRoutine(target));
+                activeAttacks[target] = routine;
+            }
+            SetCombatState(true);
         }
 
         public virtual void BeginAttacking(CombatTarget target)

--- a/Assets/Scripts/NPC/Combat/NpcCombatant.cs
+++ b/Assets/Scripts/NPC/Combat/NpcCombatant.cs
@@ -94,6 +94,16 @@ namespace NPC
                 var combat = GetComponent<BaseNpcCombat>();
                 combat?.AddThreat(combatSource, finalAmount);
                 combat?.RecordDamageFrom(combatSource);
+                if (combat != null && !combat.InCombat)
+                {
+                    var profile = this.profile;
+                    if (profile != null)
+                    {
+                        float dist = Vector2.Distance(transform.position, combat.SpawnPosition);
+                        if (dist > profile.AggroRange)
+                            combat.ReengageFromRetreat(combatSource);
+                    }
+                }
                 combat?.BeginAttacking(combatSource);
             }
             else

--- a/Assets/Scripts/NPC/Movement/NpcWanderer.cs
+++ b/Assets/Scripts/NPC/Movement/NpcWanderer.cs
@@ -75,6 +75,13 @@ namespace NPC
             BeginIdle();
         }
 
+        public void SetOrigin(Vector2 origin)
+        {
+            _origin = origin;
+            _lastPos = origin;
+            _from = _to = origin;
+        }
+
         private void OnEnable()
         {
             Ticker.Instance?.Subscribe(this);


### PR DESCRIPTION
## Summary
- Reset spawn position and reenter combat when out-of-range NPCs take damage
- Expose spawn position and reengagement logic in `BaseNpcCombat`
- Allow wanderers to update their origin when spawn moves

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*


------
https://chatgpt.com/codex/tasks/task_e_68c2a4eecdd4832e931b6301d857daa7