### PR TITLE
feat: add poison status system

### DIFF
--- a/Assets/Editor/PoisonDebugMenu.cs
+++ b/Assets/Editor/PoisonDebugMenu.cs
@@ -1,0 +1,59 @@
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEngine;
+using Status.Poison;
+
+/// <summary>
+/// Editor tools for testing poison application and curing.
+/// </summary>
+public static class PoisonDebugMenu
+{
+    [MenuItem("Tools/Status/Apply Poison (p)")]
+    private static void ApplyPoisonP()
+    {
+        Apply("poison_p");
+    }
+
+    [MenuItem("Tools/Status/Apply Poison (p++)")]
+    private static void ApplyPoisonPP()
+    {
+        Apply("poison_pp");
+    }
+
+    [MenuItem("Tools/Status/Cure (6m)")]
+    private static void Cure6m()
+    {
+        Cure(360f);
+    }
+
+    [MenuItem("Tools/Status/Cure (12m)")]
+    private static void Cure12m()
+    {
+        Cure(720f);
+    }
+
+    private static void Apply(string id)
+    {
+        var go = Selection.activeGameObject;
+        if (go == null)
+            return;
+        var controller = go.GetComponent<PoisonController>();
+        if (controller == null)
+            controller = go.AddComponent<PoisonController>();
+        var cfg = Resources.Load<PoisonConfig>($"Status/Poison/{id}");
+        if (cfg != null)
+            controller.ApplyPoison(cfg);
+        Debug.Log($"Applied {id} at {Time.time}");
+    }
+
+    private static void Cure(float immunity)
+    {
+        var go = Selection.activeGameObject;
+        if (go == null)
+            return;
+        var controller = go.GetComponent<PoisonController>();
+        controller?.CurePoison(immunity);
+        Debug.Log($"Cured poison at {Time.time}");
+    }
+}
+#endif

--- a/Assets/Editor/PoisonDebugMenu.cs.meta
+++ b/Assets/Editor/PoisonDebugMenu.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cda4e3b26f4b4a38bd5319a497474e63
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Items.meta
+++ b/Assets/Resources/Items.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 29adf0331be041e4a5b493d5b8e17d7a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Items/Consumables.meta
+++ b/Assets/Resources/Items/Consumables.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ae74512d5e264b7086c04ed0e2d5ac18
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Items/Consumables/AntidotePP.asset
+++ b/Assets/Resources/Items/Consumables/AntidotePP.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b295431c2f4b4905b34a321c77defd90, type: 3}
+  m_Name: AntidotePP
+  m_EditorClassIdentifier: 
+  displayName: Antidote++
+  immunitySeconds: 720
+  icon: {fileID: 0}

--- a/Assets/Resources/Items/Consumables/AntidotePP.asset.meta
+++ b/Assets/Resources/Items/Consumables/AntidotePP.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9e6ca5944d0b4bf78488e1e2a5752143
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Items/Consumables/Superantipoison.asset
+++ b/Assets/Resources/Items/Consumables/Superantipoison.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b295431c2f4b4905b34a321c77defd90, type: 3}
+  m_Name: Superantipoison
+  m_EditorClassIdentifier: 
+  displayName: Superantipoison
+  immunitySeconds: 360
+  icon: {fileID: 0}

--- a/Assets/Resources/Items/Consumables/Superantipoison.asset.meta
+++ b/Assets/Resources/Items/Consumables/Superantipoison.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2ab0605b96fb4515aca0109b9ad9152d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Status.meta
+++ b/Assets/Resources/Status.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 99cb33c974ba479db88794a8cbece7aa
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Status/Poison.meta
+++ b/Assets/Resources/Status/Poison.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f52fad5ac7a54162a5ed694db0ad563a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Status/Poison/Poison_p.asset
+++ b/Assets/Resources/Status/Poison/Poison_p.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c25b2f8a526d432ca7ca067961cd8ded, type: 3}
+  m_Name: Poison_p
+  m_EditorClassIdentifier: 
+  Id: poison_p
+  startDamagePerTick: 4
+  tickIntervalSeconds: 15
+  hitsPerDecayStep: 4
+  decayAmountPerStep: 1
+  minDamagePerTick: 0

--- a/Assets/Resources/Status/Poison/Poison_p.asset.meta
+++ b/Assets/Resources/Status/Poison/Poison_p.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5a501ca099d54f02a1139ef22ba213c8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Status/Poison/Poison_pPP.asset
+++ b/Assets/Resources/Status/Poison/Poison_pPP.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c25b2f8a526d432ca7ca067961cd8ded, type: 3}
+  m_Name: Poison_pPP
+  m_EditorClassIdentifier: 
+  Id: poison_pp
+  startDamagePerTick: 6
+  tickIntervalSeconds: 15
+  hitsPerDecayStep: 4
+  decayAmountPerStep: 1
+  minDamagePerTick: 0

--- a/Assets/Resources/Status/Poison/Poison_pPP.asset.meta
+++ b/Assets/Resources/Status/Poison/Poison_pPP.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f6f640a4e0374a80a749d8606f6010d8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -245,6 +245,9 @@ namespace Combat
                 if (finalDamage > 0 && !target.IsAlive)
                     OnTargetKilled?.Invoke(target);
                 Debug.Log($"Player dealt {finalDamage} damage to {targetName}.");
+                var applier = GetComponentInChildren<OnHitPoisonApplier>();
+                if (applier != null && targetMb != null)
+                    applier.TryApply(targetMb.gameObject, finalDamage > 0);
                 OnAttackLanded?.Invoke(finalDamage, hit);
             }
             else

--- a/Assets/Scripts/Combat/OnHitPoisonApplier.cs
+++ b/Assets/Scripts/Combat/OnHitPoisonApplier.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+using Status.Poison;
+
+namespace Combat
+{
+    /// <summary>
+    /// Applies poison to a target when a hit is confirmed.
+    /// </summary>
+    public class OnHitPoisonApplier : MonoBehaviour
+    {
+        [Tooltip("Poison configuration to apply on hit.")]
+        public PoisonConfig poison;
+
+        [Tooltip("Chance that the poison is applied on a successful hit.")]
+        [Range(0f, 1f)] public float applyChance = 0.25f;
+
+        [Tooltip("Only apply poison if the hit dealt damage.")]
+        public bool requiresDamage = true;
+
+        /// <summary>
+        /// Attempt to apply poison to the specified target.
+        /// </summary>
+        /// <param name="target">Target game object.</param>
+        /// <param name="didDealDamage">Whether the hit dealt damage.</param>
+        public void TryApply(GameObject target, bool didDealDamage)
+        {
+            if (poison == null || target == null)
+                return;
+            if (requiresDamage && !didDealDamage)
+                return;
+            if (Random.value > applyChance)
+                return;
+            var controller = target.GetComponent<PoisonController>();
+            if (controller != null && !controller.IsImmune)
+                controller.ApplyPoison(poison);
+        }
+    }
+}

--- a/Assets/Scripts/Combat/OnHitPoisonApplier.cs.meta
+++ b/Assets/Scripts/Combat/OnHitPoisonApplier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3d304b5d8fd44b7a8328c4c0a644928f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Items/Consumables.meta
+++ b/Assets/Scripts/Items/Consumables.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9b7c9fe340b742aaa0129522e602acc6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Items/Consumables/AntipoisonItem.cs
+++ b/Assets/Scripts/Items/Consumables/AntipoisonItem.cs
@@ -1,0 +1,32 @@
+using UnityEngine;
+using Status.Poison;
+
+namespace Items.Consumables
+{
+    /// <summary>
+    /// Item that cures poison and grants temporary immunity.
+    /// </summary>
+    [CreateAssetMenu(menuName = "Items/Consumables/Antipoison")]
+    public class AntipoisonItem : ScriptableObject
+    {
+        [Tooltip("Display name for UI.")]
+        public string displayName;
+
+        [Tooltip("Duration of poison immunity in seconds.")]
+        public float immunitySeconds;
+
+        [Tooltip("Icon used to represent the item.")]
+        public Sprite icon;
+
+        /// <summary>
+        /// Use the item on the given user to cure poison.
+        /// </summary>
+        public void Use(GameObject user)
+        {
+            if (user == null)
+                return;
+            var controller = user.GetComponentInParent<PoisonController>();
+            controller?.CurePoison(immunitySeconds);
+        }
+    }
+}

--- a/Assets/Scripts/Items/Consumables/AntipoisonItem.cs.meta
+++ b/Assets/Scripts/Items/Consumables/AntipoisonItem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b295431c2f4b4905b34a321c77defd90
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -336,6 +336,10 @@ namespace NPC
                 int finalDamage = target.ApplyDamage(damage, attacker.DamageType, SpellElement.None, this);
                 var targetName = (target as MonoBehaviour)?.name ?? "target";
                 Debug.Log($"{name} dealt {finalDamage} damage to {targetName}.");
+                var applier = GetComponentInChildren<OnHitPoisonApplier>();
+                var targetMb = target as MonoBehaviour;
+                if (applier != null && targetMb != null)
+                    applier.TryApply(targetMb.gameObject, finalDamage > 0);
             }
             else
             {

--- a/Assets/Scripts/Status.meta
+++ b/Assets/Scripts/Status.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e98757f5a5e34ddda79831457ebf2780
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Status/Poison.meta
+++ b/Assets/Scripts/Status/Poison.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 42f6face623a483784d1b43bdc0267c3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Status/Poison/PoisonConfig.cs
+++ b/Assets/Scripts/Status/Poison/PoisonConfig.cs
@@ -1,0 +1,29 @@
+using UnityEngine;
+
+namespace Status.Poison
+{
+    /// <summary>
+    /// Configuration data for a poison effect.
+    /// </summary>
+    [CreateAssetMenu(menuName = "Status/Poison Config")]
+    public class PoisonConfig : ScriptableObject
+    {
+        [Tooltip("Unique identifier for saving and comparisons.")]
+        public string Id;
+
+        [Tooltip("Damage dealt every tick when poison is first applied.")]
+        public int startDamagePerTick;
+
+        [Tooltip("Seconds between poison damage ticks.")]
+        public float tickIntervalSeconds = 15f;
+
+        [Tooltip("Number of poison hits before severity decays.")]
+        public int hitsPerDecayStep = 4;
+
+        [Tooltip("How much damage is reduced at each decay step.")]
+        public int decayAmountPerStep = 1;
+
+        [Tooltip("Minimum damage per tick before poison ends.")]
+        public int minDamagePerTick = 0;
+    }
+}

--- a/Assets/Scripts/Status/Poison/PoisonConfig.cs.meta
+++ b/Assets/Scripts/Status/Poison/PoisonConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c25b2f8a526d432ca7ca067961cd8ded
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Status/Poison/PoisonController.cs
+++ b/Assets/Scripts/Status/Poison/PoisonController.cs
@@ -1,0 +1,88 @@
+using UnityEngine;
+using Combat;
+
+namespace Status.Poison
+{
+    /// <summary>
+    /// Handles applying and updating poison on an entity.
+    /// </summary>
+    public class PoisonController : MonoBehaviour
+    {
+        [Tooltip("Stats component implementing CombatTarget for this entity.")]
+        [SerializeField] private MonoBehaviour statsComponent;
+
+        private CombatTarget stats;
+        private PoisonEffect active;
+        private float immunityTimer;
+
+        /// <summary>Invoked when poison deals damage.</summary>
+        public event System.Action<int> OnPoisonTick;
+
+        /// <summary>Invoked when the poison effect ends.</summary>
+        public event System.Action OnPoisonEnd;
+
+        /// <summary>Returns true if this entity is currently immune to poison.</summary>
+        public bool IsImmune => immunityTimer > 0f;
+
+        /// <summary>Access to the current poison effect.</summary>
+        public PoisonEffect ActiveEffect => active;
+
+        /// <summary>Remaining time of poison immunity in seconds.</summary>
+        public float ImmunityTimer
+        {
+            get => immunityTimer;
+            set => immunityTimer = value;
+        }
+
+        private void Awake()
+        {
+            stats = statsComponent as CombatTarget ?? GetComponent<CombatTarget>();
+        }
+
+        /// <summary>
+        /// Apply a poison configuration to this entity, refreshing if already poisoned.
+        /// </summary>
+        public void ApplyPoison(PoisonConfig cfg)
+        {
+            if (IsImmune || cfg == null)
+                return;
+            if (active == null)
+            {
+                active = new PoisonEffect(cfg);
+                active.OnPoisonTick += dmg => OnPoisonTick?.Invoke(dmg);
+                active.OnPoisonEnd += () => { OnPoisonEnd?.Invoke(); active = null; };
+            }
+            active.ApplyTo(stats);
+        }
+
+        /// <summary>
+        /// Cure current poison and optionally grant temporary immunity.
+        /// </summary>
+        public void CurePoison(float immunitySeconds)
+        {
+            if (active != null)
+            {
+                active.ForceEnd();
+                active = null;
+            }
+            immunityTimer = Mathf.Max(immunityTimer, immunitySeconds);
+        }
+
+        private void Update()
+        {
+            if (immunityTimer > 0f)
+                immunityTimer = Mathf.Max(0f, immunityTimer - Time.deltaTime);
+            if (active != null)
+                active.Tick(Time.deltaTime, DealTrueDamageBridge);
+        }
+
+        /// <summary>
+        /// Bridge method to apply true damage using the existing damage system.
+        /// </summary>
+        private bool DealTrueDamageBridge(int amount)
+        {
+            stats?.ApplyDamage(amount, DamageType.Magic, SpellElement.None, this);
+            return true;
+        }
+    }
+}

--- a/Assets/Scripts/Status/Poison/PoisonController.cs.meta
+++ b/Assets/Scripts/Status/Poison/PoisonController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 43cf1b12cd8843bfba005476a51223af
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Status/Poison/PoisonEffect.cs
+++ b/Assets/Scripts/Status/Poison/PoisonEffect.cs
@@ -1,0 +1,108 @@
+using System;
+using UnityEngine;
+using Combat;
+
+namespace Status.Poison
+{
+    /// <summary>
+    /// Runtime poison state and ticking logic.
+    /// </summary>
+    public class PoisonEffect
+    {
+        /// <summary>Configuration driving this poison.</summary>
+        public PoisonConfig Config { get; }
+
+        /// <summary>Current damage dealt per tick.</summary>
+        public int CurrentDamage { get; private set; }
+
+        /// <summary>Ticks since last decay step.</summary>
+        public int TicksSinceDecay { get; private set; }
+
+        /// <summary>Time accumulated toward the next tick.</summary>
+        public float TickTimer { get; private set; }
+
+        /// <summary>Whether the poison is active.</summary>
+        public bool IsActive => active;
+
+        private bool active;
+
+        /// <summary>Invoked when poison deals damage.</summary>
+        public event Action<int> OnPoisonTick;
+
+        /// <summary>Invoked when poison ends.</summary>
+        public event Action OnPoisonEnd;
+
+        /// <summary>
+        /// Initialize a poison effect with the given configuration.
+        /// </summary>
+        public PoisonEffect(PoisonConfig cfg)
+        {
+            Config = cfg;
+        }
+
+        /// <summary>
+        /// Start or refresh the poison on a target.
+        /// </summary>
+        /// <param name="target">Target stats (unused, for API compatibility).</param>
+        public void ApplyTo(CombatTarget target)
+        {
+            active = true;
+            CurrentDamage = Config.startDamagePerTick;
+            TicksSinceDecay = 0;
+            TickTimer = 0f;
+        }
+
+        /// <summary>
+        /// Progress the poison and apply damage when appropriate.
+        /// </summary>
+        /// <param name="delta">Delta time.</param>
+        /// <param name="dealTrueDamage">Delegate used to apply true damage.</param>
+        public void Tick(float delta, Func<int, bool> dealTrueDamage)
+        {
+            if (!active)
+                return;
+            TickTimer += delta;
+            if (TickTimer >= Config.tickIntervalSeconds)
+            {
+                TickTimer -= Config.tickIntervalSeconds;
+                dealTrueDamage?.Invoke(CurrentDamage);
+                OnPoisonTick?.Invoke(CurrentDamage);
+                TicksSinceDecay++;
+                if (TicksSinceDecay >= Config.hitsPerDecayStep)
+                {
+                    TicksSinceDecay = 0;
+                    CurrentDamage = Mathf.Max(Config.minDamagePerTick, CurrentDamage - Config.decayAmountPerStep);
+                }
+                if (CurrentDamage <= Config.minDamagePerTick)
+                    End();
+            }
+        }
+
+        /// <summary>
+        /// Forcefully end the poison effect.
+        /// </summary>
+        public void ForceEnd()
+        {
+            if (!active)
+                return;
+            End();
+        }
+
+        /// <summary>
+        /// Restore internal state when loading from save.
+        /// </summary>
+        public void RestoreState(int currentDamage, int ticksSinceDecay, float tickTimer)
+        {
+            CurrentDamage = currentDamage;
+            TicksSinceDecay = ticksSinceDecay;
+            TickTimer = tickTimer;
+            active = currentDamage > 0;
+        }
+
+        private void End()
+        {
+            active = false;
+            OnPoisonEnd?.Invoke();
+        }
+    }
+}

--- a/Assets/Scripts/Status/Poison/PoisonEffect.cs.meta
+++ b/Assets/Scripts/Status/Poison/PoisonEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e285081cdfdd43f2a9d2f91593c2c235
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Status/Poison/PoisonSaveBridge.cs
+++ b/Assets/Scripts/Status/Poison/PoisonSaveBridge.cs
@@ -1,0 +1,85 @@
+using UnityEngine;
+using Core.Save;
+
+namespace Status.Poison
+{
+    /// <summary>
+    /// Persists <see cref="PoisonController"/> state using the <see cref="SaveManager"/>.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class PoisonSaveBridge : MonoBehaviour, ISaveable
+    {
+        [SerializeField] private PoisonController controller;
+
+        [System.Serializable]
+        private class PoisonSaveData
+        {
+            public bool isPoisoned;
+            public string configId;
+            public int currentDamage;
+            public int ticksSinceDecay;
+            public float timeToNextTick;
+            public float immunityTimer;
+        }
+
+        private string SaveKey => $"poison_{gameObject.name}";
+
+        private void Awake()
+        {
+            if (controller == null)
+                controller = GetComponent<PoisonController>();
+        }
+
+        private void OnEnable()
+        {
+            SaveManager.Register(this);
+        }
+
+        private void OnDisable()
+        {
+            Save();
+            SaveManager.Unregister(this);
+        }
+
+        /// <inheritdoc />
+        public void Save()
+        {
+            var data = new PoisonSaveData { immunityTimer = controller != null ? controller.ImmunityTimer : 0f };
+            var effect = controller != null ? controller.ActiveEffect : null;
+            if (effect != null && effect.IsActive)
+            {
+                data.isPoisoned = true;
+                data.configId = effect.Config != null ? effect.Config.Id : null;
+                data.currentDamage = effect.CurrentDamage;
+                data.ticksSinceDecay = effect.TicksSinceDecay;
+                data.timeToNextTick = effect.Config.tickIntervalSeconds - effect.TickTimer;
+            }
+            SaveManager.Save(SaveKey, data);
+        }
+
+        /// <inheritdoc />
+        public void Load()
+        {
+            var data = SaveManager.Load<PoisonSaveData>(SaveKey);
+            if (data == null || controller == null)
+                return;
+
+            controller.ImmunityTimer = data.immunityTimer;
+            if (data.isPoisoned && !string.IsNullOrEmpty(data.configId))
+            {
+                var cfg = Resources.Load<PoisonConfig>($"Status/Poison/{data.configId}");
+                if (cfg != null)
+                {
+                    float savedImmune = controller.ImmunityTimer;
+                    controller.ImmunityTimer = 0f;
+                    controller.ApplyPoison(cfg);
+                    controller.ActiveEffect?.RestoreState(
+                        data.currentDamage,
+                        data.ticksSinceDecay,
+                        cfg.tickIntervalSeconds - data.timeToNextTick);
+                    controller.ImmunityTimer = savedImmune;
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Status/Poison/PoisonSaveBridge.cs.meta
+++ b/Assets/Scripts/Status/Poison/PoisonSaveBridge.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 582e91441b154c16a96cb371bc38a2b7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add configurable poison status effect with ticking, decay and immunity
- save and load per-entity poison state and provide debug tools
- apply poison on confirmed hits and provide consumable cures

## Testing
- ⚠️ `dotnet build` (no project or solution file found)


------
https://chatgpt.com/codex/tasks/task_e_68c348e22cdc832e8740066ad39fef87