### PR TITLE
Add poison support for weapons

### DIFF
--- a/Assets/Resources/Item/Engraved Silver Dagger.asset
+++ b/Assets/Resources/Item/Engraved Silver Dagger.asset
@@ -36,3 +36,6 @@ MonoBehaviour:
     RangeDefence: 0
     MagicDefence: 0
     AttackSpeedTicks: 4
+  onHitPoison: {fileID: 11400000, guid: 5a501ca099d54f02a1139ef22ba213c8, type: 2}
+  poisonApplyChance: 0.25
+  poisonRequiresDamage: 1

--- a/Assets/Scripts/Inventory/ItemData.cs
+++ b/Assets/Scripts/Inventory/ItemData.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 using Items;
 using Skills;
 using Skills.Fishing;
+using Status.Poison;
 
 namespace Inventory
 {
@@ -120,5 +121,15 @@ namespace Inventory
 
         [Header("Combat")]
         public ItemCombatStats combat = ItemCombatStats.Default;
+
+        [Header("Poison")]
+        public PoisonConfig onHitPoison;
+
+        [Range(0f, 1f)]
+        [Tooltip("Chance that the poison is applied on a successful hit.")]
+        public float poisonApplyChance = 0.25f;
+
+        [Tooltip("Only apply poison if the hit dealt damage.")]
+        public bool poisonRequiresDamage = true;
     }
 }

--- a/Assets/Scripts/Player/PlayerCombatLoadout.cs
+++ b/Assets/Scripts/Player/PlayerCombatLoadout.cs
@@ -96,6 +96,21 @@ namespace Player
 
             var entry = equipment != null ? equipment.GetEquipped(EquipmentSlot.Weapon) : default;
             var weapon = entry.item;
+
+            var poisonApplier = GetComponent<OnHitPoisonApplier>();
+            if (weapon != null && weapon.onHitPoison != null)
+            {
+                if (poisonApplier == null)
+                    poisonApplier = gameObject.AddComponent<OnHitPoisonApplier>();
+                poisonApplier.poison = weapon.onHitPoison;
+                poisonApplier.applyChance = weapon.poisonApplyChance;
+                poisonApplier.requiresDamage = weapon.poisonRequiresDamage;
+            }
+            else if (poisonApplier != null)
+            {
+                Destroy(poisonApplier);
+            }
+
             if (weapon != null)
             {
                 if (weapon.combat.Magic > 0)


### PR DESCRIPTION
## Summary
- allow ItemData to specify poison effects on hit
- attach or remove OnHitPoisonApplier when equipping weapons
- configure Engraved Silver Dagger to inflict poison

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c3b3c2edb8832e9da6bd2a93e9b8b6