### PR TITLE
feat: add poison settings for NPC combat

### DIFF
--- a/Assets/Scripts/Combat/NpcCombatProfile.cs
+++ b/Assets/Scripts/Combat/NpcCombatProfile.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 using NPC;
+using Status.Poison;
 
 namespace Combat
 {
@@ -46,6 +47,12 @@ namespace Combat
         /// Faction that this NPC belongs to. Defaults to <see cref="FactionId.Neutral"/>.
         /// </summary>
         public FactionId Faction = FactionId.Neutral;
+
+        [Header("Poison")]
+        public bool IsPoisonous;
+        public PoisonConfig OnHitPoison;
+        [Range(0f, 1f)] public float PoisonChance = 0.25f;
+        public bool PoisonRequiresDamage = true;
 
         public List<ElementalModifier> elementalModifiers = new();
     }

--- a/Assets/Scripts/NPC/Combat/NpcCombatant.cs
+++ b/Assets/Scripts/NPC/Combat/NpcCombatant.cs
@@ -47,6 +47,16 @@ namespace NPC
             ResetDamageCounters();
             OnHealthChanged?.Invoke(currentHp, MaxHP);
             poisonHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Poison_hitsplat");
+
+            if (profile != null && profile.IsPoisonous && profile.OnHitPoison != null)
+            {
+                var applier = GetComponent<OnHitPoisonApplier>();
+                if (applier == null)
+                    applier = gameObject.AddComponent<OnHitPoisonApplier>();
+                applier.poison = profile.OnHitPoison;
+                applier.applyChance = profile.PoisonChance;
+                applier.requiresDamage = profile.PoisonRequiresDamage;
+            }
         }
 
         /// <summary>Apply damage to this NPC.</summary>


### PR DESCRIPTION
## Summary
- add poison fields to NPC combat profiles
- auto-attach and configure OnHitPoisonApplier for poisonous NPCs

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c3b8144748832eabe1494d3ac7f8b0