### PR TITLE
Refactor interaction input to use Input System actions

### DIFF
--- a/Assets/InputSystem_Actions.inputactions
+++ b/Assets/InputSystem_Actions.inputactions
@@ -39,7 +39,7 @@
                     "id": "852140f2-7766-474d-8707-702459ba45f3",
                     "expectedControlType": "Button",
                     "processors": "",
-                    "interactions": "Hold",
+                    "interactions": "Press",
                     "initialStateCheck": false
                 },
                 {
@@ -85,6 +85,33 @@
                     "expectedControlType": "Button",
                     "processors": "",
                     "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Prospect",
+                    "type": "Button",
+                    "id": "d5143f6e-46a6-4e23-9220-c58c7d66c5de",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "Press",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Cancel",
+                    "type": "Button",
+                    "id": "9fc08694-3fae-441f-a33a-3edf9d7b8761",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "Press",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "OpenMenu",
+                    "type": "Button",
+                    "id": "50ea61f1-ef91-4bc3-9358-e9e7db2af88f",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "Press",
                     "initialStateCheck": false
                 }
             ],
@@ -471,6 +498,83 @@
                     "processors": "",
                     "groups": "Keyboard&Mouse",
                     "action": "Crouch",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "4f651650-f7ef-41c9-9ea2-015cc8c1139a",
+                    "path": "<Mouse>/leftButton",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Interact",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "530183ac-fd94-40ed-927b-abb92c885fc4",
+                    "path": "<Gamepad>/buttonSouth",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Interact",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "e81faabd-a530-4bab-9809-f0e1cb0f3096",
+                    "path": "<Mouse>/rightButton",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Prospect",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "760cc4b6-9118-4747-a4c2-9c743bffbdd3",
+                    "path": "<Keyboard>/escape",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Cancel",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "bc35c16b-957e-43f1-bd38-5200e6557afa",
+                    "path": "<Gamepad>/start",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Cancel",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "506b1bdd-8cfb-4036-a24f-16c60316a183",
+                    "path": "<Mouse>/rightButton",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "OpenMenu",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "32c1929a-63b9-43b6-92ca-44d1564f37e6",
+                    "path": "<Gamepad>/select",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "OpenMenu",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/Scripts/Core/Input.meta
+++ b/Assets/Scripts/Core/Input.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 125494bedfa94c8c80ee84bf823b57db
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/Input/InputActionResolver.cs
+++ b/Assets/Scripts/Core/Input/InputActionResolver.cs
@@ -1,0 +1,71 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+namespace Core.Input
+{
+    /// <summary>
+    /// Helper utilities that bridge serialized <see cref="InputActionReference"/> assets and runtime
+    /// <see cref="PlayerInput"/> components.  Centralizing the resolution logic keeps gathering and NPC
+    /// controllers lightweight while still supporting inspector based overrides.
+    /// </summary>
+    public static class InputActionResolver
+    {
+        /// <summary>
+        /// Resolves an <see cref="InputAction"/> either from a direct <paramref name="reference"/> or from
+        /// the provided <paramref name="playerInput"/> action map.  When the action is currently disabled
+        /// it will be enabled and the <paramref name="actionEnabledByResolver"/> flag is set so the caller
+        /// knows whether it should be disabled again during cleanup.
+        /// </summary>
+        /// <param name="playerInput">Player input component supplying the default action map.</param>
+        /// <param name="reference">Optional reference overriding the action lookup.</param>
+        /// <param name="actionName">Name of the action to locate within the input asset.</param>
+        /// <param name="actionEnabledByResolver">Outputs whether the helper enabled the action.</param>
+        public static InputAction Resolve(PlayerInput playerInput, InputActionReference reference, string actionName,
+            out bool actionEnabledByResolver)
+        {
+            actionEnabledByResolver = false;
+
+            // Prefer the explicit reference so designers can swap action maps per prefab if required.
+            InputAction action = reference != null ? reference.action : null;
+
+            if (action == null && playerInput != null)
+            {
+                // PlayerInput.FindAction throws if the action is missing, therefore use the safe lookup variant.
+                action = playerInput.actions != null
+                    ? playerInput.actions.FindAction(actionName, throwIfNotFound: false)
+                    : null;
+            }
+
+            if (action != null && !action.enabled)
+            {
+                action.Enable();
+                actionEnabledByResolver = true;
+            }
+
+            return action;
+        }
+
+        /// <summary>
+        /// Returns the current pointer position in screen space using whichever pointing device is active.
+        /// Falls back to the supplied <paramref name="fallback"/> when no pointer style device is detected
+        /// (e.g. controller only setups).
+        /// </summary>
+        public static Vector2 GetPointerScreenPosition(Vector2 fallback)
+        {
+            if (Mouse.current != null)
+                return Mouse.current.position.ReadValue();
+
+            if (Pen.current != null)
+                return Pen.current.position.ReadValue();
+
+            if (Touchscreen.current != null)
+            {
+                var primaryTouch = Touchscreen.current.primaryTouch;
+                if (primaryTouch.press.isPressed)
+                    return primaryTouch.position.ReadValue();
+            }
+
+            return fallback;
+        }
+    }
+}

--- a/Assets/Scripts/Core/Input/InputActionResolver.cs.meta
+++ b/Assets/Scripts/Core/Input/InputActionResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aae914183f36480cad22c75c8cc54624
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Skills/Fishing/Core/FisherController.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FisherController.cs
@@ -37,8 +37,9 @@ namespace Skills.Fishing
         /// <summary>
         /// Subscribe to skill events so animations remain in sync even if fishing stops externally.
         /// </summary>
-        private void OnEnable()
+        protected override void OnEnable()
         {
+            base.OnEnable();
             if (FishingSkill != null)
             {
                 FishingSkill.OnStartFishing += HandleStartFishing;
@@ -49,8 +50,9 @@ namespace Skills.Fishing
         /// <summary>
         /// Unsubscribe from the skill events when the component is disabled.
         /// </summary>
-        private void OnDisable()
+        protected override void OnDisable()
         {
+            base.OnDisable();
             if (FishingSkill != null)
             {
                 FishingSkill.OnStartFishing -= HandleStartFishing;

--- a/README.md
+++ b/README.md
@@ -11,6 +11,21 @@ This project currently targets **Unity 6000.2.3f1**.
 - **Skill System** – A modular framework for training skills such as woodcutting and mining through `SkillManager` and skill-specific modules.
 - **Shop System** – Supports buying and selling items via `Shop` and `ShopUI` components.
 
+## Input & Rebinding
+- The project relies on the Unity Input System with the `Assets/InputSystem_Actions.inputactions` asset. The **Player** map now
+  exposes `Move`, `Interact`, `Prospect`, `Cancel`, and `OpenMenu` so gameplay, NPCs, and UI can share the same bindings.
+- Player-facing scripts such as gathering controllers and `NpcInteractable` consume input through a `PlayerInput` component or
+  serialized `InputActionReference` fields. The shared `Core/Input/InputActionResolver` helper resolves the action instance and
+  ensures it is enabled when required.
+- To rebind controls:
+  1. Open **Input System Actions** in the Unity editor and edit the relevant binding under the **Player** action map. Left-click
+     interactions, right-click context actions, and menu cancellation already have default bindings.
+  2. Apply the changes to the `PlayerInput` component on the player prefab or scene object (it should reference the updated
+     action asset).
+  3. Any script that needs the new binding can request it via `InputActionResolver.Resolve`, optionally exposing an
+     `InputActionReference` field for prefab-level overrides. This keeps new systems aligned with the shared action map and
+     avoids duplicating bindings.
+
 ## Build and Run
 1. Install Unity 6000.2.3f1 or newer.
 2. Clone this repository.


### PR DESCRIPTION
## Summary
- define Interact, Prospect, Cancel, and OpenMenu actions in the shared Input System asset and bind them to mouse, keyboard, and gamepad controls
- add a reusable InputActionResolver helper and update gathering controllers plus fishing events to consume PlayerInput callbacks instead of polling legacy Input APIs
- rework NPC context interactions to subscribe to the OpenMenu action and document the input rebinding workflow for future features

## Testing
- not run (Unity editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c936e2b2dc832eacbc3b9b3f2a7750