### PR TITLE
Fix null-conditional assignment in NpcCombatant

### DIFF
--- a/Assets/Scripts/NPC/Combat/NpcCombatant.cs
+++ b/Assets/Scripts/NPC/Combat/NpcCombatant.cs
@@ -120,7 +120,7 @@ namespace NPC
 
                 ResetDamageCounters();
                 GetComponent<BaseNpcCombat>()?.ResetCombatState();
-                GetComponent<NpcWanderer>()?.enabled = false;
+                if (wanderer != null) wanderer.enabled = false;
                 OnDeath?.Invoke();
                 if (collider2D) collider2D.enabled = false;
                 if (spriteRenderer) spriteRenderer.enabled = false;
@@ -143,7 +143,7 @@ namespace NPC
             currentHp = profile != null ? profile.HitpointsLevel : 1;
             if (collider2D) collider2D.enabled = true;
             if (spriteRenderer) spriteRenderer.enabled = true;
-            GetComponent<NpcWanderer>()?.enabled = true;
+            if (wanderer != null) wanderer.enabled = true;
             var combat = GetComponent<BaseNpcCombat>();
             Vector2 spawn = combat != null ? combat.SpawnPosition : (Vector2)transform.position;
             transform.position = spawn;


### PR DESCRIPTION
## Summary
- avoid using null-conditional operator on assignment when enabling or disabling wanderer

## Testing
- `dotnet build` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c7317554832eb550a8db067e9fb5