### PR TITLE
Add shared ticked skill base behaviour

### DIFF
--- a/Assets/Scripts/Skills/Common/TickedSkillBehaviour.cs
+++ b/Assets/Scripts/Skills/Common/TickedSkillBehaviour.cs
@@ -1,0 +1,136 @@
+using System.Collections;
+using UnityEngine;
+using Util;
+
+namespace Skills.Common
+{
+    /// <summary>
+    ///     Base component for any skill that relies on the global <see cref="Ticker"/> to drive its logic.
+    ///     Handles subscribing/unsubscribing when enabled or disabled and exposes hooks so derived
+    ///     classes only need to focus on their actual tick behaviour.
+    /// </summary>
+    public abstract class TickedSkillBehaviour : MonoBehaviour, ITickable
+    {
+        private Coroutine tickerCoroutine;
+        private bool tickerSubscribed;
+
+        /// <summary>
+        ///     When enabled the component will emit debug messages whenever it subscribes or unsubscribes
+        ///     from the <see cref="Ticker"/> singleton. Derived classes can override this to toggle logging.
+        /// </summary>
+        protected virtual bool LogTickerSubscription => false;
+
+        /// <summary>
+        ///     Human readable identifier used in debug logs. Defaults to the component type name but can be
+        ///     overridden for more context (for example, when multiple instances exist).
+        /// </summary>
+        protected virtual string TickerDebugName => GetType().Name;
+
+        /// <summary>
+        ///     Automatically attempts to subscribe to the ticker when the component becomes enabled.
+        /// </summary>
+        protected virtual void OnEnable()
+        {
+            TrySubscribeToTicker();
+        }
+
+        /// <summary>
+        ///     Ensures the subscription (and any pending coroutine) is torn down when disabled so no stray
+        ///     ticks are processed after the object leaves the scene.
+        /// </summary>
+        protected virtual void OnDisable()
+        {
+            CancelTickerSubscription();
+        }
+
+        /// <summary>
+        ///     Explicitly attempts to register this behaviour with <see cref="Ticker.Instance"/>. When the
+        ///     singleton is not yet spawned the base class will queue a coroutine that keeps retrying each
+        ///     frame until the ticker becomes available.
+        /// </summary>
+        protected void TrySubscribeToTicker()
+        {
+            if (tickerSubscribed)
+                return;
+
+            if (Ticker.Instance != null)
+            {
+                Ticker.Instance.Subscribe(this);
+                tickerSubscribed = true;
+                if (LogTickerSubscription)
+                    Debug.Log($"{TickerDebugName} subscribed to ticker.");
+                OnTickerReady();
+            }
+            else if (tickerCoroutine == null)
+            {
+                tickerCoroutine = StartCoroutine(WaitForTicker());
+            }
+        }
+
+        /// <summary>
+        ///     Stops listening for ticks and cancels the waiter coroutine if one is pending. Safe to invoke
+        ///     multiple times and from derived classes when manual control is required.
+        /// </summary>
+        protected void CancelTickerSubscription()
+        {
+            if (tickerCoroutine != null)
+            {
+                StopCoroutine(tickerCoroutine);
+                tickerCoroutine = null;
+            }
+
+            if (tickerSubscribed && Ticker.Instance != null)
+            {
+                Ticker.Instance.Unsubscribe(this);
+                if (LogTickerSubscription)
+                    Debug.Log($"{TickerDebugName} unsubscribed from ticker.");
+            }
+
+            tickerSubscribed = false;
+        }
+
+        /// <summary>
+        ///     Coroutine that waits for the ticker singleton to be created before subscribing.
+        /// </summary>
+        private IEnumerator WaitForTicker()
+        {
+            while (Ticker.Instance == null)
+                yield return null;
+
+            tickerCoroutine = null;
+            Ticker.Instance.Subscribe(this);
+            tickerSubscribed = true;
+            if (LogTickerSubscription)
+                Debug.Log($"{TickerDebugName} subscribed to ticker after waiting.");
+            OnTickerReady();
+        }
+
+        /// <summary>
+        ///     Called immediately after a successful subscription (both when the ticker already existed or
+        ///     once the waiter coroutine completes). Derived skills can override this to perform any
+        ///     additional setup that relies on the ticker being alive.
+        /// </summary>
+        protected virtual void OnTickerReady()
+        {
+        }
+
+        /// <summary>
+        ///     Utility property so derived classes can query the current subscription status if needed.
+        /// </summary>
+        protected bool IsSubscribedToTicker => tickerSubscribed;
+
+        /// <summary>
+        ///     Implementation of <see cref="ITickable"/> that forwards to <see cref="HandleTick"/> so
+        ///     derived classes only need to override a single method.
+        /// </summary>
+        public void OnTick()
+        {
+            HandleTick();
+        }
+
+        /// <summary>
+        ///     Called every OSRS tick. Derived skill behaviours implement their actual logic here.
+        /// </summary>
+        protected abstract void HandleTick();
+    }
+}

--- a/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
+++ b/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
@@ -9,6 +9,7 @@ using BankSystem;
 using Pets;
 using Skills.Outfits;
 using Core.Save;
+using Skills.Common;
 
 namespace Skills.Cooking
 {
@@ -18,7 +19,7 @@ namespace Skills.Cooking
     /// simply removes the raw item.
     /// </summary>
     [DisallowMultipleComponent]
-    public class CookingSkill : MonoBehaviour, ITickable
+    public class CookingSkill : TickedSkillBehaviour
     {
         [SerializeField] private Inventory.Inventory inventory;
         [SerializeField] private Equipment equipment;
@@ -29,7 +30,6 @@ namespace Skills.Cooking
         private int itemsRemaining;
         private int cookProgress;
         private const int CookIntervalTicks = 5;
-        private Coroutine tickerCoroutine;
         private SkillingOutfitProgress cookingOutfit;
 
         public event Action<CookableRecipe> OnStartCooking;
@@ -59,41 +59,9 @@ namespace Skills.Cooking
             }, "CookingOutfitOwned");
         }
 
-        private void OnEnable()
-        {
-            TrySubscribeToTicker();
-        }
-
-        private void OnDisable()
-        {
-            if (Ticker.Instance != null)
-                Ticker.Instance.Unsubscribe(this);
-            if (tickerCoroutine != null)
-                StopCoroutine(tickerCoroutine);
-        }
-
         private void OnDestroy()
         {
             SaveManager.Unregister(cookingOutfit);
-        }
-
-        private void TrySubscribeToTicker()
-        {
-            if (Ticker.Instance != null)
-            {
-                Ticker.Instance.Subscribe(this);
-            }
-            else
-            {
-                tickerCoroutine = StartCoroutine(WaitForTicker());
-            }
-        }
-
-        private IEnumerator WaitForTicker()
-        {
-            while (Ticker.Instance == null)
-                yield return null;
-            Ticker.Instance.Subscribe(this);
         }
 
         public void StartCooking(CookableRecipe recipe, int quantity)
@@ -118,7 +86,7 @@ namespace Skills.Cooking
             OnStopCooking?.Invoke();
         }
 
-        public void OnTick()
+        protected override void HandleTick()
         {
             if (!IsCooking)
                 return;

--- a/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
@@ -10,11 +10,12 @@ using Core;
 using BankSystem;
 using Core.Save;
 using Skills.Outfits;
+using Skills.Common;
 
 namespace Skills.Fishing
 {
     [DisallowMultipleComponent]
-    public class FishingSkill : MonoBehaviour, ITickable
+    public class FishingSkill : TickedSkillBehaviour
     {
         [SerializeField] private Inventory.Inventory inventory;
         [SerializeField] private Equipment equipment;
@@ -45,7 +46,6 @@ namespace Skills.Fishing
         public int CurrentCatchIntervalTicks => currentIntervalTicks;
 
         private SkillManager skills;
-        private Coroutine tickerCoroutine;
 
         private void Awake()
         {
@@ -67,44 +67,12 @@ namespace Skills.Fishing
                 bycatchManager = GameManager.BycatchManager;
         }
 
-        private void OnEnable()
-        {
-            TrySubscribeToTicker();
-        }
-
-        private void OnDisable()
-        {
-            if (Ticker.Instance != null)
-                Ticker.Instance.Unsubscribe(this);
-            if (tickerCoroutine != null)
-                StopCoroutine(tickerCoroutine);
-        }
-
         private void OnDestroy()
         {
             SaveManager.Unregister(fishingOutfit);
         }
 
-        private void TrySubscribeToTicker()
-        {
-            if (Ticker.Instance != null)
-            {
-                Ticker.Instance.Subscribe(this);
-            }
-            else
-            {
-                tickerCoroutine = StartCoroutine(WaitForTicker());
-            }
-        }
-
-        private IEnumerator WaitForTicker()
-        {
-            while (Ticker.Instance == null)
-                yield return null;
-            Ticker.Instance.Subscribe(this);
-        }
-
-        public void OnTick()
+        protected override void HandleTick()
         {
             if (!IsFishing)
                 return;

--- a/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
@@ -6,6 +6,7 @@ using Inventory;
 using Util;
 using Skills.Mining;
 using Skills;
+using Skills.Common;
 using Pets;
 using Quests;
 using BankSystem;
@@ -20,7 +21,7 @@ namespace Skills.Mining
     /// Handles XP, level, and mining tick logic.
     /// </summary>
     [DisallowMultipleComponent]
-    public class MiningSkill : MonoBehaviour, ITickable
+    public class MiningSkill : TickedSkillBehaviour
     {
         [SerializeField] private Inventory.Inventory inventory;
         [SerializeField] private Equipment equipment;
@@ -69,48 +70,17 @@ namespace Skills.Mining
             }, "MiningOutfitOwned");
         }
 
-        private Coroutine tickerCoroutine;
-
-        private void OnEnable()
-        {
-            TrySubscribeToTicker();
-        }
-
-        private void OnDisable()
-        {
-            if (Ticker.Instance != null)
-                Ticker.Instance.Unsubscribe(this);
-            if (tickerCoroutine != null)
-                StopCoroutine(tickerCoroutine);
-        }
-
         private void OnDestroy()
         {
             SaveManager.Unregister(miningOutfit);
         }
 
-        private void TrySubscribeToTicker()
-        {
-            if (Ticker.Instance != null)
-            {
-                Ticker.Instance.Subscribe(this);
-                Debug.Log("MiningSkill subscribed to ticker.");
-            }
-            else
-            {
-                tickerCoroutine = StartCoroutine(WaitForTicker());
-            }
-        }
+        /// <summary>
+        ///     Enables ticker logging so we can trace subscription timing during debugging sessions.
+        /// </summary>
+        protected override bool LogTickerSubscription => true;
 
-        private IEnumerator WaitForTicker()
-        {
-            while (Ticker.Instance == null)
-                yield return null;
-            Ticker.Instance.Subscribe(this);
-            Debug.Log("MiningSkill subscribed to ticker after waiting.");
-        }
-
-        public void OnTick()
+        protected override void HandleTick()
         {
             if (!IsMining)
                 return;

--- a/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
@@ -6,6 +6,7 @@ using Inventory;
 using Util;
 using UI;
 using Skills;
+using Skills.Common;
 using Pets;
 using Quests;
 using BankSystem;
@@ -19,7 +20,7 @@ namespace Skills.Woodcutting
     /// Handles XP, level, and woodcutting tick logic.
     /// </summary>
     [DisallowMultipleComponent]
-    public class WoodcuttingSkill : MonoBehaviour, ITickable
+    public class WoodcuttingSkill : TickedSkillBehaviour
     {
         [SerializeField] private Inventory.Inventory inventory;
         [SerializeField] private Equipment equipment;
@@ -68,48 +69,17 @@ namespace Skills.Woodcutting
             }, "WoodcuttingOutfitOwned");
         }
 
-        private Coroutine tickerCoroutine;
-
-        private void OnEnable()
-        {
-            TrySubscribeToTicker();
-        }
-
-        private void OnDisable()
-        {
-            if (Ticker.Instance != null)
-                Ticker.Instance.Unsubscribe(this);
-            if (tickerCoroutine != null)
-                StopCoroutine(tickerCoroutine);
-        }
-
         private void OnDestroy()
         {
             SaveManager.Unregister(woodcuttingOutfit);
         }
 
-        private void TrySubscribeToTicker()
-        {
-            if (Ticker.Instance != null)
-            {
-                Ticker.Instance.Subscribe(this);
-                Debug.Log("WoodcuttingSkill subscribed to ticker.");
-            }
-            else
-            {
-                tickerCoroutine = StartCoroutine(WaitForTicker());
-            }
-        }
+        /// <summary>
+        ///     Enables ticker logging so we can trace subscription timing during debugging sessions.
+        /// </summary>
+        protected override bool LogTickerSubscription => true;
 
-        private IEnumerator WaitForTicker()
-        {
-            while (Ticker.Instance == null)
-                yield return null;
-            Ticker.Instance.Subscribe(this);
-            Debug.Log("WoodcuttingSkill subscribed to ticker after waiting.");
-        }
-
-        public void OnTick()
+        protected override void HandleTick()
         {
             if (!IsChopping)
                 return;


### PR DESCRIPTION
## Summary
- add an abstract `TickedSkillBehaviour` that manages ticker subscription, waiting, and cleanup for tick-driven skills
- update woodcutting, mining, fishing, and cooking skills to inherit from the shared base while overriding only their tick handlers and logging flag

## Testing
- not run (requires Unity editor)


------
https://chatgpt.com/codex/tasks/task_e_68c9a795f738832e827c0944fc8c5a45