### PR TITLE
fix: toggle NPC health HUD on death and spawn

### DIFF
--- a/Assets/Scripts/NPC/Combat/NpcHealthHUD.cs
+++ b/Assets/Scripts/NPC/Combat/NpcHealthHUD.cs
@@ -106,7 +106,15 @@ namespace NPC
             if (text != null)
                 text.text = $"{current}/{max}";
             if (current <= 0)
+            {
                 HandleDeath();
+            }
+            else if (canvas != null && !canvas.gameObject.activeSelf)
+            {
+                canvas.gameObject.SetActive(true);
+                if (canvasGroup != null)
+                    canvasGroup.alpha = 1f;
+            }
         }
 
         private void HandleCombatStateChanged(bool inCombat)


### PR DESCRIPTION
## Summary
- ensure NPC health HUD hides on death and reappears when NPC respawns

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*


------
https://chatgpt.com/codex/tasks/task_e_68c2cb1148c4832ea468802093354d80