### PR TITLE
Guard poison ticks against dead targets

### DIFF
--- a/Assets/Scripts/Status/Poison/PoisonController.cs
+++ b/Assets/Scripts/Status/Poison/PoisonController.cs
@@ -73,7 +73,26 @@ namespace Status.Poison
             if (immunityTimer > 0f)
                 immunityTimer = Mathf.Max(0f, immunityTimer - Time.deltaTime);
             if (active != null)
-                active.Tick(Time.deltaTime, DealTrueDamageBridge);
+            {
+                if (stats != null && stats.IsAlive)
+                {
+                    active.Tick(Time.deltaTime, DealTrueDamageBridge);
+                }
+                else
+                {
+                    active.ForceEnd();
+                    active = null;
+                }
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (active != null)
+            {
+                active.ForceEnd();
+                active = null;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- Prevent poison from ticking on missing or dead targets by ending the effect
- Clean up active poison when the controller is disabled

## Testing
- `unity -version` *(fails: command not found)*
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c3b9bc526c832eabb7efa66eb85b31