### PR TITLE
Fix pointer UI hover detection for Input System 1.14

### DIFF
--- a/Assets/Scripts/NPC/Interaction/NpcInteractable.cs
+++ b/Assets/Scripts/NPC/Interaction/NpcInteractable.cs
@@ -164,7 +164,24 @@ namespace NPC
             if (pointer == null)
                 return false;
 
-            return module.IsPointerOverGameObject(pointer.pointerId);
+            if (pointer is Touchscreen touchscreen)
+            {
+                var touches = touchscreen.touches;
+                for (int i = 0; i < touches.Count; i++)
+                {
+                    var touchControl = touches[i];
+                    if (!touchControl.press.isPressed)
+                        continue;
+
+                    int touchId = touchControl.touchId.ReadValue();
+                    if (module.IsPointerOverGameObject(touchId))
+                        return true;
+                }
+
+                return module.IsPointerOverGameObject(touchscreen.deviceId);
+            }
+
+            return module.IsPointerOverGameObject(pointer.deviceId);
         }
 
         public virtual void Talk()

--- a/Assets/Scripts/NPC/Interaction/NpcShopOpener.cs
+++ b/Assets/Scripts/NPC/Interaction/NpcShopOpener.cs
@@ -141,7 +141,26 @@ namespace NPC
             if (pointer == null)
                 return false;
 
-            return module.IsPointerOverGameObject(pointer.pointerId);
+            // Input System 1.14 removed Pointer.pointerId. Device ids and explicit touch ids must
+            // now be supplied when querying the UI module, so we mirror Unity's recommendations.
+            if (pointer is Touchscreen touchscreen)
+            {
+                var touches = touchscreen.touches;
+                for (int i = 0; i < touches.Count; i++)
+                {
+                    var touchControl = touches[i];
+                    if (!touchControl.press.isPressed)
+                        continue;
+
+                    int touchId = touchControl.touchId.ReadValue();
+                    if (module.IsPointerOverGameObject(touchId))
+                        return true;
+                }
+
+                return module.IsPointerOverGameObject(touchscreen.deviceId);
+            }
+
+            return module.IsPointerOverGameObject(pointer.deviceId);
         }
     }
 }

--- a/Assets/Scripts/Skills/Common/GatheringController.cs
+++ b/Assets/Scripts/Skills/Common/GatheringController.cs
@@ -445,7 +445,24 @@ namespace Skills.Common
             if (pointer == null)
                 return false;
 
-            return module.IsPointerOverGameObject(pointer.pointerId);
+            if (pointer is Touchscreen touchscreen)
+            {
+                var touches = touchscreen.touches;
+                for (int i = 0; i < touches.Count; i++)
+                {
+                    var touchControl = touches[i];
+                    if (!touchControl.press.isPressed)
+                        continue;
+
+                    int touchId = touchControl.touchId.ReadValue();
+                    if (module.IsPointerOverGameObject(touchId))
+                        return true;
+                }
+
+                return module.IsPointerOverGameObject(touchscreen.deviceId);
+            }
+
+            return module.IsPointerOverGameObject(pointer.deviceId);
         }
 
         /// <summary>

--- a/Assets/Scripts/World/Door.cs
+++ b/Assets/Scripts/World/Door.cs
@@ -126,7 +126,24 @@ namespace World
             if (pointer == null)
                 return false;
 
-            return module.IsPointerOverGameObject(pointer.pointerId);
+            if (pointer is Touchscreen touchscreen)
+            {
+                var touches = touchscreen.touches;
+                for (int i = 0; i < touches.Count; i++)
+                {
+                    var touchControl = touches[i];
+                    if (!touchControl.press.isPressed)
+                        continue;
+
+                    int touchId = touchControl.touchId.ReadValue();
+                    if (module.IsPointerOverGameObject(touchId))
+                        return true;
+                }
+
+                return module.IsPointerOverGameObject(touchscreen.deviceId);
+            }
+
+            return module.IsPointerOverGameObject(pointer.deviceId);
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace the deprecated `Pointer.pointerId` usage with device and touch identifiers in the UI hover checks used by shop, interaction, door, and gathering systems
- add explicit support for multi-touch devices when evaluating whether interactions should be blocked by UI elements

## Testing
- not run (requires Unity editor)

------
https://chatgpt.com/codex/tasks/task_e_68c96eb76d4c832eba4cd94c105a7711