### PR TITLE
Use defender combat stats and remove hit chance clamp

### DIFF
--- a/Assets/Scripts/Combat/CombatMath.cs
+++ b/Assets/Scripts/Combat/CombatMath.cs
@@ -10,8 +10,6 @@ namespace Combat
         /// <summary>Seconds per OSRS tick.</summary>
         public const float TICK_SECONDS = 0.6f;
 
-        public const float MIN_HIT_CHANCE = 0.25f;
-
         /// <summary>Maximum distance allowed for melee combat.</summary>
         public const float MELEE_RANGE = 1.5f;
 
@@ -68,7 +66,7 @@ namespace Combat
                 chance = 1f - (defenceRoll + 2f) / (2f * (attackRoll + 1f));
             else
                 chance = attackRoll / (2f * (defenceRoll + 1f));
-            return Mathf.Clamp(chance, MIN_HIT_CHANCE, 1f);
+            return chance;
         }
 
         public static int GetMaxHit(int effectiveStrength, int strengthBonus)

--- a/Assets/Scripts/Player/PlayerCombatTarget.cs
+++ b/Assets/Scripts/Player/PlayerCombatTarget.cs
@@ -2,6 +2,8 @@ using UnityEngine;
 using Combat;
 using UI;
 using System.Collections.Generic;
+using EquipmentSystem;
+using Skills;
 
 namespace Player
 {
@@ -40,6 +42,22 @@ namespace Player
         public DamageType PreferredDefenceType => DamageType.Melee;
         public int CurrentHP => hitpoints.CurrentHp;
         public int MaxHP => hitpoints.MaxHp;
+
+        /// <summary>Get combat stats representing the player's current defensive state.</summary>
+        public CombatantStats GetCombatantStats()
+        {
+            var binder = GetComponent<PlayerCombatBinder>();
+            if (binder != null)
+                return binder.GetCombatantStats();
+
+            var loadout = GetComponent<PlayerCombatLoadout>();
+            if (loadout != null)
+                return loadout.GetCombatantStats();
+
+            var skills = GetComponent<SkillManager>();
+            var equipment = GetComponent<EquipmentAggregator>();
+            return CombatantStats.ForPlayer(skills, equipment, CombatStyle.Defensive, PreferredDefenceType);
+        }
 
         public int ApplyDamage(int amount, DamageType type, SpellElement element, object source)
         {


### PR DESCRIPTION
## Summary
- pull defender combat stats from NPC or player targets when resolving player attacks, falling back to defaults if unavailable
- expose combat stats from PlayerCombatTarget so other systems can access real defensive levels and gear bonuses
- remove the hard-coded minimum hit chance so accuracy follows the raw OSRS formula

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68c87fc18458832e8fc3e1227f86aec4