### PR TITLE
Use EventSystem pointer checks across UI gating

### DIFF
--- a/Assets/Scripts/NPC/Interaction/NpcInteractable.cs
+++ b/Assets/Scripts/NPC/Interaction/NpcInteractable.cs
@@ -2,7 +2,6 @@ using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.EventSystems;
 using UnityEngine.InputSystem;
-using UnityEngine.InputSystem.UI;
 using ShopSystem;
 using Pets;
 using Combat;
@@ -157,14 +156,9 @@ namespace NPC
             if (EventSystem.current == null)
                 return false;
 
-            if (!(EventSystem.current.currentInputModule is InputSystemUIInputModule module))
-                return false;
-
-            Pointer pointer = Pointer.current;
-            if (pointer == null)
-                return false;
-
-            if (pointer is Touchscreen touchscreen)
+            // Evaluate active touches first so mobile presses correctly block world interactions.
+            Touchscreen touchscreen = Touchscreen.current;
+            if (touchscreen != null)
             {
                 var touches = touchscreen.touches;
                 for (int i = 0; i < touches.Count; i++)
@@ -173,15 +167,17 @@ namespace NPC
                     if (!touchControl.press.isPressed)
                         continue;
 
-                    int touchId = touchControl.touchId.ReadValue();
-                    if (module.IsPointerOverGameObject(touchId))
+                    if (EventSystem.current.IsPointerOverGameObject(touchControl.touchId.ReadValue()))
                         return true;
                 }
-
-                return module.IsPointerOverGameObject(touchscreen.deviceId);
             }
 
-            return module.IsPointerOverGameObject(pointer.deviceId);
+            // If a mouse or pen pointer is available, rely on the default EventSystem behaviour.
+            Pointer pointer = Pointer.current;
+            if (pointer != null && !(pointer is Touchscreen))
+                return EventSystem.current.IsPointerOverGameObject();
+
+            return false;
         }
 
         public virtual void Talk()

--- a/Assets/Scripts/Skills/Common/GatheringController.cs
+++ b/Assets/Scripts/Skills/Common/GatheringController.cs
@@ -1,7 +1,6 @@
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.InputSystem;
-using UnityEngine.InputSystem.UI;
 using Player;
 using UI;
 using Core.Input;
@@ -438,14 +437,9 @@ namespace Skills.Common
             if (EventSystem.current == null)
                 return false;
 
-            if (!(EventSystem.current.currentInputModule is InputSystemUIInputModule module))
-                return false;
-
-            Pointer pointer = Pointer.current;
-            if (pointer == null)
-                return false;
-
-            if (pointer is Touchscreen touchscreen)
+            // Evaluate active touches first so mobile presses correctly block gathering interactions.
+            Touchscreen touchscreen = Touchscreen.current;
+            if (touchscreen != null)
             {
                 var touches = touchscreen.touches;
                 for (int i = 0; i < touches.Count; i++)
@@ -454,15 +448,17 @@ namespace Skills.Common
                     if (!touchControl.press.isPressed)
                         continue;
 
-                    int touchId = touchControl.touchId.ReadValue();
-                    if (module.IsPointerOverGameObject(touchId))
+                    if (EventSystem.current.IsPointerOverGameObject(touchControl.touchId.ReadValue()))
                         return true;
                 }
-
-                return module.IsPointerOverGameObject(touchscreen.deviceId);
             }
 
-            return module.IsPointerOverGameObject(pointer.deviceId);
+            // If a mouse or pen pointer is available, rely on the default EventSystem behaviour.
+            Pointer pointer = Pointer.current;
+            if (pointer != null && !(pointer is Touchscreen))
+                return EventSystem.current.IsPointerOverGameObject();
+
+            return false;
         }
 
         /// <summary>

--- a/Assets/Scripts/World/Door.cs
+++ b/Assets/Scripts/World/Door.cs
@@ -2,7 +2,6 @@ using System.Collections;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.InputSystem;
-using UnityEngine.InputSystem.UI;
 
 namespace World
 {
@@ -112,21 +111,16 @@ namespace World
         private void OnTransitionCompleted() => _transitioning = false;
 
         /// <summary>
-        ///     Checks whether the pointer is hovering a UI element managed by the Input System UI module.
+        ///     Checks whether the pointer is hovering a UI element registered with the active <see cref="EventSystem"/>.
         /// </summary>
         private static bool IsPointerOverUI()
         {
             if (EventSystem.current == null)
                 return false;
 
-            if (!(EventSystem.current.currentInputModule is InputSystemUIInputModule module))
-                return false;
-
-            Pointer pointer = Pointer.current;
-            if (pointer == null)
-                return false;
-
-            if (pointer is Touchscreen touchscreen)
+            // Evaluate active touches first so mobile presses correctly block door usage.
+            Touchscreen touchscreen = Touchscreen.current;
+            if (touchscreen != null)
             {
                 var touches = touchscreen.touches;
                 for (int i = 0; i < touches.Count; i++)
@@ -135,15 +129,17 @@ namespace World
                     if (!touchControl.press.isPressed)
                         continue;
 
-                    int touchId = touchControl.touchId.ReadValue();
-                    if (module.IsPointerOverGameObject(touchId))
+                    if (EventSystem.current.IsPointerOverGameObject(touchControl.touchId.ReadValue()))
                         return true;
                 }
-
-                return module.IsPointerOverGameObject(touchscreen.deviceId);
             }
 
-            return module.IsPointerOverGameObject(pointer.deviceId);
+            // If a mouse or pen pointer is available, rely on the default EventSystem behaviour.
+            Pointer pointer = Pointer.current;
+            if (pointer != null && !(pointer is Touchscreen))
+                return EventSystem.current.IsPointerOverGameObject();
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace direct InputSystemUIInputModule queries with EventSystem.current.IsPointerOverGameObject in all pointer gating helpers
- iterate active touches to honour UI blocking for mobile presses before evaluating mouse or pen pointers
- drop references to the Input System UI module and pointer device IDs in favour of unified EventSystem checks

## Testing
- not run (not supported in container)

------
https://chatgpt.com/codex/tasks/task_e_68c972b3e4c4832eb1d14b95979cfd15