### PR TITLE
Skip NPC combat when dead

### DIFF
--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -94,6 +94,8 @@ namespace NPC
 
         protected virtual void Update()
         {
+            if (!combatant.IsAlive)
+                return;
             var profile = combatant.Profile;
             if (profile == null || (!profile.IsAggressive && threatLevels.Count == 0))
                 return;
@@ -223,6 +225,8 @@ namespace NPC
 
         public virtual void BeginAttacking(CombatTarget target)
         {
+            if (!combatant.IsAlive)
+                return;
             if (target == null || activeAttacks.ContainsKey(target))
                 return;
             if (activeAttacks.Count == 0)


### PR DESCRIPTION
## Summary
- prevent combat logic from running if NPC is dead
- stop dead NPCs from beginning attacks

## Testing
- `dotnet build` *(fails: MSB1003: project or solution file not found)*
- `dotnet test` *(fails: MSB1003: project or solution file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2cd5a08a4832e8653093f6ab163ed