### PR TITLE
Rely on ScenePersistentObject for persistence management

### DIFF
--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -52,7 +52,6 @@ namespace Core
             base.Awake();
 
             Instance = this;
-            DontDestroyOnLoad(gameObject);
 
             CacheServices(false);
         }

--- a/Assets/Scripts/Dialogue/DialogueManager.cs
+++ b/Assets/Scripts/Dialogue/DialogueManager.cs
@@ -26,7 +26,6 @@ namespace Dialogue
             base.Awake();
 
             Instance = this;
-            DontDestroyOnLoad(gameObject);
 
             ui = gameObject.AddComponent<DialogueUI>();
         }

--- a/Assets/Scripts/Inventory/ItemDatabase.cs
+++ b/Assets/Scripts/Inventory/ItemDatabase.cs
@@ -50,7 +50,6 @@ namespace Inventory
 
             instance = this;
             base.Awake();
-            DontDestroyOnLoad(gameObject);
 
             var loadedItems = Resources.LoadAll<ItemData>("Item");
             foreach (var item in loadedItems)

--- a/Assets/Scripts/Player/CameraFollow2D.cs
+++ b/Assets/Scripts/Player/CameraFollow2D.cs
@@ -28,7 +28,6 @@ namespace Player
         {
             base.Awake();
             cam = GetComponent<Camera>();
-            DontDestroyOnLoad(gameObject);
         }
 
         void LateUpdate()

--- a/Assets/Scripts/Player/PlayerRespawnSystem.cs
+++ b/Assets/Scripts/Player/PlayerRespawnSystem.cs
@@ -31,7 +31,6 @@ namespace Player
 
             Instance = this;
             base.Awake();
-            DontDestroyOnLoad(gameObject);
         }
 
         private void OnEnable()

--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -33,7 +33,6 @@ namespace Quests
             base.Awake();
 
             Instance = this;
-            DontDestroyOnLoad(gameObject);
 
             if (QuestsUpdated == null)
                 QuestsUpdated = new UnityEvent();

--- a/Assets/Scripts/Quests/QuestRegistrar.cs
+++ b/Assets/Scripts/Quests/QuestRegistrar.cs
@@ -15,7 +15,6 @@ namespace Quests
         protected override void Awake()
         {
             base.Awake();
-            DontDestroyOnLoad(gameObject);
         }
 
         private void Start()

--- a/Assets/Scripts/Quests/QuestUI.cs
+++ b/Assets/Scripts/Quests/QuestUI.cs
@@ -47,7 +47,6 @@ namespace Quests
             gameObject.AddComponent<GraphicRaycaster>();
 
             BuildLayout();
-            DontDestroyOnLoad(gameObject);
             canvas.enabled = false;
             playerMover = FindObjectOfType<PlayerMover>();
             UIManager.Instance.RegisterWindow(this);

--- a/Assets/Scripts/Shop/ShopUI.cs
+++ b/Assets/Scripts/Shop/ShopUI.cs
@@ -60,7 +60,6 @@ namespace ShopSystem
 
             instance = this;
             base.Awake();
-            DontDestroyOnLoad(gameObject);
 
             if (sharedUIRoot == null)
                 sharedUIRoot = GameObject.Find("ShopUI");

--- a/Assets/Scripts/Skills/Fishing/Bycatch/BycatchManager.cs
+++ b/Assets/Scripts/Skills/Fishing/Bycatch/BycatchManager.cs
@@ -31,7 +31,6 @@ namespace Skills.Fishing
 
             instance = this;
             base.Awake();
-            DontDestroyOnLoad(gameObject);
         }
 
         public int GetStreak(WaterType wt)

--- a/Assets/Scripts/UI/MergeHudTimer.cs
+++ b/Assets/Scripts/UI/MergeHudTimer.cs
@@ -25,7 +25,6 @@ namespace UI
             instance = this;
 
             base.Awake();
-            DontDestroyOnLoad(gameObject);
 
             var canvas = GetComponentInChildren<Canvas>();
             if (canvas == null)

--- a/Assets/Scripts/Util/Ticker.cs
+++ b/Assets/Scripts/Util/Ticker.cs
@@ -30,7 +30,6 @@ namespace Util
             base.Awake();
 
             Instance = this;
-            DontDestroyOnLoad(gameObject);
             Debug.Log("Ticker initialized");
         }
 

--- a/Assets/Scripts/World/ScenePersistentObject.cs
+++ b/Assets/Scripts/World/ScenePersistentObject.cs
@@ -21,7 +21,7 @@ namespace World
         /// </summary>
         protected virtual void Awake()
         {
-            var others = FindObjectsOfType<ScenePersistentObject>();
+            var others = FindObjectsOfType<ScenePersistentObject>(true);
             foreach (var obj in others)
             {
                 if (obj != this && obj.gameObject.name == gameObject.name)

--- a/Assets/Scripts/World/SceneTransitionManager.cs
+++ b/Assets/Scripts/World/SceneTransitionManager.cs
@@ -42,7 +42,6 @@ namespace World
             base.Awake();
 
             Instance = this;
-            DontDestroyOnLoad(gameObject);
         }
 
         public IEnumerator Transition(string sceneToLoad, string spawnPointName, string requiredItemId, bool removeItemOnUse)

--- a/Assets/Scripts/World/ScreenFader.cs
+++ b/Assets/Scripts/World/ScreenFader.cs
@@ -27,7 +27,6 @@ namespace World
             base.Awake();
 
             Instance = this;
-            DontDestroyOnLoad(gameObject);
 
             var canvas = GetComponentInChildren<Canvas>();
             if (canvas == null)


### PR DESCRIPTION
## Summary
- remove redundant DontDestroyOnLoad calls from every ScenePersistentObject-derived singleton so persistence flows through the shared lifecycle hooks
- allow ScenePersistentObject to detect duplicates even when inactive by passing includeInactive to FindObjectsOfType

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68c95983a1a0832e814d51a4b4f3c26d