### PR TITLE
Fix MergeHudTimer lookup for inactive HUDs

### DIFF
--- a/Assets/Scripts/Skills/Beastmaster/PetMergeController.cs
+++ b/Assets/Scripts/Skills/Beastmaster/PetMergeController.cs
@@ -67,7 +67,7 @@ namespace Beastmaster
             petService = petServiceComponent as IPetService;
 
             if (hudTimer == null)
-                hudTimer = GetComponentInChildren<MergeHudTimer>(true) ?? FindObjectOfType<MergeHudTimer>();
+                hudTimer = GetComponentInChildren<MergeHudTimer>(true) ?? FindObjectOfType<MergeHudTimer>(true);
             if (playerMover == null)
                 playerMover = GetComponent<PlayerMover>();
 


### PR DESCRIPTION
## Summary
- allow PetMergeController to locate MergeHudTimer components even when inactive by searching inactive objects

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c966cf8a8c832eb74fa7eee91192ef