### PR TITLE
Ensure persistent object keeps earliest instance

### DIFF
--- a/Assets/Scripts/World/ScenePersistentObject.cs
+++ b/Assets/Scripts/World/ScenePersistentObject.cs
@@ -21,13 +21,61 @@ namespace World
         /// </summary>
         protected virtual void Awake()
         {
+            // Gather every persistent object so we can determine which instance
+            // should be allowed to survive.  Each prefab / scene setup can only
+            // have a single persistent representative, otherwise a camera, UI, or
+            // manager duplicated across scenes would start stacking up and spam
+            // warnings like "No cameras rendering" as duplicates get disabled.
             var others = FindObjectsOfType<ScenePersistentObject>(true);
+
+            // Track whether a lower instance ID already exists.  Unity assigns
+            // monotonically increasing instance IDs, so the very first copy of a
+            // prefab receives the smallest ID value.  By preserving the lowest ID
+            // we guarantee the original object persists and any later scene load
+            // clones are culled immediately.
+            bool hasLowerInstance = false;
+            int thisId = GetInstanceID();
+
             foreach (var obj in others)
             {
-                if (obj != this && obj.gameObject.name == gameObject.name)
+                // Ignore unrelated persistent objects.
+                if (obj == this || obj.gameObject.name != gameObject.name)
                 {
-                    Destroy(gameObject);
-                    return;
+                    continue;
+                }
+
+                int otherId = obj.GetInstanceID();
+
+                if (otherId < thisId)
+                {
+                    // A lower ID means a pre-existing instance is already
+                    // persistent.  Mark this instance for destruction.
+                    hasLowerInstance = true;
+                    break;
+                }
+            }
+
+            if (hasLowerInstance)
+            {
+                // A prior persistent instance exists – destroy the newcomer so
+                // the original remains the sole survivor across scenes.
+                Destroy(gameObject);
+                return;
+            }
+
+            // This is the first instance, so remove any higher-ID duplicates to
+            // enforce singleton behaviour before they can execute additional
+            // lifecycle logic.
+            foreach (var obj in others)
+            {
+                if (obj == this || obj.gameObject.name != gameObject.name)
+                {
+                    continue;
+                }
+
+                if (obj.GetInstanceID() > thisId)
+                {
+                    Destroy(obj.gameObject);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- update ScenePersistentObject duplicate detection to preserve the earliest instance by comparing instance IDs
- destroy higher instance-ID duplicates to prevent multiple persistent cameras from stacking across scene loads

## Testing
- not run (Unity Editor not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68c962804740832eb5b3e9841e079d7a