### PR TITLE
Add poison hitsplat handling

### DIFF
--- a/Assets/Scripts/Combat/CombatEnums.cs
+++ b/Assets/Scripts/Combat/CombatEnums.cs
@@ -10,7 +10,8 @@ namespace Combat
         Melee,
         Ranged,
         Magic,
-        Burn
+        Burn,
+        Poison
     }
 
     /// <summary>

--- a/Assets/Scripts/NPC/Combat/NpcCombatant.cs
+++ b/Assets/Scripts/NPC/Combat/NpcCombatant.cs
@@ -4,6 +4,7 @@ using Combat;
 using MyGame.Drops;
 using Player;
 using Pets;
+using UI;
 
 namespace NPC
 {
@@ -20,6 +21,7 @@ namespace NPC
         private NpcWanderer wanderer;
         private int playerDamage;
         private int npcDamage;
+        private Sprite poisonHitsplat;
 
         public event System.Action<int, int> OnHealthChanged; // current, max
         public event System.Action OnDeath;
@@ -44,6 +46,7 @@ namespace NPC
             wanderer = GetComponent<NpcWanderer>();
             ResetDamageCounters();
             OnHealthChanged?.Invoke(currentHp, MaxHP);
+            poisonHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Poison_hitsplat");
         }
 
         /// <summary>Apply damage to this NPC.</summary>
@@ -67,6 +70,8 @@ namespace NPC
             currentHp = Mathf.Max(0, currentHp - finalAmount);
             Debug.Log($"{name} took {finalAmount} damage ({currentHp}/{MaxHP}).");
             OnHealthChanged?.Invoke(currentHp, MaxHP);
+            if (type == DamageType.Poison && poisonHitsplat != null)
+                FloatingText.Show(finalAmount.ToString(), transform.position, Color.white, null, poisonHitsplat);
             var combatSource = source as CombatTarget;
             bool creditedToPlayer = false;
             if (combatSource != null)

--- a/Assets/Scripts/Player/PlayerCombatTarget.cs
+++ b/Assets/Scripts/Player/PlayerCombatTarget.cs
@@ -15,6 +15,7 @@ namespace Player
         private Sprite damageHitsplat;
         private Sprite zeroHitsplat;
         private Sprite burnHitsplat;
+        private Sprite poisonHitsplat;
         private Dictionary<SpellElement, Sprite> elementHitsplats;
 
         private void Awake()
@@ -23,6 +24,7 @@ namespace Player
             damageHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Damage_hitsplat");
             zeroHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Zero_damage_hitsplat");
             burnHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Burn_hitsplat");
+            poisonHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Poison_hitsplat");
             elementHitsplats = new Dictionary<SpellElement, Sprite>
             {
                 { SpellElement.Air, Resources.Load<Sprite>("Sprites/HitSplats/Air_hitsplat") },
@@ -48,6 +50,8 @@ namespace Player
                 sprite = zeroHitsplat;
             else if (type == DamageType.Burn)
                 sprite = burnHitsplat;
+            else if (type == DamageType.Poison)
+                sprite = poisonHitsplat;
             else if (type == DamageType.Magic && elementHitsplats != null && elementHitsplats.TryGetValue(element, out var elemSprite) && elemSprite != null)
             {
                 sprite = elemSprite;

--- a/Assets/Scripts/Status/Poison/PoisonController.cs
+++ b/Assets/Scripts/Status/Poison/PoisonController.cs
@@ -81,7 +81,7 @@ namespace Status.Poison
         /// </summary>
         private bool DealTrueDamageBridge(int amount)
         {
-            stats?.ApplyDamage(amount, DamageType.Magic, SpellElement.None, this);
+            stats?.ApplyDamage(amount, DamageType.Poison, SpellElement.None, this);
             return true;
         }
     }


### PR DESCRIPTION
## Summary
- add DamageType.Poison and load Poison_hitsplat sprite
- show poison hitsplat when players or NPCs take poison damage
- apply poison damage using new damage type

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c3b53be320832eb9eb217400c249a8