### PR TITLE
Fix poison persistence after player respawn

### DIFF
--- a/Assets/Scripts/Player/PlayerRespawnSystem.cs
+++ b/Assets/Scripts/Player/PlayerRespawnSystem.cs
@@ -4,6 +4,7 @@ using UnityEngine.SceneManagement;
 using Core;
 using World;
 using Combat;
+using Status.Poison;
 
 namespace Player
 {
@@ -17,6 +18,7 @@ namespace Player
         private PlayerHitpoints hitpoints;
         private PlayerMover playerMover;
         private CombatController combatController;
+        private PoisonController poisonController;
         private bool isRespawning;
 
         private void Awake()
@@ -60,12 +62,14 @@ namespace Player
                 hitpoints = playerObj.GetComponent<PlayerHitpoints>();
                 playerMover = playerObj.GetComponent<PlayerMover>();
                 combatController = playerObj.GetComponent<CombatController>();
+                poisonController = playerObj.GetComponent<PoisonController>();
             }
             else
             {
                 hitpoints = null;
                 playerMover = null;
                 combatController = null;
+                poisonController = null;
             }
             if (hitpoints != null)
                 hitpoints.OnHealthChanged += HandleHealthChanged;
@@ -77,6 +81,7 @@ namespace Player
             {
                 playerMover?.StopMovement();
                 combatController?.CancelCombat();
+                poisonController?.CurePoison(0f);
                 StartCoroutine(RespawnRoutine());
             }
         }


### PR DESCRIPTION
## Summary
- clear any active poison effect when the player dies before respawning
- track the player's PoisonController in respawn system

## Testing
- `dotnet test` (fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)

------
https://chatgpt.com/codex/tasks/task_e_68c3bc269524832e9a59263313e8c5ed