### PR TITLE
Update strike spells and sync max hits to magic level

### DIFF
--- a/Assets/Resources/Spells/ElectricStrike.asset
+++ b/Assets/Resources/Spells/ElectricStrike.asset
@@ -18,7 +18,7 @@ MonoBehaviour:
   projectilePrefab: {fileID: 8992547425151743537, guid: da296c280bba8ff4ab726123c3ec8ee7, type: 3}
   hitEffectPrefab: {fileID: 8992547425151743537, guid: 00efa5df98b070248b8352df720f440b, type: 3}
   hitFadeTime: 1
-  maxHit: 6
+  maxHit: 7
   icon: {fileID: 21300000, guid: 72c6399e42241534681e9ce227d7744f, type: 3}
   requiredMagicLevel: 10
   element: 3

--- a/Assets/Resources/Spells/FireStrike.asset
+++ b/Assets/Resources/Spells/FireStrike.asset
@@ -12,14 +12,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 75a0bfa1a4e537c4d914009ef1161c3e, type: 3}
   m_Name: FireStrike
   m_EditorClassIdentifier: Assembly-CSharp::Magic.SpellDefinition
-  displayName: Electric Strike
+  displayName: Fire Strike
   range: 5
   speed: 8
   projectilePrefab: {fileID: 8992547425151743537, guid: 4207e90c2f565fd4bb49b23f64061efb, type: 3}
   hitEffectPrefab: {fileID: 8992547425151743537, guid: 24d88c1201e2b754b823bf54279d734d, type: 3}
   hitFadeTime: 1
-  maxHit: 6
+  maxHit: 8
   icon: {fileID: 21300000, guid: 3b8d01116d0907f458d43bfa1ea6da5a, type: 3}
-  requiredMagicLevel: 1
+  requiredMagicLevel: 13
   element: 5
   loadOrder: 4

--- a/Assets/Resources/Spells/WindStrike.asset
+++ b/Assets/Resources/Spells/WindStrike.asset
@@ -18,7 +18,7 @@ MonoBehaviour:
   projectilePrefab: {fileID: 8992547425151743537, guid: bd7dc5f10d2a37049a3c33112171e9c9, type: 3}
   hitEffectPrefab: {fileID: 8992547425151743537, guid: 4fadbc66e865ef04a9fdd14ccf48f69b, type: 3}
   hitFadeTime: 1
-  maxHit: 4
+  maxHit: 2
   icon: {fileID: 21300000, guid: 615f182a766d77c41b8c44f8e0732e3a, type: 3}
   requiredMagicLevel: 1
   element: 0

--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -58,6 +58,9 @@ namespace Combat
             if (equipment == null)
                 Debug.LogWarning("CombatController could not find an EquipmentAggregator; equipment bonuses will be ignored.", this);
 
+            if (skills != null)
+                skills.LevelChanged += OnSkillLevelChanged;
+
             damageHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Damage_hitsplat");
             zeroHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Zero_damage_hitsplat");
             maxHitHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Damage_hitsplat_maxhit");
@@ -103,6 +106,18 @@ namespace Combat
                 pet?.CommandAttack(target);
             }
             return true;
+        }
+
+        private void OnDestroy()
+        {
+            if (skills != null)
+                skills.LevelChanged -= OnSkillLevelChanged;
+        }
+
+        private void OnSkillLevelChanged(SkillType type, int level)
+        {
+            if (type == SkillType.Magic)
+                MagicUI.UpdateStrikeMaxHits(level);
         }
 
         /// <summary>

--- a/Assets/Scripts/Skills/SkillManager.cs
+++ b/Assets/Scripts/Skills/SkillManager.cs
@@ -19,6 +19,8 @@ namespace Skills
         private readonly Dictionary<SkillType, SkillRecord> skills = new();
         private ICombatSkillSave save;
 
+        public event Action<SkillType, int> LevelChanged;
+
         private struct SkillRecord
         {
             public float xp;
@@ -59,10 +61,16 @@ namespace Skills
             if (xpTable == null || amount <= 0f)
                 return GetLevel(skill);
 
+            InitialiseSkill(skill);
             var record = skills[skill];
+            int oldLevel = record.level;
             record.xp += amount;
             record.level = xpTable.GetLevel(Mathf.FloorToInt(record.xp));
             skills[skill] = record;
+
+            if (record.level > oldLevel)
+                LevelChanged?.Invoke(skill, record.level);
+
             return record.level;
         }
 


### PR DESCRIPTION
## Summary
- cache strike spells in MagicUI and add helper to sync max hits by level
- raise SkillManager.LevelChanged event and update CombatController on Magic levels
- tune strike spell assets with correct max hits and unlock levels

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c340760a88832eb81e991a39b58f22