### PR TITLE
Derive NPC aggro radius from wander bounds

### DIFF
--- a/Assets/NPCCombatProfile/Goblin.asset
+++ b/Assets/NPCCombatProfile/Goblin.asset
@@ -25,7 +25,6 @@ MonoBehaviour:
   AttackType: 0
   Style: 0
   IsAggressive: 0
-  AggroRange: 15
   MaxConcurrentTargets: 6
   PlayerAggroWeight: 1
   Faction: 1

--- a/Assets/NPCCombatProfile/GoblinWarchief.asset
+++ b/Assets/NPCCombatProfile/GoblinWarchief.asset
@@ -25,7 +25,6 @@ MonoBehaviour:
   AttackType: 0
   Style: 0
   IsAggressive: 0
-  AggroRange: 15
   MaxConcurrentTargets: 6
   PlayerAggroWeight: 1
   Faction: 2

--- a/Assets/Scripts/Combat/NpcCombatProfile.cs
+++ b/Assets/Scripts/Combat/NpcCombatProfile.cs
@@ -33,10 +33,7 @@ namespace Combat
         public CombatStyle Style = CombatStyle.Accurate;
         [Tooltip("If true, this NPC will automatically attack nearby players.")]
         public bool IsAggressive;
-        [Tooltip("Maximum distance in tiles before an aggressive NPC loses aggro.")]
-        public float AggroRange = 5f;
-
-        [Tooltip("Seconds to keep aggro on a target after it moves beyond AggroRange.")]
+        [Tooltip("Seconds to keep aggro on a target after it moves beyond the chase radius.")]
         public float AggroTimeoutSeconds = 5f;
 
         [Tooltip("Maximum number of targets this NPC can attack at once.")]

--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -101,6 +101,7 @@ namespace NPC
             if (playerTarget == null)
                 playerTarget = FindObjectOfType<PlayerCombatTarget>();
 
+            float aggroRadius = wanderer != null ? wanderer.AggroRadius : 5f;
             float npcChaseDist = Vector2.Distance(transform.position, spawnPosition);
             foreach (var t in new List<CombatTarget>(threatLevels.Keys))
             {
@@ -108,7 +109,7 @@ namespace NPC
                 if (!remove)
                 {
                     float targetDist = Vector2.Distance(t.transform.position, spawnPosition);
-                    if (targetDist > profile.AggroRange)
+                    if (targetDist > aggroRadius)
                     {
                         float last;
                         if (!lastDamageTimes.TryGetValue(t, out last))
@@ -132,7 +133,7 @@ namespace NPC
 
             if (threatLevels.Count == 0 &&
                 activeAttacks.Count == 0 &&
-                npcChaseDist > profile.AggroRange)
+                npcChaseDist > aggroRadius)
             {
                 // Without targets, send the NPC back toward its spawn when it has wandered too far.
                 ResetCombatState();
@@ -147,7 +148,7 @@ namespace NPC
             if (playerTarget != null && playerTarget.IsAlive)
             {
                 float playerDist = Vector2.Distance(playerTarget.transform.position, spawnPosition);
-                if (playerDist <= profile.AggroRange)
+                if (playerDist <= aggroRadius)
                     potentials.Add(playerTarget);
             }
 
@@ -162,7 +163,7 @@ namespace NPC
                     if (otherFaction == null || !myFaction.IsEnemy(otherFaction.Faction))
                         continue;
                     float dist = Vector2.Distance(npc.transform.position, spawnPosition);
-                    if (dist <= profile.AggroRange)
+                    if (dist <= aggroRadius)
                         potentials.Add(npc);
                 }
             }
@@ -246,8 +247,9 @@ namespace NPC
             while (combatant.IsAlive && target != null && target.IsAlive)
             {
                 var profile = combatant.Profile;
+                float aggroRadius = wanderer != null ? wanderer.AggroRadius : 5f;
                 float spawnDist = Vector2.Distance(target.transform.position, spawnPosition);
-                if (spawnDist > profile.AggroRange)
+                if (spawnDist > aggroRadius)
                 {
                     float last;
                     if (!lastDamageTimes.TryGetValue(target, out last))

--- a/Assets/Scripts/NPC/Combat/NpcCombatant.cs
+++ b/Assets/Scripts/NPC/Combat/NpcCombatant.cs
@@ -17,6 +17,7 @@ namespace NPC
         private int currentHp;
         private Collider2D collider2D;
         private SpriteRenderer spriteRenderer;
+        private NpcWanderer wanderer;
         private int playerDamage;
         private int npcDamage;
 
@@ -40,6 +41,7 @@ namespace NPC
             currentHp = profile != null ? profile.HitpointsLevel : 1;
             collider2D = GetComponent<Collider2D>();
             spriteRenderer = GetComponent<SpriteRenderer>();
+            wanderer = GetComponent<NpcWanderer>();
             ResetDamageCounters();
             OnHealthChanged?.Invoke(currentHp, MaxHP);
         }
@@ -96,14 +98,11 @@ namespace NPC
                 combat?.RecordDamageFrom(combatSource);
                 if (combat != null && !combat.InCombat)
                 {
-                    var profile = this.profile;
-                    if (profile != null)
-                    {
-                        float dist = Vector2.Distance(combatSource.transform.position, combat.SpawnPosition);
-                        if (dist > profile.AggroRange)
-                            combat.ReengageFromRetreat(combatSource);
+                    float dist = Vector2.Distance(combatSource.transform.position, combat.SpawnPosition);
+                    float radius = wanderer != null ? wanderer.AggroRadius : 5f;
+                    if (dist > radius)
+                        combat.ReengageFromRetreat(combatSource);
                     }
-                }
                 combat?.BeginAttacking(combatSource);
             }
             else

--- a/Assets/Scripts/NPC/Movement/NpcWanderer.cs
+++ b/Assets/Scripts/NPC/Movement/NpcWanderer.cs
@@ -30,6 +30,7 @@ namespace NPC
         [Header("Chasing")]
         [Tooltip("Maximum distance from the spawn position that the NPC may chase a target.")]
         public float chaseRadius = 5f;
+        public float AggroRadius => chaseRadius;
 
         [Header("Visuals")]
         [Tooltip("Component handling sprite animation/animator updates.")]
@@ -47,6 +48,27 @@ namespace NPC
         private Vector2 _from;
         private Vector2 _to;
         private float _lerpTime;
+
+        private float ComputeChaseRadius()
+        {
+            if (useAreaSize)
+            {
+                Vector2 half = areaSize * 0.5f;
+                return half.magnitude;
+            }
+
+            Vector2[] corners = new Vector2[4]
+            {
+                minOffset,
+                maxOffset,
+                new Vector2(minOffset.x, maxOffset.y),
+                new Vector2(maxOffset.x, minOffset.y)
+            };
+            float max = 0f;
+            foreach (var c in corners)
+                max = Mathf.Max(max, c.magnitude);
+            return max;
+        }
 
         private void Reset()
         {
@@ -68,9 +90,7 @@ namespace NPC
             _from = _to = _origin;
             _lerpTime = Ticker.TickDuration;
 
-            var combatant = GetComponent<NpcCombatant>();
-            if (combatant != null && combatant.Profile != null)
-                chaseRadius = combatant.Profile.AggroRange;
+            chaseRadius = ComputeChaseRadius();
 
             BeginIdle();
         }
@@ -80,6 +100,7 @@ namespace NPC
             _origin = origin;
             _lastPos = origin;
             _from = _to = origin;
+            chaseRadius = ComputeChaseRadius();
         }
 
         private void OnEnable()


### PR DESCRIPTION
## Summary
- Drop AggroRange from NPC combat profiles and assets
- Compute chase radius from wander bounds and expose AggroRadius
- Use wanderer radius in combat logic with safe fallbacks

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ab9dbaf4832eb6ffce67b75edac7