### PR TITLE
Add persistent object bootstrap system

### DIFF
--- a/Assets/Prefabs/EventSystem.prefab
+++ b/Assets/Prefabs/EventSystem.prefab
@@ -9,6 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1275879031103303567}
+  - component: {fileID: 1313131313131313131}
   - component: {fileID: 312706842149785227}
   - component: {fileID: 7099375072489141131}
   m_Layer: 0
@@ -79,3 +80,15 @@ MonoBehaviour:
   m_PointerBehavior: 0
   m_CursorLockBehavior: 0
   m_ScrollDeltaPerTick: 6
+--- !u!114 &1313131313131313131
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2419982046797033590}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a23b760b7356ac141a5ff9fe31e13251, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:

--- a/Assets/Prefabs/MainScriptObjects/InputActionResolver.prefab
+++ b/Assets/Prefabs/MainScriptObjects/InputActionResolver.prefab
@@ -9,6 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 9042410377599621593}
+  - component: {fileID: 1212121212121212121}
   - component: {fileID: 3307467799377144067}
   m_Layer: 0
   m_Name: InputActionResolver
@@ -76,3 +77,15 @@ MonoBehaviour:
     y: 0
     width: 1
     height: 1
+--- !u!114 &1212121212121212121
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5629681538045410937}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a23b760b7356ac141a5ff9fe31e13251, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:

--- a/Assets/Prefabs/MainScriptObjects/ItemDatabase.prefab
+++ b/Assets/Prefabs/MainScriptObjects/ItemDatabase.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1460000000000000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1460000000000000001}
+  - component: {fileID: 1460000000000000002}
+  m_Layer: 0
+  m_Name: ItemDatabase
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1460000000000000001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1460000000000000000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1460000000000000002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1460000000000000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4fe0a0f23c609a941a09c3376805978b, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:

--- a/Assets/Prefabs/MainScriptObjects/ItemDatabase.prefab.meta
+++ b/Assets/Prefabs/MainScriptObjects/ItemDatabase.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8d79d02c678b4761bf1e4ce93122782b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/MainScriptObjects/PlayerRespawnSystem.prefab
+++ b/Assets/Prefabs/MainScriptObjects/PlayerRespawnSystem.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1470000000000000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1470000000000000001}
+  - component: {fileID: 1470000000000000002}
+  m_Layer: 0
+  m_Name: PlayerRespawnSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1470000000000000001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1470000000000000000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1470000000000000002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1470000000000000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4265ae917bbc463c839850c65a2a49b4, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:

--- a/Assets/Prefabs/MainScriptObjects/PlayerRespawnSystem.prefab.meta
+++ b/Assets/Prefabs/MainScriptObjects/PlayerRespawnSystem.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f4463a4842cd4d0abf9fcca952dcb475
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/MainScriptObjects/ScreenFader.prefab
+++ b/Assets/Prefabs/MainScriptObjects/ScreenFader.prefab
@@ -1,0 +1,47 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1337000000000000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1337000000000000001}
+  - component: {fileID: 1337000000000000002}
+  m_Layer: 0
+  m_Name: ScreenFader
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1337000000000000001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1337000000000000000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1337000000000000002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1337000000000000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b8d1fc5037fd46c9b5682b1aaf06c458, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  fadeDuration: 0.5

--- a/Assets/Prefabs/MainScriptObjects/ScreenFader.prefab.meta
+++ b/Assets/Prefabs/MainScriptObjects/ScreenFader.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 24e6c0c2e5b54061bcf3d3e331bbb747
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/MainScriptObjects/ShopUI.prefab
+++ b/Assets/Prefabs/MainScriptObjects/ShopUI.prefab
@@ -1,0 +1,57 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1450000000000000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1450000000000000001}
+  - component: {fileID: 1450000000000000002}
+  m_Layer: 0
+  m_Name: ShopUI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1450000000000000001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1450000000000000000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1450000000000000002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1450000000000000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 771a3fc4c6bc41e79214eb125c3c0e44, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  slotSize: {x: 32, y: 32}
+  slotSpacing: {x: 4, y: 4}
+  referenceResolution: {x: 640, y: 360}
+  slotFrameSprite: {fileID: 0}
+  emptySlotColor: {r: 1, g: 1, b: 1, a: 0.25}
+  windowColor: {r: 0.15, g: 0.15, b: 0.15, a: 0.95}
+  windowPadding: {x: 8, y: 8}
+  extraWindowHeight: 33
+  priceFont: {fileID: 0}
+  priceColor: {r: 1, g: 1, b: 1, a: 1}
+  playerInventory: {fileID: 0}

--- a/Assets/Prefabs/MainScriptObjects/ShopUI.prefab.meta
+++ b/Assets/Prefabs/MainScriptObjects/ShopUI.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b5491e846856443d99a8573cd56be3d9
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/PersistentObjects.asset
+++ b/Assets/Resources/PersistentObjects.asset
@@ -1,0 +1,32 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 39d5ec0af0a74b118ef78cfdd213a250, type: 3}
+  m_Name: PersistentObjects
+  m_EditorClassIdentifier:
+  prefabs:
+  - {fileID: 100100000, guid: 57c979e119416be42911c3b9e0c59577, type: 3}
+  - {fileID: 100100000, guid: 24e6c0c2e5b54061bcf3d3e331bbb747, type: 3}
+  - {fileID: 100100000, guid: 8d79d02c678b4761bf1e4ce93122782b, type: 3}
+  - {fileID: 100100000, guid: b5491e846856443d99a8573cd56be3d9, type: 3}
+  - {fileID: 100100000, guid: f4463a4842cd4d0abf9fcca952dcb475, type: 3}
+  - {fileID: 100100000, guid: b216a84afc7867e479dfdc33c1480131, type: 3}
+  - {fileID: 100100000, guid: 4cc0866bd73b19b44af86e158cbea32e, type: 3}
+  - {fileID: 100100000, guid: cdc5a60f0ff83ab4396a6a865b9fd686, type: 3}
+  - {fileID: 100100000, guid: 9c5a972980e03c444abead330939be03, type: 3}
+  - {fileID: 100100000, guid: 3161b64352319164c8eb1c4fcd80803e, type: 3}
+  - {fileID: 100100000, guid: 4b2853c859c004b48a226e4f765468ec, type: 3}
+  - {fileID: 100100000, guid: eb67b7820e43b2d4ca52d438eba45f61, type: 3}
+  - {fileID: 100100000, guid: 5276085bbbec9004d89f354a91adcf8e, type: 3}
+  - {fileID: 100100000, guid: 4fbebeaadd02b7746bc147a808fd9b35, type: 3}
+  - {fileID: 100100000, guid: c1d5d4eaa2d92d844b2e1d7870945653, type: 3}
+  - {fileID: 100100000, guid: 1a096839d4aa300478fd58a9681f3d8c, type: 3}
+  - {fileID: 100100000, guid: ac4dc3793be1bee4caf981f7340bf02d, type: 3}

--- a/Assets/Resources/PersistentObjects.asset.meta
+++ b/Assets/Resources/PersistentObjects.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9a1541f5e4c74ea1b52e6980de9616c1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -13,8 +13,11 @@ namespace Core
 {
     /// <summary>
     /// Central bootstrapper that persists across scenes and exposes global services.
+    /// All of the referenced singletons are instantiated by <c>PersistentObjects.asset</c>,
+    /// so adding a new cross-scene dependency only requires dropping its prefab into the
+    /// asset's list.
     /// </summary>
-    public class GameManager : MonoBehaviour
+    public class GameManager : ScenePersistentObject
     {
         public static GameManager Instance { get; private set; }
 
@@ -38,7 +41,7 @@ namespace Core
         public static ItemDatabase ItemDatabase => Instance.itemDatabase;
         public static BycatchManager BycatchManager => Instance.bycatchManager;
 
-        private void Awake()
+        protected override void Awake()
         {
             if (Instance != null && Instance != this)
             {
@@ -46,19 +49,22 @@ namespace Core
                 return;
             }
 
+            base.Awake();
+
             Instance = this;
             DontDestroyOnLoad(gameObject);
 
-            ticker = FindOrCreate<Ticker>();
-            screenFader = FindOrCreate<ScreenFader>();
-            itemDatabase = FindOrCreate<ItemDatabase>();
-            shopUI = FindOrCreate<ShopUI>();
-            respawnSystem = FindOrCreate<PlayerRespawnSystem>();
-            bycatchManager = FindOrCreate<BycatchManager>();
+            CacheServices(false);
+        }
+
+        private void Start()
+        {
+            CacheServices(true);
 
             ServicesReady?.Invoke();
 
-            autosaveRoutine = StartCoroutine(AutoSaveLoop());
+            if (autosaveRoutine == null)
+                autosaveRoutine = StartCoroutine(AutoSaveLoop());
         }
 
         private IEnumerator AutoSaveLoop()
@@ -78,16 +84,31 @@ namespace Core
         }
 
         /// <summary>
-        /// Finds an existing service of type <typeparamref name="T"/> or creates a new one.
+        /// Locates required cross-scene services that should have been spawned by
+        /// <see cref="World.PersistentObjectBootstrap"/>.
         /// </summary>
-        private static T FindOrCreate<T>() where T : Component
+        /// <param name="logIfMissing">When <c>true</c>, logs guidance if a service could not be found.</param>
+        private void CacheServices(bool logIfMissing)
         {
-            var service = FindObjectOfType<T>();
-            if (service == null)
+            ticker ??= FindService<Ticker>(logIfMissing);
+            screenFader ??= FindService<ScreenFader>(logIfMissing);
+            itemDatabase ??= FindService<ItemDatabase>(logIfMissing);
+            shopUI ??= FindService<ShopUI>(logIfMissing);
+            respawnSystem ??= FindService<PlayerRespawnSystem>(logIfMissing);
+            bycatchManager ??= FindService<BycatchManager>(logIfMissing);
+        }
+
+        /// <summary>
+        /// Searches the scene hierarchy (including inactive objects) for the requested service.
+        /// When the service is missing, the log message explains that it should be added to
+        /// <c>PersistentObjects.asset</c> so future scenes include it automatically.
+        /// </summary>
+        private T FindService<T>(bool logIfMissing) where T : Component
+        {
+            var service = FindObjectOfType<T>(true);
+            if (service == null && logIfMissing)
             {
-                var go = new GameObject(typeof(T).Name);
-                service = go.AddComponent<T>();
-                DontDestroyOnLoad(go);
+                Debug.LogError($"Required service of type {typeof(T).Name} was not found. Add its prefab to Resources/{World.PersistentObjectBootstrap.CatalogResourcePath}.asset to have it loaded automatically.", this);
             }
             return service;
         }

--- a/Assets/Scripts/Dialogue/DialogueManager.cs
+++ b/Assets/Scripts/Dialogue/DialogueManager.cs
@@ -1,12 +1,13 @@
 using UnityEngine;
 using Quests;
+using World;
 
 namespace Dialogue
 {
     /// <summary>
     /// Controls dialogue flow and applies option actions.
     /// </summary>
-    public class DialogueManager : MonoBehaviour
+    public class DialogueManager : ScenePersistentObject
     {
         public static DialogueManager Instance { get; private set; }
 
@@ -14,13 +15,16 @@ namespace Dialogue
         private int currentIndex;
         private DialogueUI ui;
 
-        private void Awake()
+        protected override void Awake()
         {
             if (Instance != null && Instance != this)
             {
                 Destroy(gameObject);
                 return;
             }
+
+            base.Awake();
+
             Instance = this;
             DontDestroyOnLoad(gameObject);
 

--- a/Assets/Scripts/Inventory/ItemDatabase.cs
+++ b/Assets/Scripts/Inventory/ItemDatabase.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using UnityEngine;
+using World;
 
 namespace Inventory
 {
@@ -8,7 +9,7 @@ namespace Inventory
     /// fast lookup by item id. The database will initialize itself on first use
     /// so callers do not need to ensure the component exists ahead of time.
     /// </summary>
-    public class ItemDatabase : MonoBehaviour
+    public class ItemDatabase : ScenePersistentObject
     {
         private static ItemDatabase instance;
         private readonly Dictionary<string, ItemData> items = new();
@@ -38,7 +39,7 @@ namespace Inventory
             return item;
         }
 
-        private void Awake()
+        protected override void Awake()
         {
             // Singleton enforcement.
             if (instance != null && instance != this)
@@ -48,6 +49,7 @@ namespace Inventory
             }
 
             instance = this;
+            base.Awake();
             DontDestroyOnLoad(gameObject);
 
             var loadedItems = Resources.LoadAll<ItemData>("Item");

--- a/Assets/Scripts/Player/CameraFollow2D.cs
+++ b/Assets/Scripts/Player/CameraFollow2D.cs
@@ -1,11 +1,12 @@
 ﻿// Assets/Scripts/Camera/CameraFollow2D.cs
 
 using UnityEngine;
+using World;
 
 namespace Player
 {
     [RequireComponent(typeof(Camera))]
-    public class CameraFollow2D : MonoBehaviour
+    public class CameraFollow2D : ScenePersistentObject
     {
         public Transform target;
         public Vector2 offset = Vector2.zero;
@@ -23,8 +24,9 @@ namespace Player
         private Vector3 velocity;
         private Camera cam;
 
-        void Awake()
+        protected override void Awake()
         {
+            base.Awake();
             cam = GetComponent<Camera>();
             DontDestroyOnLoad(gameObject);
         }

--- a/Assets/Scripts/Player/PlayerRespawnSystem.cs
+++ b/Assets/Scripts/Player/PlayerRespawnSystem.cs
@@ -11,7 +11,7 @@ namespace Player
     /// <summary>
     /// Listens for player death and handles respawning with a screen fade.
     /// </summary>
-    public class PlayerRespawnSystem : MonoBehaviour
+    public class PlayerRespawnSystem : ScenePersistentObject
     {
         public static PlayerRespawnSystem Instance { get; private set; }
 
@@ -21,7 +21,7 @@ namespace Player
         private PoisonController poisonController;
         private bool isRespawning;
 
-        private void Awake()
+        protected override void Awake()
         {
             if (Instance != null && Instance != this)
             {
@@ -30,6 +30,7 @@ namespace Player
             }
 
             Instance = this;
+            base.Awake();
             DontDestroyOnLoad(gameObject);
         }
 

--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -2,13 +2,14 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;
 using Core.Save;
+using World;
 
 namespace Quests
 {
     /// <summary>
     /// Manages the player's quests and notifies listeners when they change.
     /// </summary>
-    public class QuestManager : MonoBehaviour, ISaveable
+    public class QuestManager : ScenePersistentObject, ISaveable
     {
         public static QuestManager Instance { get; private set; }
 
@@ -21,13 +22,16 @@ namespace Quests
 
         private const string SaveKey = "QuestData";
 
-        private void Awake()
+        protected override void Awake()
         {
             if (Instance != null && Instance != this)
             {
                 Destroy(gameObject);
                 return;
             }
+
+            base.Awake();
+
             Instance = this;
             DontDestroyOnLoad(gameObject);
 

--- a/Assets/Scripts/Quests/QuestRegistrar.cs
+++ b/Assets/Scripts/Quests/QuestRegistrar.cs
@@ -1,10 +1,28 @@
-﻿using UnityEngine;
+using UnityEngine;
+using World;
 
 namespace Quests
 {
-    public class QuestRegistrar : MonoBehaviour {
+    /// <summary>
+    /// Registers quests defined in the inspector so they are always available regardless
+    /// of which scene loads first.
+    /// </summary>
+    public class QuestRegistrar : ScenePersistentObject
+    {
+        [Tooltip("Quest definitions that should be registered at startup.")]
         public QuestDefinition[] quests;
-        void Start() {
+
+        protected override void Awake()
+        {
+            base.Awake();
+            DontDestroyOnLoad(gameObject);
+        }
+
+        private void Start()
+        {
+            if (quests == null)
+                return;
+
             foreach (var q in quests)
                 QuestManager.Instance.RegisterQuest(q);
         }

--- a/Assets/Scripts/Quests/QuestUI.cs
+++ b/Assets/Scripts/Quests/QuestUI.cs
@@ -4,13 +4,14 @@ using UnityEngine.UI;
 using Inventory;
 using Player;
 using UI;
+using World;
 
 namespace Quests
 {
     /// <summary>
     /// Simple quest log UI built entirely in code.
     /// </summary>
-    public class QuestUI : MonoBehaviour, IUIWindow
+    public class QuestUI : ScenePersistentObject, IUIWindow
     {
         private RectTransform listContent;
         private Text titleText;
@@ -28,13 +29,15 @@ namespace Quests
 
         public bool IsOpen => canvas != null && canvas.enabled;
 
-        private void Awake()
+        protected override void Awake()
         {
             if (instance != null && instance != this)
             {
                 Destroy(gameObject);
                 return;
             }
+
+            base.Awake();
 
             instance = this;
             name = "QuestUI";

--- a/Assets/Scripts/Shop/ShopUI.cs
+++ b/Assets/Scripts/Shop/ShopUI.cs
@@ -5,6 +5,7 @@ using Inventory;
 using Player;
 using NPC;
 using UI;
+using World;
 
 namespace ShopSystem
 {
@@ -12,7 +13,7 @@ namespace ShopSystem
     /// Runtime generated shop UI used to display items for sale.
     /// </summary>
     [DisallowMultipleComponent]
-    public class ShopUI : MonoBehaviour, IUIWindow
+    public class ShopUI : ScenePersistentObject, IUIWindow
     {
         [Header("Layout")]
         public Vector2 slotSize = new Vector2(32, 32);
@@ -49,7 +50,7 @@ namespace ShopSystem
 
         public bool IsOpen => uiRoot != null && uiRoot.activeSelf;
 
-        private void Awake()
+        protected override void Awake()
         {
             if (instance != null && instance != this)
             {
@@ -58,6 +59,7 @@ namespace ShopSystem
             }
 
             instance = this;
+            base.Awake();
             DontDestroyOnLoad(gameObject);
 
             if (sharedUIRoot == null)

--- a/Assets/Scripts/Skills/Fishing/Bycatch/BycatchManager.cs
+++ b/Assets/Scripts/Skills/Fishing/Bycatch/BycatchManager.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using World;
 
 namespace Skills.Fishing
 {
-    public class BycatchManager : MonoBehaviour
+    public class BycatchManager : ScenePersistentObject
     {
         public BycatchTable bycatchTable;
         public bool useDailySeed = true;
@@ -20,7 +21,7 @@ namespace Skills.Fishing
 
         private static BycatchManager instance;
 
-        private void Awake()
+        protected override void Awake()
         {
             if (instance != null && instance != this)
             {
@@ -29,6 +30,7 @@ namespace Skills.Fishing
             }
 
             instance = this;
+            base.Awake();
             DontDestroyOnLoad(gameObject);
         }
 

--- a/Assets/Scripts/UI/MergeHudTimer.cs
+++ b/Assets/Scripts/UI/MergeHudTimer.cs
@@ -1,20 +1,21 @@
 using System;
 using UnityEngine;
 using UnityEngine.UI;
+using World;
 
 namespace UI
 {
     /// <summary>
     /// Displays the remaining merge time at the top centre of the screen.
     /// </summary>
-    public class MergeHudTimer : MonoBehaviour
+    public class MergeHudTimer : ScenePersistentObject
     {
         [SerializeField] private Font font;
         private Text text;
         private Image background;
         private static MergeHudTimer instance;
 
-        private void Awake()
+        protected override void Awake()
         {
             if (instance != null && instance != this)
             {
@@ -22,6 +23,9 @@ namespace UI
                 return;
             }
             instance = this;
+
+            base.Awake();
+            DontDestroyOnLoad(gameObject);
 
             var canvas = GetComponentInChildren<Canvas>();
             if (canvas == null)

--- a/Assets/Scripts/Util/Ticker.cs
+++ b/Assets/Scripts/Util/Ticker.cs
@@ -1,24 +1,15 @@
 using System.Collections.Generic;
 using UnityEngine;
+using World;
 
 namespace Util
 {
     /// <summary>
     /// Fires an event every OSRS-style tick (0.6 seconds).
     /// </summary>
-    public class Ticker : MonoBehaviour
+    public class Ticker : ScenePersistentObject
     {
         public const float TickDuration = 0.6f;
-
-        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
-        private static void Initialize()
-        {
-            if (Instance == null)
-            {
-                var go = new GameObject(nameof(Ticker));
-                go.AddComponent<Ticker>();
-            }
-        }
 
         public static Ticker Instance { get; private set; }
 
@@ -29,13 +20,15 @@ namespace Util
         [SerializeField]
         private bool logTicks;
 
-        private void Awake()
+        protected override void Awake()
         {
             if (Instance != null && Instance != this)
             {
                 Destroy(gameObject);
                 return;
             }
+            base.Awake();
+
             Instance = this;
             DontDestroyOnLoad(gameObject);
             Debug.Log("Ticker initialized");

--- a/Assets/Scripts/World/PersistentObjectBootstrap.cs
+++ b/Assets/Scripts/World/PersistentObjectBootstrap.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace World
+{
+    /// <summary>
+    /// Ensures a curated list of prefabs exists in every scene.  The prefabs live in
+    /// <c>PersistentObjects.asset</c> under <see cref="Resources"/> and are instantiated
+    /// when missing so cross-scene singletons do not need to be placed manually in each
+    /// scene.
+    /// </summary>
+    [DefaultExecutionOrder(-1000)]
+    public class PersistentObjectBootstrap : MonoBehaviour
+    {
+        /// <summary>
+        /// Default resource path used to load the <see cref="PersistentObjectCatalog"/> asset.
+        /// </summary>
+        public const string CatalogResourcePath = "PersistentObjects";
+
+        [Tooltip("Catalog describing which prefabs must exist in every scene.")]
+        [SerializeField]
+        private PersistentObjectCatalog catalog;
+
+        private static PersistentObjectBootstrap instance;
+
+        /// <summary>
+        /// Makes sure a bootstrapper exists even in empty scenes by creating one before the
+        /// first scene loads.  Developers can still place the component manually when desired.
+        /// </summary>
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        private static void EnsureBootstrapper()
+        {
+            if (instance != null)
+                return;
+
+            var existing = FindObjectOfType<PersistentObjectBootstrap>();
+            if (existing != null)
+            {
+                instance = existing;
+                return;
+            }
+
+            var go = new GameObject(nameof(PersistentObjectBootstrap));
+            instance = go.AddComponent<PersistentObjectBootstrap>();
+        }
+
+        private void Awake()
+        {
+            if (instance != null && instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            instance = this;
+            DontDestroyOnLoad(gameObject);
+
+            if (catalog == null)
+                catalog = Resources.Load<PersistentObjectCatalog>(CatalogResourcePath);
+
+            if (catalog == null)
+            {
+                Debug.LogWarning($"PersistentObjectBootstrap could not locate a catalog at Resources/{CatalogResourcePath}.asset, so no persistent prefabs were spawned.");
+                return;
+            }
+
+            EnsurePersistentObjects();
+        }
+
+        private void OnEnable()
+        {
+            SceneManager.sceneLoaded += HandleSceneLoaded;
+        }
+
+        private void OnDisable()
+        {
+            SceneManager.sceneLoaded -= HandleSceneLoaded;
+        }
+
+        /// <summary>
+        /// Re-runs the spawn routine whenever a new scene becomes active.  This keeps the
+        /// project resilient if a persistent object is accidentally removed at runtime.
+        /// </summary>
+        private void HandleSceneLoaded(Scene scene, LoadSceneMode mode)
+        {
+            EnsurePersistentObjects();
+        }
+
+        /// <summary>
+        /// Instantiates any missing prefabs from the catalog and verifies they include
+        /// <see cref="ScenePersistentObject"/> so they register with
+        /// <see cref="SceneTransitionManager"/> automatically.
+        /// </summary>
+        private void EnsurePersistentObjects()
+        {
+            IReadOnlyList<GameObject> prefabs = catalog.Prefabs;
+            for (int i = 0; i < prefabs.Count; i++)
+            {
+                var prefab = prefabs[i];
+                if (prefab == null)
+                    continue;
+
+                string rootName = prefab.name;
+                if (RootExists(rootName))
+                    continue;
+
+                var instance = Instantiate(prefab);
+                instance.name = rootName;
+
+                if (!TryEnsurePersistentComponent(instance))
+                {
+                    Debug.LogWarning($"Persistent prefab \"{rootName}\" was missing a ScenePersistentObject component. One was added automatically so it is tracked across scenes.", instance);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Checks for a root-level object with the provided name in the active hierarchy or the
+        /// DontDestroyOnLoad scene.
+        /// </summary>
+        private static bool RootExists(string rootName)
+        {
+            var objects = Resources.FindObjectsOfTypeAll<GameObject>();
+            for (int i = 0; i < objects.Length; i++)
+            {
+                var candidate = objects[i];
+                if (!candidate.scene.IsValid())
+                    continue;
+                if (candidate.transform.parent != null)
+                    continue;
+                if (!string.Equals(candidate.name, rootName, StringComparison.Ordinal))
+                    continue;
+                if ((candidate.hideFlags & HideFlags.HideAndDontSave) != 0)
+                    continue;
+
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Ensures the instantiated prefab includes a <see cref="ScenePersistentObject"/>
+        /// so it is registered with the transition system.
+        /// </summary>
+        private static bool TryEnsurePersistentComponent(GameObject instance)
+        {
+            var persistent = instance.GetComponent<ScenePersistentObject>();
+            if (persistent != null)
+                return true;
+
+            persistent = instance.GetComponentInChildren<ScenePersistentObject>();
+            if (persistent != null)
+                return true;
+
+            var behaviours = instance.GetComponentsInChildren<MonoBehaviour>(true);
+            for (int i = 0; i < behaviours.Length; i++)
+            {
+                if (behaviours[i] is IScenePersistent)
+                    return true;
+            }
+
+            instance.AddComponent<ScenePersistentObject>();
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Scriptable object containing the prefabs required in every scene.  Stored under
+    /// <see cref="Resources"/> so it can be loaded automatically by the bootstrapper.
+    /// </summary>
+    [CreateAssetMenu(menuName = "World/Persistent Object Catalog", fileName = "PersistentObjects")]
+    public sealed class PersistentObjectCatalog : ScriptableObject
+    {
+        [SerializeField]
+        [Tooltip("Prefabs that should be spawned automatically if they are missing from the scene.")]
+        private List<GameObject> prefabs = new();
+
+        /// <summary>
+        /// Read-only view of the prefabs used by the bootstrapper.
+        /// </summary>
+        public IReadOnlyList<GameObject> Prefabs => prefabs;
+
+#if UNITY_EDITOR
+        private void OnValidate()
+        {
+            // Filter out scene instances that may have been dragged in by mistake to keep the
+            // list focused on prefabs only.
+            for (int i = prefabs.Count - 1; i >= 0; i--)
+            {
+                var entry = prefabs[i];
+                if (entry == null)
+                    continue;
+
+                if (entry.scene.IsValid())
+                {
+                    Debug.LogWarning($"Removed scene object '{entry.name}' from {name}. Drag prefab assets into the list instead.", this);
+                    prefabs.RemoveAt(i);
+                }
+            }
+        }
+#endif
+    }
+}

--- a/Assets/Scripts/World/PersistentObjectBootstrap.cs.meta
+++ b/Assets/Scripts/World/PersistentObjectBootstrap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 39d5ec0af0a74b118ef78cfdd213a250
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/World/ScenePersistentObject.cs
+++ b/Assets/Scripts/World/ScenePersistentObject.cs
@@ -14,7 +14,12 @@ namespace World
         // alongside the existing instance that was carried over via
         // DontDestroyOnLoad, leading to duplicated managers and HUD
         // elements.
-        void Awake()
+        /// <summary>
+        /// Performs duplicate detection so only a single copy of the object survives
+        /// scene loads.  Derived classes should call the base implementation when
+        /// overriding <see cref="Awake"/>.
+        /// </summary>
+        protected virtual void Awake()
         {
             var others = FindObjectsOfType<ScenePersistentObject>();
             foreach (var obj in others)

--- a/Assets/Scripts/World/SceneTransitionManager.cs
+++ b/Assets/Scripts/World/SceneTransitionManager.cs
@@ -8,7 +8,7 @@ namespace World
     /// <summary>
     /// Manages moving key objects between scenes and handling fade transitions.
     /// </summary>
-    public class SceneTransitionManager : MonoBehaviour
+    public class SceneTransitionManager : ScenePersistentObject
     {
         public static SceneTransitionManager Instance;
         public static bool IsTransitioning;
@@ -31,13 +31,15 @@ namespace World
                 _persistentObjects.Remove(obj);
         }
 
-        private void Awake()
+        protected override void Awake()
         {
             if (Instance != null && Instance != this)
             {
                 Destroy(gameObject);
                 return;
             }
+
+            base.Awake();
 
             Instance = this;
             DontDestroyOnLoad(gameObject);

--- a/Assets/Scripts/World/ScreenFader.cs
+++ b/Assets/Scripts/World/ScreenFader.cs
@@ -7,7 +7,7 @@ namespace World
     /// <summary>
     /// Handles fading the screen in and out using a full screen canvas.
     /// </summary>
-    public class ScreenFader : MonoBehaviour
+    public class ScreenFader : ScenePersistentObject
     {
         public static ScreenFader Instance;
 
@@ -16,13 +16,15 @@ namespace World
 
         private CanvasGroup _group;
 
-        private void Awake()
+        protected override void Awake()
         {
             if (Instance != null && Instance != this)
             {
                 Destroy(gameObject);
                 return;
             }
+
+            base.Awake();
 
             Instance = this;
             DontDestroyOnLoad(gameObject);


### PR DESCRIPTION
## Summary
- add a `PersistentObjectBootstrap` runtime component and catalog asset to spawn required cross-scene prefabs from `Resources`
- convert core singletons (GameManager, SceneTransitionManager, ScreenFader, Ticker, etc.) to derive from `ScenePersistentObject`
- author prefabs for services (ItemDatabase, ShopUI, PlayerRespawnSystem, ScreenFader) and register them in `PersistentObjects.asset`

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68c944e789f0832eb12b39cc8cdeb66c