### PR TITLE
Keep persistent prefabs across scene transitions

### DIFF
--- a/Assets/Scripts/World/PersistentObjectBootstrap.cs
+++ b/Assets/Scripts/World/PersistentObjectBootstrap.cs
@@ -108,6 +108,8 @@ namespace World
 
                 var instance = Instantiate(prefab);
                 instance.name = rootName;
+                // Prevent required objects—such as the main camera—from being destroyed before the initial scene transition.
+                DontDestroyOnLoad(instance);
 
                 if (!TryEnsurePersistentComponent(instance))
                 {


### PR DESCRIPTION
## Summary
- ensure instantiated persistent prefabs are moved into the DontDestroyOnLoad scene
- explain that the step protects critical objects like the main camera prior to scene changes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c960483b7c832e964a921e3778eb84