### PR TITLE
Fix ScenePersistentObject duplicate handling

### DIFF
--- a/Assets/Prefabs/SceneObjects/BycatchManager.prefab
+++ b/Assets/Prefabs/SceneObjects/BycatchManager.prefab
@@ -10,7 +10,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1730321474125209323}
   - component: {fileID: 1673605016979059047}
-  - component: {fileID: -536712880797316376}
   m_Layer: 0
   m_Name: BycatchManager
   m_TagString: Untagged
@@ -47,15 +46,3 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   bycatchTable: {fileID: 11400000, guid: 9099503588d0e334b933e7363942b865, type: 2}
   useDailySeed: 1
---- !u!114 &-536712880797316376
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6374956931679646004}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a23b760b7356ac141a5ff9fe31e13251, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::World.ScenePersistentObject

--- a/Assets/Prefabs/SceneObjects/DialogueManager.prefab
+++ b/Assets/Prefabs/SceneObjects/DialogueManager.prefab
@@ -10,7 +10,6 @@ GameObject:
   m_Component:
   - component: {fileID: 7500953353994040917}
   - component: {fileID: 8531773506327946706}
-  - component: {fileID: -1749587285411163875}
   m_Layer: 0
   m_Name: DialogueManager
   m_TagString: Untagged
@@ -45,15 +44,3 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 385067e1ae9b4e56888001d3cf5132b1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &-1749587285411163875
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5924813278431017395}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a23b760b7356ac141a5ff9fe31e13251, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::World.ScenePersistentObject

--- a/Assets/Prefabs/SceneObjects/GameManager.prefab
+++ b/Assets/Prefabs/SceneObjects/GameManager.prefab
@@ -10,7 +10,6 @@ GameObject:
   m_Component:
   - component: {fileID: 2736636695575937378}
   - component: {fileID: 9137887379022518763}
-  - component: {fileID: 4048762319538598020}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -45,15 +44,3 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 90bc5f973cd14884beff3967ea2e0eb5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &4048762319538598020
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1514773939915699660}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a23b760b7356ac141a5ff9fe31e13251, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::World.ScenePersistentObject

--- a/Assets/Prefabs/SceneObjects/ItemDatabase.prefab
+++ b/Assets/Prefabs/SceneObjects/ItemDatabase.prefab
@@ -10,7 +10,6 @@ GameObject:
   m_Component:
   - component: {fileID: 3718198433237480997}
   - component: {fileID: 8279677513170532452}
-  - component: {fileID: 4310450756832646946}
   m_Layer: 0
   m_Name: ItemDatabase
   m_TagString: Untagged
@@ -45,15 +44,3 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4fe0a0f23c609a941a09c3376805978b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Inventory.ItemDatabase
---- !u!114 &4310450756832646946
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8565483953987582831}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a23b760b7356ac141a5ff9fe31e13251, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::World.ScenePersistentObject

--- a/Assets/Prefabs/SceneObjects/PlayerRespawnSystem.prefab
+++ b/Assets/Prefabs/SceneObjects/PlayerRespawnSystem.prefab
@@ -10,7 +10,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1424843122579645638}
   - component: {fileID: 1660509826054094924}
-  - component: {fileID: -5458000856981965856}
   m_Layer: 0
   m_Name: PlayerRespawnSystem
   m_TagString: Untagged
@@ -45,15 +44,3 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4265ae917bbc463c839850c65a2a49b4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Player.PlayerRespawnSystem
---- !u!114 &-5458000856981965856
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2417333853597210264}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a23b760b7356ac141a5ff9fe31e13251, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::World.ScenePersistentObject

--- a/Assets/Prefabs/SceneObjects/QuestManager.prefab
+++ b/Assets/Prefabs/SceneObjects/QuestManager.prefab
@@ -10,7 +10,6 @@ GameObject:
   m_Component:
   - component: {fileID: 8209069909101689037}
   - component: {fileID: 5160930348881747523}
-  - component: {fileID: -1398055988848780901}
   m_Layer: 0
   m_Name: QuestManager
   m_TagString: Untagged
@@ -48,15 +47,3 @@ MonoBehaviour:
   QuestsUpdated:
     m_PersistentCalls:
       m_Calls: []
---- !u!114 &-1398055988848780901
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8971425371066198580}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a23b760b7356ac141a5ff9fe31e13251, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::World.ScenePersistentObject

--- a/Assets/Prefabs/SceneObjects/QuestRegistrar.prefab
+++ b/Assets/Prefabs/SceneObjects/QuestRegistrar.prefab
@@ -10,7 +10,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1738358971530823370}
   - component: {fileID: 5944113595315184592}
-  - component: {fileID: 3243749518771363254}
   m_Layer: 0
   m_Name: QuestRegistrar
   m_TagString: Untagged
@@ -47,15 +46,3 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   quests:
   - {fileID: 11400000, guid: 0611674d31283824a84cf53887d02bef, type: 2}
---- !u!114 &3243749518771363254
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5392178745851484221}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a23b760b7356ac141a5ff9fe31e13251, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::World.ScenePersistentObject

--- a/Assets/Prefabs/SceneObjects/QuestUI.prefab
+++ b/Assets/Prefabs/SceneObjects/QuestUI.prefab
@@ -10,7 +10,6 @@ GameObject:
   m_Component:
   - component: {fileID: 5885225840941563164}
   - component: {fileID: 118234047380651774}
-  - component: {fileID: -5769189400914546569}
   m_Layer: 0
   m_Name: QuestUI
   m_TagString: Untagged
@@ -46,15 +45,3 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   questEntryPrefab: {fileID: 0}
---- !u!114 &-5769189400914546569
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 887038742252277172}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a23b760b7356ac141a5ff9fe31e13251, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::World.ScenePersistentObject

--- a/Assets/Prefabs/SceneObjects/SceneTransitionManager.prefab
+++ b/Assets/Prefabs/SceneObjects/SceneTransitionManager.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 7447017724681048069}
   - component: {fileID: 2969031710698792310}
   - component: {fileID: 1485498968601153823}
-  - component: {fileID: -7123710762207635356}
   m_Layer: 0
   m_Name: SceneTransitionManager
   m_TagString: Untagged
@@ -59,15 +58,3 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   fadeDuration: 0.5
---- !u!114 &-7123710762207635356
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7479822293747661446}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a23b760b7356ac141a5ff9fe31e13251, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::World.ScenePersistentObject

--- a/Assets/Prefabs/SceneObjects/ScreenFader.prefab
+++ b/Assets/Prefabs/SceneObjects/ScreenFader.prefab
@@ -10,7 +10,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1337000000000000001}
   - component: {fileID: 1337000000000000002}
-  - component: {fileID: 81430198720978976}
   m_Layer: 0
   m_Name: ScreenFader
   m_TagString: Untagged
@@ -46,15 +45,3 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   fadeDuration: 0.5
---- !u!114 &81430198720978976
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1337000000000000000}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a23b760b7356ac141a5ff9fe31e13251, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::World.ScenePersistentObject

--- a/Assets/Prefabs/SceneObjects/ShopUI.prefab
+++ b/Assets/Prefabs/SceneObjects/ShopUI.prefab
@@ -10,7 +10,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1450000000000000001}
   - component: {fileID: 1450000000000000002}
-  - component: {fileID: 665816692127586653}
   m_Layer: 0
   m_Name: ShopUI
   m_TagString: Untagged
@@ -56,15 +55,3 @@ MonoBehaviour:
   priceFont: {fileID: 0}
   priceColor: {r: 1, g: 1, b: 1, a: 1}
   playerInventory: {fileID: 0}
---- !u!114 &665816692127586653
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1450000000000000000}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a23b760b7356ac141a5ff9fe31e13251, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::World.ScenePersistentObject

--- a/Assets/Prefabs/SceneObjects/Ticker.prefab
+++ b/Assets/Prefabs/SceneObjects/Ticker.prefab
@@ -10,7 +10,6 @@ GameObject:
   m_Component:
   - component: {fileID: 3439745518211581394}
   - component: {fileID: 2599973930880696068}
-  - component: {fileID: 9055126442304068514}
   m_Layer: 0
   m_Name: Ticker
   m_TagString: Untagged
@@ -46,15 +45,3 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   logTicks: 0
---- !u!114 &9055126442304068514
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3292544441928706444}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a23b760b7356ac141a5ff9fe31e13251, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::World.ScenePersistentObject

--- a/Assets/Scripts/World/ScenePersistentObject.cs
+++ b/Assets/Scripts/World/ScenePersistentObject.cs
@@ -39,7 +39,21 @@ namespace World
             foreach (var obj in others)
             {
                 // Ignore unrelated persistent objects.
-                if (obj == this || obj.gameObject.name != gameObject.name)
+                if (obj == this)
+                {
+                    continue;
+                }
+
+                // Allow derived components that live on the same GameObject to
+                // coexist without being flagged as duplicates.  Prefabs often
+                // include a base ScenePersistentObject component alongside a
+                // specialised subclass and they should not cull each other.
+                if (obj.gameObject == gameObject)
+                {
+                    continue;
+                }
+
+                if (obj.gameObject.name != gameObject.name)
                 {
                     continue;
                 }
@@ -68,7 +82,17 @@ namespace World
             // lifecycle logic.
             foreach (var obj in others)
             {
-                if (obj == this || obj.gameObject.name != gameObject.name)
+                if (obj == this)
+                {
+                    continue;
+                }
+
+                if (obj.gameObject == gameObject)
+                {
+                    continue;
+                }
+
+                if (obj.gameObject.name != gameObject.name)
                 {
                     continue;
                 }


### PR DESCRIPTION
## Summary
- update ScenePersistentObject duplicate detection to ignore sibling components on the same GameObject
- remove redundant standalone ScenePersistentObject components from persistent prefabs that already inherit the behaviour

## Testing
- not run (Unity editor unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c9b3a41d40832e9b53fce09d36f00c