### PR TITLE
Reset NPC combat state, wandering, and HUD visibility on death

### DIFF
--- a/Assets/Scripts/NPC/Combat/NpcCombatant.cs
+++ b/Assets/Scripts/NPC/Combat/NpcCombatant.cs
@@ -119,6 +119,8 @@ namespace NPC
                     dropper?.OnDeath();
 
                 ResetDamageCounters();
+                GetComponent<BaseNpcCombat>()?.ResetCombatState();
+                GetComponent<NpcWanderer>()?.enabled = false;
                 OnDeath?.Invoke();
                 if (collider2D) collider2D.enabled = false;
                 if (spriteRenderer) spriteRenderer.enabled = false;
@@ -141,7 +143,12 @@ namespace NPC
             currentHp = profile != null ? profile.HitpointsLevel : 1;
             if (collider2D) collider2D.enabled = true;
             if (spriteRenderer) spriteRenderer.enabled = true;
-            GetComponent<BaseNpcCombat>()?.ResetCombatState(true);
+            GetComponent<NpcWanderer>()?.enabled = true;
+            var combat = GetComponent<BaseNpcCombat>();
+            Vector2 spawn = combat != null ? combat.SpawnPosition : (Vector2)transform.position;
+            transform.position = spawn;
+            wanderer?.SetOrigin(spawn);
+            combat?.ResetCombatState(true);
             ResetDamageCounters();
             OnHealthChanged?.Invoke(currentHp, MaxHP);
         }

--- a/Assets/Scripts/NPC/Combat/NpcHealthHUD.cs
+++ b/Assets/Scripts/NPC/Combat/NpcHealthHUD.cs
@@ -150,6 +150,7 @@ namespace NPC
                 if (canvasGroup != null)
                     canvasGroup.alpha = 0f;
             }
+            isVisible = false;
         }
 
         private void OnDestroy()


### PR DESCRIPTION
## Summary
- Clear combat and disable wandering when an NPC dies
- Restore NPC movement and spawn position on respawn
- Keep NPC health HUD hidden while dead

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*


------
https://chatgpt.com/codex/tasks/task_e_68c2c5687bdc832e8d81731fdbfc0ba6