### PR TITLE
Fix retreat reengage distance check

### DIFF
--- a/Assets/Scripts/NPC/Combat/NpcCombatant.cs
+++ b/Assets/Scripts/NPC/Combat/NpcCombatant.cs
@@ -99,7 +99,7 @@ namespace NPC
                     var profile = this.profile;
                     if (profile != null)
                     {
-                        float dist = Vector2.Distance(transform.position, combat.SpawnPosition);
+                        float dist = Vector2.Distance(combatSource.transform.position, combat.SpawnPosition);
                         if (dist > profile.AggroRange)
                             combat.ReengageFromRetreat(combatSource);
                     }


### PR DESCRIPTION
## Summary
- use the attacker's position when evaluating reengagement distance for retreating NPCs

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a810ab7c832ebf449441b1a96898