### PR TITLE
Implement pooled floating text system

### DIFF
--- a/Assets/Scripts/UI/FloatingText.cs
+++ b/Assets/Scripts/UI/FloatingText.cs
@@ -4,79 +4,186 @@ using UnityEngine.UI;
 namespace UI
 {
     /// <summary>
-    /// Simple floating text utility for feedback messages.
+    /// Simple floating text utility for feedback messages that leverages an object pool.
+    /// Instances are configured by <see cref="FloatingTextPool"/> and returned to it when their lifetime expires.
     /// </summary>
     public class FloatingText : MonoBehaviour
     {
-        [SerializeField] private float lifetime = 1.5f;
-        [SerializeField] private Vector3 floatSpeed = new Vector3(0f, 1f, 0f);
-        [SerializeField] private float textSize = 0.2f;
+        [SerializeField, Tooltip("How long the text remains on screen before it returns to the pool.")]
+        private float lifetime = 1.5f;
+
+        [SerializeField, Tooltip("World-space velocity applied each frame while the text is visible.")]
+        private Vector3 floatSpeed = new Vector3(0f, 1f, 0f);
+
+        [SerializeField, Tooltip("Baseline text size multiplier when no override is supplied.")]
+        private float textSize = 0.2f;
 
         private Text uiText;
         private RectTransform rectTransform;
+        private RectTransform textRect;
+        private Image backgroundImage;
         private Vector3 worldPosition;
         private Camera mainCamera;
         private float remainingLifetime;
+        private FloatingTextPool owningPool;
 
+        /// <summary>
+        /// Displays a floating text message using a pooled instance.
+        /// </summary>
+        /// <param name="message">Message to render.</param>
+        /// <param name="position">World position the text should track.</param>
+        /// <param name="color">Optional colour override.</param>
+        /// <param name="size">Optional size override in OSRS units (1 = 64px font).</param>
+        /// <param name="background">Optional background sprite.</param>
         public static void Show(string message, Vector3 position, Color? color = null, float? size = null, Sprite background = null)
         {
-            GameObject go = new GameObject("FloatingText", typeof(Canvas));
-            var instance = go.AddComponent<FloatingText>();
-            var canvas = go.GetComponent<Canvas>();
-            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
-            go.AddComponent<CanvasScaler>().uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
-            go.AddComponent<GraphicRaycaster>();
+            var pool = FloatingTextPool.Instance;
+            if (pool == null)
+            {
+                Debug.LogWarning("FloatingText.Show was called but no FloatingTextPool exists in the scene.");
+                return;
+            }
 
-            GameObject parentGO = go;
+            if (!pool.TryGet(out FloatingText instance) || instance == null)
+            {
+                Debug.LogWarning("FloatingTextPool is exhausted and cannot provide a floating text instance.");
+                return;
+            }
+
+            instance.Present(message, position, color, size, background);
+        }
+
+        /// <summary>
+        /// Injects pooled UI component references into the instance.
+        /// </summary>
+        /// <param name="pool">The managing pool.</param>
+        /// <param name="textComponent">Text component used for rendering.</param>
+        /// <param name="canvasRect">RectTransform that will be positioned in screen-space.</param>
+        /// <param name="background">Background image that can optionally be shown.</param>
+        internal void ConfigureFromPool(FloatingTextPool pool, Text textComponent, RectTransform canvasRect, Image background)
+        {
+            owningPool = pool;
+            uiText = textComponent;
+            rectTransform = canvasRect != null ? canvasRect : GetComponent<RectTransform>();
+            backgroundImage = background;
+            textRect = textComponent.rectTransform;
+            ResetForPool();
+        }
+
+        /// <summary>
+        /// Applies the requested payload to the floating text and begins counting down its lifetime.
+        /// </summary>
+        /// <param name="message">Message to display.</param>
+        /// <param name="position">World position the text should follow.</param>
+        /// <param name="color">Optional colour override.</param>
+        /// <param name="size">Optional size override in OSRS units.</param>
+        /// <param name="background">Optional background sprite override.</param>
+        internal void Present(string message, Vector3 position, Color? color, float? size, Sprite background)
+        {
+            if (uiText == null)
+            {
+                Debug.LogError("FloatingText instance has not been configured by the pool.");
+                return;
+            }
+
+            if (!gameObject.activeSelf)
+                gameObject.SetActive(true);
+
+            worldPosition = position;
+            mainCamera = Camera.main;
+
+            float finalSize = Mathf.Max(0.01f, size ?? textSize);
+            uiText.fontSize = Mathf.RoundToInt(64f * finalSize);
+            uiText.text = message;
+            uiText.color = color ?? Color.white;
+
+            if (textRect != null)
+            {
+                Canvas.ForceUpdateCanvases();
+                LayoutRebuilder.ForceRebuildLayoutImmediate(textRect);
+                textRect.sizeDelta = new Vector2(uiText.preferredWidth, uiText.preferredHeight);
+            }
 
             if (background != null)
             {
-                var imageGO = new GameObject("Background", typeof(Image));
-                imageGO.transform.SetParent(go.transform, false);
-                var image = imageGO.GetComponent<Image>();
-                image.sprite = background;
-                image.SetNativeSize();
-                parentGO = imageGO;
+                if (backgroundImage != null)
+                {
+                    backgroundImage.sprite = background;
+                    backgroundImage.enabled = true;
+                    backgroundImage.SetNativeSize();
+                    backgroundImage.rectTransform.anchoredPosition = Vector2.zero;
+                    backgroundImage.rectTransform.pivot = new Vector2(0.5f, 0.5f);
+
+                    if (textRect != null)
+                        textRect.sizeDelta = backgroundImage.rectTransform.sizeDelta;
+                }
+            }
+            else if (backgroundImage != null)
+            {
+                backgroundImage.sprite = null;
+                backgroundImage.enabled = false;
+                backgroundImage.rectTransform.sizeDelta = Vector2.zero;
             }
 
-            var textGO = new GameObject("Text", typeof(Text));
-            textGO.transform.SetParent(parentGO.transform, false);
-            instance.uiText = textGO.GetComponent<Text>();
-            instance.uiText.alignment = TextAnchor.MiddleCenter;
-            instance.uiText.horizontalOverflow = HorizontalWrapMode.Overflow;
-            instance.uiText.verticalOverflow = VerticalWrapMode.Overflow;
-            instance.uiText.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
-            instance.rectTransform = background != null ? parentGO.GetComponent<RectTransform>() : textGO.GetComponent<RectTransform>();
-            instance.mainCamera = Camera.main;
-
-            instance.worldPosition = position;
-            if (instance.mainCamera == null)
-                instance.mainCamera = Camera.main;
-            instance.rectTransform.position = instance.mainCamera.WorldToScreenPoint(position);
-            instance.uiText.text = message;
-            instance.uiText.color = color ?? Color.white;
-            float finalSize = size ?? instance.textSize;
-            instance.uiText.fontSize = Mathf.RoundToInt(64 * finalSize);
-            instance.remainingLifetime = instance.lifetime;
-        }
-
-        private void Awake()
-        {
+            UpdateScreenPosition();
             remainingLifetime = lifetime;
         }
 
+        /// <summary>
+        /// Updates the floating text every frame while active.
+        /// </summary>
         private void Update()
         {
+            if (remainingLifetime <= 0f)
+                return;
+
             worldPosition += floatSpeed * Time.deltaTime;
-            if (mainCamera == null)
-                mainCamera = Camera.main;
-            if (rectTransform != null && mainCamera != null)
-                rectTransform.position = mainCamera.WorldToScreenPoint(worldPosition);
+            UpdateScreenPosition();
 
             remainingLifetime -= Time.deltaTime;
-            if (remainingLifetime <= 0f)
-                Destroy(gameObject);
+            if (remainingLifetime <= 0f && owningPool != null)
+                owningPool.Release(this);
         }
 
+        /// <summary>
+        /// Forces the RectTransform to track the current world position in screen-space.
+        /// </summary>
+        private void UpdateScreenPosition()
+        {
+            if (rectTransform == null)
+                return;
+
+            if (mainCamera == null)
+                mainCamera = Camera.main;
+
+            if (mainCamera != null)
+                rectTransform.position = mainCamera.WorldToScreenPoint(worldPosition);
+        }
+
+        /// <summary>
+        /// Resets all runtime data so the instance is ready for reuse when returned to the pool.
+        /// </summary>
+        internal void ResetForPool()
+        {
+            remainingLifetime = 0f;
+            worldPosition = Vector3.zero;
+            mainCamera = null;
+
+            if (uiText != null)
+            {
+                uiText.text = string.Empty;
+                uiText.color = Color.white;
+            }
+
+            if (textRect != null)
+                textRect.sizeDelta = Vector2.zero;
+
+            if (backgroundImage != null)
+            {
+                backgroundImage.sprite = null;
+                backgroundImage.enabled = false;
+                backgroundImage.rectTransform.sizeDelta = Vector2.zero;
+            }
+        }
     }
 }

--- a/Assets/Scripts/UI/FloatingTextPool.cs
+++ b/Assets/Scripts/UI/FloatingTextPool.cs
@@ -1,0 +1,206 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace UI
+{
+    /// <summary>
+    /// Object pool responsible for creating, warming and reusing <see cref="FloatingText"/> instances.
+    /// The pool avoids costly GameObject instantiation and allows tuning through inspector-exposed settings.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class FloatingTextPool : MonoBehaviour
+    {
+        /// <summary>
+        /// Global accessor so <see cref="FloatingText.Show(string, Vector3, Color?, float?, Sprite)"/> can locate the pool.
+        /// </summary>
+        public static FloatingTextPool Instance { get; private set; }
+
+        [Header("Pooling Settings")]
+        [SerializeField, Tooltip("Number of floating text instances created on Awake for immediate reuse.")]
+        private int initialPoolSize = 10;
+
+        [SerializeField, Tooltip("Absolute cap on the total number of pooled floating text objects.")]
+        private int maxPoolSize = 50;
+
+        [SerializeField, Tooltip("How many new instances to create whenever the pool needs to expand.")]
+        private int growthStep = 5;
+
+        [SerializeField, Tooltip("Allow the pool to grow beyond the prewarmed count when demand exceeds supply.")]
+        private bool allowGrowth = true;
+
+        private readonly Queue<FloatingText> availableTexts = new Queue<FloatingText>();
+        private readonly List<FloatingText> allTexts = new List<FloatingText>();
+        private readonly HashSet<FloatingText> pooledLookup = new HashSet<FloatingText>();
+
+        /// <summary>
+        /// Ensures a single pool instance exists and prewarms the requested number of entries.
+        /// </summary>
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Debug.LogWarning("Duplicate FloatingTextPool detected. Destroying the newest instance to preserve the original pool.");
+                Destroy(gameObject);
+                return;
+            }
+
+            Instance = this;
+            Prewarm(initialPoolSize);
+        }
+
+        /// <summary>
+        /// Clears the singleton reference if this pool is destroyed (i.e. during scene transitions).
+        /// </summary>
+        private void OnDestroy()
+        {
+            if (Instance == this)
+                Instance = null;
+        }
+
+        /// <summary>
+        /// Validates inspector data to ensure sensible pooling bounds when edited at runtime.
+        /// </summary>
+        private void OnValidate()
+        {
+            maxPoolSize = Mathf.Max(1, maxPoolSize);
+            initialPoolSize = Mathf.Clamp(initialPoolSize, 0, maxPoolSize);
+            growthStep = Mathf.Max(1, growthStep);
+        }
+
+        /// <summary>
+        /// Requests a floating text instance from the pool, growing the pool if necessary and permitted.
+        /// </summary>
+        /// <param name="instance">Returned pooled instance ready for configuration.</param>
+        /// <returns>True if an instance was supplied, false if the pool is exhausted.</returns>
+        public bool TryGet(out FloatingText instance)
+        {
+            if (availableTexts.Count == 0)
+                TryExpandPool();
+
+            if (availableTexts.Count == 0)
+            {
+                instance = null;
+                return false;
+            }
+
+            instance = availableTexts.Dequeue();
+            pooledLookup.Remove(instance);
+
+            if (!instance.gameObject.activeSelf)
+                instance.gameObject.SetActive(true);
+
+            instance.transform.SetAsLastSibling();
+            instance.transform.localScale = Vector3.one;
+            return true;
+        }
+
+        /// <summary>
+        /// Returns a floating text instance back to the pool after its lifetime expires.
+        /// </summary>
+        /// <param name="floatingText">Instance that should be recycled.</param>
+        internal void Release(FloatingText floatingText)
+        {
+            if (floatingText == null)
+                return;
+
+            floatingText.ResetForPool();
+            floatingText.gameObject.SetActive(false);
+            floatingText.transform.SetParent(transform, false);
+
+            if (pooledLookup.Add(floatingText))
+                availableTexts.Enqueue(floatingText);
+        }
+
+        /// <summary>
+        /// Attempts to grow the pool by the configured step if growth is allowed and the cap has not been reached.
+        /// </summary>
+        private void TryExpandPool()
+        {
+            if (!allowGrowth || allTexts.Count >= maxPoolSize)
+                return;
+
+            int availableSpace = Mathf.Max(0, maxPoolSize - allTexts.Count);
+            if (availableSpace <= 0)
+                return;
+
+            int toCreate = Mathf.Min(growthStep, availableSpace);
+            Prewarm(toCreate);
+        }
+
+        /// <summary>
+        /// Creates and enqueues the requested number of floating text instances.
+        /// </summary>
+        /// <param name="amount">Number of instances to generate.</param>
+        private void Prewarm(int amount)
+        {
+            int availableSpace = Mathf.Max(0, maxPoolSize - allTexts.Count);
+            int createCount = Mathf.Min(Mathf.Max(0, amount), availableSpace);
+            for (int i = 0; i < createCount; i++)
+            {
+                FloatingText textInstance = CreateFloatingTextInstance();
+                textInstance.gameObject.SetActive(false);
+                availableTexts.Enqueue(textInstance);
+                pooledLookup.Add(textInstance);
+            }
+        }
+
+        /// <summary>
+        /// Generates a new floating text object with the correct UI hierarchy and wiring.
+        /// </summary>
+        private FloatingText CreateFloatingTextInstance()
+        {
+            GameObject root = new GameObject($"FloatingText_{allTexts.Count}", typeof(RectTransform));
+            root.transform.SetParent(transform, false);
+
+            var rectTransform = root.GetComponent<RectTransform>();
+            rectTransform.anchorMin = rectTransform.anchorMax = new Vector2(0.5f, 0.5f);
+            rectTransform.pivot = new Vector2(0.5f, 0.5f);
+            rectTransform.anchoredPosition = Vector2.zero;
+            rectTransform.localScale = Vector3.one;
+
+            var canvas = root.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+
+            var scaler = root.AddComponent<CanvasScaler>();
+            scaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+            scaler.referenceResolution = new Vector2(1920f, 1080f);
+
+            root.AddComponent<GraphicRaycaster>();
+
+            GameObject backgroundGO = new GameObject("Background", typeof(RectTransform), typeof(Image));
+            backgroundGO.transform.SetParent(root.transform, false);
+            var backgroundRect = backgroundGO.GetComponent<RectTransform>();
+            backgroundRect.anchorMin = backgroundRect.anchorMax = new Vector2(0.5f, 0.5f);
+            backgroundRect.pivot = new Vector2(0.5f, 0.5f);
+            backgroundRect.anchoredPosition = Vector2.zero;
+            var backgroundImage = backgroundGO.GetComponent<Image>();
+            backgroundImage.enabled = false;
+            backgroundImage.raycastTarget = false;
+
+            GameObject textGO = new GameObject("Text", typeof(RectTransform), typeof(Text));
+            textGO.transform.SetParent(root.transform, false);
+            var textRect = textGO.GetComponent<RectTransform>();
+            textRect.anchorMin = textRect.anchorMax = new Vector2(0.5f, 0.5f);
+            textRect.pivot = new Vector2(0.5f, 0.5f);
+            textRect.anchoredPosition = Vector2.zero;
+
+            var textComponent = textGO.GetComponent<Text>();
+            textComponent.alignment = TextAnchor.MiddleCenter;
+            textComponent.horizontalOverflow = HorizontalWrapMode.Overflow;
+            textComponent.verticalOverflow = VerticalWrapMode.Overflow;
+            textComponent.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            textComponent.raycastTarget = false;
+
+            // Ensure the background renders beneath the text.
+            backgroundGO.transform.SetSiblingIndex(0);
+            textGO.transform.SetSiblingIndex(1);
+
+            var floatingText = root.AddComponent<FloatingText>();
+            floatingText.ConfigureFromPool(this, textComponent, rectTransform, backgroundImage);
+
+            allTexts.Add(floatingText);
+            return floatingText;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a `FloatingTextPool` MonoBehaviour that prewarms floating text instances, exposes pool sizing controls, and reuses objects instead of instantiating
- update `FloatingText` to request instances from the pool, configure their appearance, and release them for reuse when their lifetime elapses

## Testing
- not run (Unity editor not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68c9b916665c832ebac2ebf8ed710807