### PR TITLE
Add halberd AOE damage handling

### DIFF
--- a/Assets/Scripts/Inventory/ItemData.cs
+++ b/Assets/Scripts/Inventory/ItemData.cs
@@ -131,5 +131,12 @@ namespace Inventory
 
         [Tooltip("Only apply poison if the hit dealt damage.")]
         public bool poisonRequiresDamage = true;
+
+        [Header("Halberd AOE")]
+        public bool isHalberd = false;
+        public float aoeRadiusTiles = 0f;
+        public float coneAngleDeg = 0f;
+        public int aoeMaxTargets = 0;
+        public float aoeMultiplier = 0f;
     }
 }


### PR DESCRIPTION
## Summary
- expose halberd AOE configuration on ItemData assets
- cache the player's Equipment component and return damage values from ApplyDamageResult
- apply halberd frontal AOE damage using weapon settings after the primary hit

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68c888d835dc832e876f68063a01c149