### PR TITLE
Adjust floating text defaults for visibility

### DIFF
--- a/Assets/Scripts/UI/FloatingText.cs
+++ b/Assets/Scripts/UI/FloatingText.cs
@@ -15,8 +15,11 @@ namespace UI
         [SerializeField, Tooltip("World-space velocity applied each frame while the text is visible.")]
         private Vector3 floatSpeed = new Vector3(0f, 1f, 0f);
 
-        [SerializeField, Tooltip("Baseline text size multiplier when no override is supplied.")]
-        private float textSize = 0.2f;
+        [SerializeField, Tooltip("Baseline text size multiplier when no override is supplied (1 = 64px font).")]
+        private float textSize = 1f;
+
+        [SerializeField, Tooltip("World-space offset applied when positioning the floating text (helps align with character height).")]
+        private Vector3 spawnOffset = new Vector3(0f, 0.75f, 0f);
 
         private Text uiText;
         private RectTransform rectTransform;
@@ -89,7 +92,8 @@ namespace UI
             if (!gameObject.activeSelf)
                 gameObject.SetActive(true);
 
-            worldPosition = position;
+            // Capture the desired world position with the configured spawn offset so text renders above the anchor point.
+            worldPosition = position + spawnOffset;
             mainCamera = Camera.main;
 
             float finalSize = Mathf.Max(0.01f, size ?? textSize);


### PR DESCRIPTION
## Summary
- raise the default floating text size multiplier to map to a 64px font baseline
- add a configurable world-space spawn offset so pooled popups appear above their anchor

## Testing
- Not run (Unity Editor required)


------
https://chatgpt.com/codex/tasks/task_e_68c9c0155b54832e97fa4b483ac56a6b