### PR TITLE
Hide NPC health bar on zero health

### DIFF
--- a/Assets/Scripts/NPC/Combat/NpcHealthHUD.cs
+++ b/Assets/Scripts/NPC/Combat/NpcHealthHUD.cs
@@ -105,6 +105,8 @@ namespace NPC
                 fill.fillAmount = max > 0 ? (float)current / max : 0f;
             if (text != null)
                 text.text = $"{current}/{max}";
+            if (current <= 0)
+                HandleDeath();
         }
 
         private void HandleCombatStateChanged(bool inCombat)


### PR DESCRIPTION
## Summary
- ensure NPC health bar hides when health reaches zero by calling `HandleDeath`

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c8863d04832ebbd3548a4d6a0c6c