### PR TITLE
Centralize hitsplat sprites via HitSplatLibrary

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -40,10 +40,13 @@ namespace Combat
         private int pendingMaxHit;
         private SpellElement pendingElement;
 
+        [SerializeField, Tooltip("Centralised hitsplat sprite references assigned via the inspector.")]
+        private HitSplatLibrary hitSplatLibrary;
+
         private Sprite damageHitsplat;
         private Sprite zeroHitsplat;
         private Sprite maxHitHitsplat;
-        private Dictionary<SpellElement, Sprite> elementHitsplats;
+        private IReadOnlyDictionary<SpellElement, Sprite> elementHitsplats;
 
         private void Awake()
         {
@@ -65,19 +68,17 @@ namespace Combat
             if (skills != null)
                 skills.LevelChanged += OnSkillLevelChanged;
 
-            damageHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Damage_hitsplat");
-            zeroHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Zero_damage_hitsplat");
-            maxHitHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Damage_hitsplat_maxhit");
-
-            elementHitsplats = new Dictionary<SpellElement, Sprite>
+            if (hitSplatLibrary == null)
             {
-                { SpellElement.Air, Resources.Load<Sprite>("Sprites/HitSplats/Air_hitsplat") },
-                { SpellElement.Water, Resources.Load<Sprite>("Sprites/HitSplats/Water_hitsplat") },
-                { SpellElement.Earth, Resources.Load<Sprite>("Sprites/HitSplats/Earth_hitsplat") },
-                { SpellElement.Electric, Resources.Load<Sprite>("Sprites/HitSplats/Electrocute_hitsplat") },
-                { SpellElement.Ice, Resources.Load<Sprite>("Sprites/HitSplats/Water_hitsplat") },
-                { SpellElement.Fire, Resources.Load<Sprite>("Sprites/HitSplats/Burn_hitsplat") }
-            };
+                Debug.LogError("CombatController requires a HitSplatLibrary reference. Assign one in the inspector.", this);
+            }
+            else
+            {
+                damageHitsplat = hitSplatLibrary.DamageHitsplat;
+                zeroHitsplat = hitSplatLibrary.ZeroDamageHitsplat;
+                maxHitHitsplat = hitSplatLibrary.MaxHitHitsplat;
+                elementHitsplats = hitSplatLibrary.ElementHitsplats;
+            }
         }
 
         /// <summary>

--- a/Assets/Scripts/Combat/HitSplatLibrary.cs
+++ b/Assets/Scripts/Combat/HitSplatLibrary.cs
@@ -1,0 +1,143 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Combat
+{
+    /// <summary>
+    /// ScriptableObject that centralises every hitsplat sprite so gameplay systems can
+    /// reference them without performing runtime Resources.Load calls.
+    /// </summary>
+    [CreateAssetMenu(fileName = "HitSplatLibrary", menuName = "Combat/Hit Splat Library")]
+    public class HitSplatLibrary : ScriptableObject
+    {
+        /// <summary>
+        /// Simple pairing of an elemental affinity with the sprite that should represent it.
+        /// Serialized so designers can configure the mapping directly in the inspector.
+        /// </summary>
+        [System.Serializable]
+        private struct ElementHitSplat
+        {
+            [Tooltip("The elemental affinity these hitsplat visuals belong to.")]
+            public SpellElement element;
+
+            [Tooltip("Sprite displayed when damage is dealt with the configured element.")]
+            public Sprite sprite;
+        }
+
+        [Header("Core Hitsplat Sprites")]
+        [Tooltip("Default sprite displayed for non-elemental successful hits.")]
+        [SerializeField] private Sprite damageHitsplat;
+
+        [Tooltip("Sprite displayed when an attack deals zero damage.")]
+        [SerializeField] private Sprite zeroDamageHitsplat;
+
+        [Tooltip("Sprite used when the attacker rolls their maximum possible hit.")]
+        [SerializeField] private Sprite maxHitHitsplat;
+
+        [Tooltip("Sprite used for damage caused by burning effects.")]
+        [SerializeField] private Sprite burnHitsplat;
+
+        [Tooltip("Sprite used for damage caused by poison effects.")]
+        [SerializeField] private Sprite poisonHitsplat;
+
+        [Header("Elemental Hitsplat Overrides")]
+        [Tooltip("Overrides that map elemental spell damage to themed hitsplat sprites.")]
+        [SerializeField] private ElementHitSplat[] elementalHitsplats;
+
+        /// <summary>
+        /// Runtime lookup built from the serialized array so systems can grab sprites quickly.
+        /// </summary>
+        private readonly Dictionary<SpellElement, Sprite> elementLookup = new Dictionary<SpellElement, Sprite>();
+
+        /// <summary>
+        /// Tracks whether the lookup must be rebuilt due to inspector edits or asset reloads.
+        /// </summary>
+        private bool elementLookupDirty = true;
+
+        /// <summary>Sprite displayed for standard damaging hits.</summary>
+        public Sprite DamageHitsplat => damageHitsplat;
+
+        /// <summary>Sprite displayed when an attack misses or deals zero damage.</summary>
+        public Sprite ZeroDamageHitsplat => zeroDamageHitsplat;
+
+        /// <summary>Sprite displayed when the attacker achieves their maximum hit.</summary>
+        public Sprite MaxHitHitsplat => maxHitHitsplat;
+
+        /// <summary>Sprite displayed when damage comes from a burning effect.</summary>
+        public Sprite BurnHitsplat => burnHitsplat;
+
+        /// <summary>Sprite displayed when damage comes from a poison effect.</summary>
+        public Sprite PoisonHitsplat => poisonHitsplat;
+
+        /// <summary>
+        /// Provides a cached, read-only dictionary containing every configured elemental sprite.
+        /// Consumers can cache the result or query it directly whenever they need an elemental hitsplat.
+        /// </summary>
+        public IReadOnlyDictionary<SpellElement, Sprite> ElementHitsplats
+        {
+            get
+            {
+                EnsureLookup();
+                return elementLookup;
+            }
+        }
+
+        /// <summary>
+        /// Fetch the sprite assigned to a specific elemental affinity.
+        /// Returns null if the element is unconfigured or represents the "None" type.
+        /// </summary>
+        public Sprite GetElementHitsplat(SpellElement element)
+        {
+            if (element == SpellElement.None)
+                return null;
+
+            EnsureLookup();
+            elementLookup.TryGetValue(element, out var sprite);
+            return sprite;
+        }
+
+        /// <summary>
+        /// Ensures the runtime dictionary reflects the serialized inspector data.
+        /// Only rebuilds when flagged dirty to avoid unnecessary allocations at runtime.
+        /// </summary>
+        private void EnsureLookup()
+        {
+            if (!elementLookupDirty)
+                return;
+
+            elementLookup.Clear();
+            if (elementalHitsplats != null)
+            {
+                for (int i = 0; i < elementalHitsplats.Length; i++)
+                {
+                    var entry = elementalHitsplats[i];
+                    if (entry.sprite == null || entry.element == SpellElement.None)
+                        continue;
+
+                    elementLookup[entry.element] = entry.sprite;
+                }
+            }
+
+            elementLookupDirty = false;
+        }
+
+        /// <summary>
+        /// Unity callback invoked when the asset becomes active. Marks the lookup as dirty so it
+        /// will rebuild using the most up-to-date inspector data the next time it is queried.
+        /// </summary>
+        private void OnEnable()
+        {
+            elementLookupDirty = true;
+        }
+
+#if UNITY_EDITOR
+        /// <summary>
+        /// Ensures the lookup refreshes immediately when values change inside the editor.
+        /// </summary>
+        private void OnValidate()
+        {
+            elementLookupDirty = true;
+        }
+#endif
+    }
+}

--- a/Assets/Scripts/NPC/Combat/NpcCombatant.cs
+++ b/Assets/Scripts/NPC/Combat/NpcCombatant.cs
@@ -15,6 +15,8 @@ namespace NPC
     public class NpcCombatant : MonoBehaviour, CombatTarget, IFactionProvider
     {
         [SerializeField] private NpcCombatProfile profile;
+        [SerializeField, Tooltip("Centralised hitsplat sprite references assigned via the inspector.")]
+        private HitSplatLibrary hitSplatLibrary;
         private int currentHp;
         private Collider2D collider2D;
         private SpriteRenderer spriteRenderer;
@@ -46,7 +48,14 @@ namespace NPC
             wanderer = GetComponent<NpcWanderer>();
             ResetDamageCounters();
             OnHealthChanged?.Invoke(currentHp, MaxHP);
-            poisonHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Poison_hitsplat");
+            if (hitSplatLibrary == null)
+            {
+                Debug.LogError("NpcCombatant requires a HitSplatLibrary reference. Assign one in the inspector.", this);
+            }
+            else
+            {
+                poisonHitsplat = hitSplatLibrary.PoisonHitsplat;
+            }
 
             if (profile != null && profile.IsPoisonous && profile.OnHitPoison != null)
             {

--- a/Assets/Scripts/Pets/PetCombatController.cs
+++ b/Assets/Scripts/Pets/PetCombatController.cs
@@ -18,6 +18,9 @@ namespace Pets
         public PetDefinition definition;
         public float moveSpeed = 5f;
 
+        [SerializeField, Tooltip("Centralised hitsplat sprite references assigned via the inspector.")]
+        private HitSplatLibrary hitSplatLibrary;
+
         private PetFollower follower;
         private Animator animator;
         private SpriteRenderer spriteRenderer;
@@ -50,9 +53,16 @@ namespace Pets
             if (TryGetComponent<Collider2D>(out var col2d))
                 col2d.isTrigger = true;
 
-            damageHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Damage_hitsplat");
-            zeroHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Zero_damage_hitsplat");
-            maxHitHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Damage_hitsplat_maxhit");
+            if (hitSplatLibrary == null)
+            {
+                Debug.LogError("PetCombatController requires a HitSplatLibrary reference. Assign one in the inspector.", this);
+            }
+            else
+            {
+                damageHitsplat = hitSplatLibrary.DamageHitsplat;
+                zeroHitsplat = hitSplatLibrary.ZeroDamageHitsplat;
+                maxHitHitsplat = hitSplatLibrary.MaxHitHitsplat;
+            }
         }
 
         /// <summary>Returns true if this pet has combat capabilities.</summary>

--- a/Assets/Scripts/Player/PlayerCombatTarget.cs
+++ b/Assets/Scripts/Player/PlayerCombatTarget.cs
@@ -13,29 +13,31 @@ namespace Player
     [RequireComponent(typeof(PlayerHitpoints))]
     public class PlayerCombatTarget : MonoBehaviour, CombatTarget
     {
+        [SerializeField, Tooltip("Centralised hitsplat sprite references assigned via the inspector.")]
+        private HitSplatLibrary hitSplatLibrary;
+
         private PlayerHitpoints hitpoints;
         private Sprite damageHitsplat;
         private Sprite zeroHitsplat;
         private Sprite burnHitsplat;
         private Sprite poisonHitsplat;
-        private Dictionary<SpellElement, Sprite> elementHitsplats;
+        private IReadOnlyDictionary<SpellElement, Sprite> elementHitsplats;
 
         private void Awake()
         {
             hitpoints = GetComponent<PlayerHitpoints>();
-            damageHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Damage_hitsplat");
-            zeroHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Zero_damage_hitsplat");
-            burnHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Burn_hitsplat");
-            poisonHitsplat = Resources.Load<Sprite>("Sprites/HitSplats/Poison_hitsplat");
-            elementHitsplats = new Dictionary<SpellElement, Sprite>
+            if (hitSplatLibrary == null)
             {
-                { SpellElement.Air, Resources.Load<Sprite>("Sprites/HitSplats/Air_hitsplat") },
-                { SpellElement.Water, Resources.Load<Sprite>("Sprites/HitSplats/Water_hitsplat") },
-                { SpellElement.Earth, Resources.Load<Sprite>("Sprites/HitSplats/Earth_hitsplat") },
-                { SpellElement.Electric, Resources.Load<Sprite>("Sprites/HitSplats/Electrocute_hitsplat") },
-                { SpellElement.Ice, Resources.Load<Sprite>("Sprites/HitSplats/Water_hitsplat") },
-                { SpellElement.Fire, burnHitsplat }
-            };
+                Debug.LogError("PlayerCombatTarget requires a HitSplatLibrary reference. Assign one in the inspector.", this);
+            }
+            else
+            {
+                damageHitsplat = hitSplatLibrary.DamageHitsplat;
+                zeroHitsplat = hitSplatLibrary.ZeroDamageHitsplat;
+                burnHitsplat = hitSplatLibrary.BurnHitsplat;
+                poisonHitsplat = hitSplatLibrary.PoisonHitsplat;
+                elementHitsplats = hitSplatLibrary.ElementHitsplats;
+            }
         }
 
         public bool IsAlive => hitpoints.CurrentHp > 0;


### PR DESCRIPTION
## Summary
- add a HitSplatLibrary ScriptableObject to hold combat hitsplat sprites
- inject the shared library into combat related behaviours instead of loading from Resources at runtime
- hook NPC poison damage into the new library to reuse the shared poison hitsplat asset

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68c996cf6e10832eba87785d868fbbd8