### PR TITLE
Improve prospect floating text positioning

### DIFF
--- a/Assets/Scripts/Skills/Fishing/Core/FishableSpot.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishableSpot.cs
@@ -28,6 +28,16 @@ namespace Skills.Fishing
 
         private double respawnAt;
 
+        /// <summary>
+        /// Consistent offset used so prospect feedback renders comfortably above the player's head.
+        /// </summary>
+        private static readonly Vector3 ProspectTextOffset = new Vector3(0f, 0.9f, 0f);
+
+        /// <summary>
+        /// Slightly reduced size so prospect text matches the scale of other OSRS-style popups.
+        /// </summary>
+        private const float ProspectTextSize = 0.65f;
+
         private void Awake()
         {
             if (sr == null)
@@ -114,8 +124,17 @@ namespace Skills.Fishing
             if (requester == null)
                 yield break;
 
-            FloatingText.Show("Checking...", requester.position);
+            Transform anchor = ResolveFloatingTextAnchor(requester);
+            Vector3 anchorPosition = anchor != null ? anchor.position : requester.position;
+
+            FloatingText.Show("Checking...", anchorPosition, null, ProspectTextSize, null, ProspectTextOffset);
             yield return new WaitForSeconds(Ticker.TickDuration * 2f);
+
+            if (requester == null)
+                yield break;
+
+            anchor = ResolveFloatingTextAnchor(requester);
+            anchorPosition = anchor != null ? anchor.position : requester.position;
 
             var fishNames = new List<string>();
             if (def != null && def.AvailableFish != null)
@@ -133,12 +152,28 @@ namespace Skills.Fishing
             }
 
             string message;
-            if (fishNames.Count == 1)
+            if (fishNames.Count == 0)
+                message = "There are no fish in this spot";
+            else if (fishNames.Count == 1)
                 message = $"This spot contains {fishNames[0]} here";
             else
                 message = $"This spot contains {string.Join(" & ", fishNames)} here";
 
-            FloatingText.Show(message, requester.position);
+            FloatingText.Show(message, anchorPosition, null, ProspectTextSize, null, ProspectTextOffset);
+        }
+
+        /// <summary>
+        /// Attempts to locate a dedicated floating text anchor on the requester so popups appear at head height.
+        /// </summary>
+        /// <param name="requester">Transform responsible for triggering the prospect action.</param>
+        /// <returns>The floating text anchor if one exists, otherwise the requester transform.</returns>
+        private static Transform ResolveFloatingTextAnchor(Transform requester)
+        {
+            if (requester == null)
+                return null;
+
+            var anchor = requester.Find("FloatingTextAnchor");
+            return anchor != null ? anchor : requester;
         }
     }
 }

--- a/Assets/Scripts/Skills/Mining/Core/MineableRock.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MineableRock.cs
@@ -23,6 +23,16 @@ namespace Skills.Mining
         private bool depleted;
         private float respawnTimer;
 
+        /// <summary>
+        /// Offset ensuring prospect feedback floats above the player's head for mining just like fishing.
+        /// </summary>
+        private static readonly Vector3 ProspectTextOffset = new Vector3(0f, 0.9f, 0f);
+
+        /// <summary>
+        /// Shared prospect text scale that keeps informational popups unobtrusive.
+        /// </summary>
+        private const float ProspectTextSize = 0.65f;
+
         public RockDefinition RockDef => rockDef;
         public bool IsDepleted => depleted;
 
@@ -92,9 +102,37 @@ namespace Skills.Mining
             if (requester == null)
                 yield break;
 
-            FloatingText.Show("Prospecting...", requester.position);
+            Transform anchor = ResolveFloatingTextAnchor(requester);
+            Vector3 anchorPosition = anchor != null ? anchor.position : requester.position;
+
+            FloatingText.Show("Prospecting...", anchorPosition, null, ProspectTextSize, null, ProspectTextOffset);
             yield return new WaitForSeconds(Ticker.TickDuration * 2f);
-            FloatingText.Show($"This rock contains {rockDef.Ore.DisplayName} here", requester.position);
+
+            if (requester == null)
+                yield break;
+
+            anchor = ResolveFloatingTextAnchor(requester);
+            anchorPosition = anchor != null ? anchor.position : requester.position;
+
+            string message = rockDef != null && rockDef.Ore != null
+                ? $"This rock contains {rockDef.Ore.DisplayName} here"
+                : "There is nothing of interest in this rock";
+
+            FloatingText.Show(message, anchorPosition, null, ProspectTextSize, null, ProspectTextOffset);
+        }
+
+        /// <summary>
+        /// Finds the floating text anchor on the requester so prospect feedback appears relative to the character head.
+        /// </summary>
+        /// <param name="requester">Transform that initiated the prospect action.</param>
+        /// <returns>The floating text anchor if present, otherwise the requester transform.</returns>
+        private static Transform ResolveFloatingTextAnchor(Transform requester)
+        {
+            if (requester == null)
+                return null;
+
+            var anchor = requester.Find("FloatingTextAnchor");
+            return anchor != null ? anchor : requester;
         }
     }
 }

--- a/Assets/Scripts/UI/FloatingText.cs
+++ b/Assets/Scripts/UI/FloatingText.cs
@@ -38,7 +38,9 @@ namespace UI
         /// <param name="color">Optional colour override.</param>
         /// <param name="size">Optional size override in OSRS units (1 = 64px font).</param>
         /// <param name="background">Optional background sprite.</param>
-        public static void Show(string message, Vector3 position, Color? color = null, float? size = null, Sprite background = null)
+        /// <param name="worldOffset">Optional world-space offset that overrides the default spawn offset.</param>
+        public static void Show(string message, Vector3 position, Color? color = null, float? size = null, Sprite background = null,
+            Vector3? worldOffset = null)
         {
             var pool = FloatingTextPool.Instance;
             if (pool == null)
@@ -53,7 +55,7 @@ namespace UI
                 return;
             }
 
-            instance.Present(message, position, color, size, background);
+            instance.Present(message, position, color, size, background, worldOffset);
         }
 
         /// <summary>
@@ -81,7 +83,8 @@ namespace UI
         /// <param name="color">Optional colour override.</param>
         /// <param name="size">Optional size override in OSRS units.</param>
         /// <param name="background">Optional background sprite override.</param>
-        internal void Present(string message, Vector3 position, Color? color, float? size, Sprite background)
+        /// <param name="worldOffset">Optional override that controls where the text spawns relative to the provided position.</param>
+        internal void Present(string message, Vector3 position, Color? color, float? size, Sprite background, Vector3? worldOffset)
         {
             if (uiText == null)
             {
@@ -93,7 +96,8 @@ namespace UI
                 gameObject.SetActive(true);
 
             // Capture the desired world position with the configured spawn offset so text renders above the anchor point.
-            worldPosition = position + spawnOffset;
+            Vector3 offset = worldOffset ?? spawnOffset;
+            worldPosition = position + offset;
             mainCamera = Camera.main;
 
             float finalSize = Mathf.Max(0.01f, size ?? textSize);


### PR DESCRIPTION
## Summary
- extend the floating text utility to accept optional world-space offsets so messages can be positioned precisely
- anchor fishing prospect feedback to the player's floating text anchor, reduce its font size, and handle empty fishing spots gracefully
- apply the same anchored offset and size tuning to mining prospect messages while falling back when ore data is missing

## Testing
- No automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9c171bca4832ea5ca6bde183fc370