### PR TITLE
Ensure runtime singletons persist across scene transitions

### DIFF
--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -15,7 +15,7 @@ namespace Player
     [RequireComponent(typeof(Rigidbody2D))]
     [RequireComponent(typeof(Animator))]
     [RequireComponent(typeof(SpriteRenderer))]
-    public class PlayerMover : MonoBehaviour, IScenePersistent
+    public class PlayerMover : ScenePersistentObject
     {
         [Header("Movement")]
         public float moveSpeed = 3.5f;
@@ -75,8 +75,10 @@ namespace Player
         private InputAction moveAction;
 #endif
 
-        void Awake()
+        protected override void Awake()
         {
+            base.Awake();
+
             // Destroy any duplicate player instances that might exist in
             // newly loaded scenes before they can register themselves as
             // persistent objects.  This prevents two players from
@@ -109,7 +111,6 @@ namespace Player
 
             SceneTransitionManager.TransitionStarted += OnTransitionStarted;
             SceneTransitionManager.TransitionCompleted += OnTransitionCompleted;
-            SceneTransitionManager.RegisterPersistentObject(this);
         }
 
 #if ENABLE_INPUT_SYSTEM
@@ -151,7 +152,6 @@ namespace Player
 
             SceneTransitionManager.TransitionStarted -= OnTransitionStarted;
             SceneTransitionManager.TransitionCompleted -= OnTransitionCompleted;
-            SceneTransitionManager.UnregisterPersistentObject(this);
         }
 
         void Update()
@@ -480,13 +480,15 @@ namespace Player
                 transform.position = new Vector3(data.x, data.y, data.z);
         }
 
-        public void OnBeforeSceneUnload()
+        public override void OnBeforeSceneUnload()
         {
-            DontDestroyOnLoad(gameObject);
+            base.OnBeforeSceneUnload();
         }
 
-        public void OnAfterSceneLoad(Scene scene)
+        public override void OnAfterSceneLoad(Scene scene)
         {
+            base.OnAfterSceneLoad(scene);
+
             var spawnId = SceneTransitionManager.NextSpawnPoint;
             if (!string.IsNullOrEmpty(spawnId))
             {
@@ -501,7 +503,6 @@ namespace Player
                 }
             }
 
-            SceneManager.MoveGameObjectToScene(gameObject, scene);
             var players = GameObject.FindGameObjectsWithTag("Player");
             foreach (var p in players)
             {

--- a/Assets/Scripts/UI/AttackStyleUI.cs
+++ b/Assets/Scripts/UI/AttackStyleUI.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using Combat;
 using Player;
+using World;
 
 namespace UI
 {
@@ -27,6 +28,9 @@ namespace UI
                 return;
 
             var go = new GameObject("AttackStyleUI");
+            // Ensure the UI survives scene loads and is tracked by the transition system so it
+            // can be re-parented into the active scene after a door transition.
+            go.AddComponent<ScenePersistentObject>();
             UnityEngine.Object.DontDestroyOnLoad(go);
             go.AddComponent<AttackStyleUI>();
         }

--- a/Assets/Scripts/World/ScenePersistentObject.cs
+++ b/Assets/Scripts/World/ScenePersistentObject.cs
@@ -90,12 +90,12 @@ namespace World
             SceneTransitionManager.UnregisterPersistentObject(this);
         }
 
-        public void OnBeforeSceneUnload()
+        public virtual void OnBeforeSceneUnload()
         {
             DontDestroyOnLoad(gameObject);
         }
 
-        public void OnAfterSceneLoad(Scene scene)
+        public virtual void OnAfterSceneLoad(Scene scene)
         {
             SceneManager.MoveGameObjectToScene(gameObject, scene);
         }


### PR DESCRIPTION
## Summary
- allow ScenePersistentObject subclasses to extend the default move/dont-destroy hooks
- register the runtime AttackStyleUI with the persistence system so it survives door loads
- migrate PlayerMover to ScenePersistentObject so the player automatically persists and re-parents during transitions

## Testing
- Not run (Unity Editor required)

------
https://chatgpt.com/codex/tasks/task_e_68c97f302834832eb48d788de615974c