### PR TITLE
Prevent NpcHealthHUD from showing outside combat

### DIFF
--- a/Assets/Scripts/NPC/Combat/NpcHealthHUD.cs
+++ b/Assets/Scripts/NPC/Combat/NpcHealthHUD.cs
@@ -109,12 +109,6 @@ namespace NPC
             {
                 HandleDeath();
             }
-            else if (canvas != null && !canvas.gameObject.activeSelf)
-            {
-                canvas.gameObject.SetActive(true);
-                if (canvasGroup != null)
-                    canvasGroup.alpha = 1f;
-            }
         }
 
         private void HandleCombatStateChanged(bool inCombat)


### PR DESCRIPTION
## Summary
- Remove automatic canvas activation from `NpcHealthHUD.HandleHealthChanged`
- Ensure combat state events control HUD visibility

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c2cff281e4832e9fb2ee3e719325da