### PR TITLE
Trigger LevelChanged when debugging skill levels

### DIFF
--- a/Assets/Scripts/Skills/SkillManager.cs
+++ b/Assets/Scripts/Skills/SkillManager.cs
@@ -94,18 +94,25 @@ namespace Skills
 
         /// <summary>
         /// Debug helper to directly set a skill level. Updates both level and XP
-        /// without awarding XP. Values are clamped to the XP table range.
+        /// without awarding XP. Values are clamped to the XP table range and
+        /// <see cref="LevelChanged"/> is invoked if the level actually changes.
         /// </summary>
         public void DebugSetLevel(SkillType skill, int level)
         {
             if (xpTable == null)
                 return;
 
+            InitialiseSkill(skill);
+
             level = Mathf.Clamp(level, 1, 99);
-            var record = skills.ContainsKey(skill) ? skills[skill] : new SkillRecord();
+            var record = skills[skill];
+            int oldLevel = record.level;
             record.level = level;
             record.xp = xpTable.GetXpForLevel(level);
             skills[skill] = record;
+
+            if (level != oldLevel)
+                LevelChanged?.Invoke(skill, level);
         }
 
         public void Save()


### PR DESCRIPTION
## Summary
- fire `LevelChanged` from `DebugSetLevel` when level differs
- initialize skills before setting and clamp values to table range

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c343c37bac832e8a6fe58f62c68b84