### PR TITLE
Standardize gathering floating text visuals

### DIFF
--- a/Assets/Scripts/Skills/Common/GatheringRewardProcessor.cs
+++ b/Assets/Scripts/Skills/Common/GatheringRewardProcessor.cs
@@ -71,6 +71,12 @@ namespace Skills.Common
     {
         private const float DefaultXpPopupDelayTicks = 5f;
 
+        /// <summary>
+        /// Consistent floating text scale applied to all gathering rewards so different skills
+        /// present feedback using the same visual size as prospecting popups.
+        /// </summary>
+        internal const float DefaultFloatingTextSize = 0.65f;
+
         public static GatheringRewardResult Process(in GatheringRewardContext context)
         {
             var anchor = context.floatingTextAnchor != null ? context.floatingTextAnchor : context.fallbackAnchor;
@@ -108,7 +114,7 @@ namespace Skills.Common
                     ? "Your inventory is full"
                     : context.inventoryFullMessage;
                 if (anchor != null)
-                    FloatingText.Show(fullMessage, anchor.position);
+                    FloatingText.Show(fullMessage, anchor.position, null, DefaultFloatingTextSize);
                 result.InventoryFull = true;
                 result.NewLevel = result.PreviousLevel;
                 context.onFailure?.Invoke(result);
@@ -127,7 +133,7 @@ namespace Skills.Common
                     ? context.rewardMessageFormatter(result.QuantityAwarded)
                     : $"+{result.QuantityAwarded} {displayName}";
                 if (!string.IsNullOrEmpty(rewardMessage))
-                    FloatingText.Show(rewardMessage, anchor.position);
+                    FloatingText.Show(rewardMessage, anchor.position, null, DefaultFloatingTextSize);
             }
 
             context.onItemsGranted?.Invoke(result);
@@ -215,7 +221,7 @@ namespace Skills.Common
             if (delaySeconds > 0f)
                 yield return new WaitForSeconds(delaySeconds);
             if (anchor != null)
-                FloatingText.Show($"+{xp} XP", anchor.position);
+                FloatingText.Show($"+{xp} XP", anchor.position, null, DefaultFloatingTextSize);
         }
     }
 }

--- a/Assets/Scripts/Skills/Cooking/Core/CookingObject.cs
+++ b/Assets/Scripts/Skills/Cooking/Core/CookingObject.cs
@@ -6,6 +6,7 @@ using Inventory;
 using Player;
 using UI;
 using Pets;
+using Skills.Common;
 
 namespace Skills.Cooking
 {
@@ -93,13 +94,13 @@ namespace Skills.Cooking
 
             if (!recipeLookup.TryGetValue(entry.item.id, out var recipe))
             {
-                FloatingText.Show("You can't cook that", transform.position);
+                FloatingText.Show("You can't cook that", transform.position, null, GatheringRewardProcessor.DefaultFloatingTextSize);
                 return;
             }
 
             if (cookingSkill.Level < recipe.requiredLevel)
             {
-                FloatingText.Show($"You need Cooking level {recipe.requiredLevel}", transform.position);
+                FloatingText.Show($"You need Cooking level {recipe.requiredLevel}", transform.position, null, GatheringRewardProcessor.DefaultFloatingTextSize);
                 return;
             }
 

--- a/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
+++ b/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
@@ -47,6 +47,11 @@ namespace Skills.Cooking
                 inventory = GetComponent<Inventory.Inventory>();
             if (equipment == null)
                 equipment = GetComponent<Equipment>();
+            if (floatingTextAnchor == null)
+            {
+                // Locate the floating text anchor automatically when the inspector reference is missing.
+                floatingTextAnchor = transform.Find("FloatingTextAnchor");
+            }
             skills = GetComponent<SkillManager>();
             cookingOutfit = new SkillingOutfitProgress(new[]
             {
@@ -129,7 +134,7 @@ namespace Skills.Cooking
             bool burned = UnityEngine.Random.value < burnChance;
             if (burned)
             {
-                FloatingText.Show("Burned", anchor.position);
+                FloatingText.Show("Burned", anchor.position, null, GatheringRewardProcessor.DefaultFloatingTextSize);
             }
             else
             {
@@ -163,7 +168,11 @@ namespace Skills.Cooking
 
                         if (result.LeveledUp && result.Anchor != null)
                         {
-                            FloatingText.Show($"Cooking level {result.NewLevel}", result.Anchor.position);
+                            FloatingText.Show(
+                                $"Cooking level {result.NewLevel}",
+                                result.Anchor.position,
+                                null,
+                                GatheringRewardProcessor.DefaultFloatingTextSize);
                             OnLevelUp?.Invoke(result.NewLevel);
                         }
                     },

--- a/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
@@ -52,6 +52,11 @@ namespace Skills.Fishing
                 inventory = GetComponent<Inventory.Inventory>();
             if (equipment == null)
                 equipment = GetComponent<Equipment>();
+            if (floatingTextAnchor == null)
+            {
+                // Ensure floating text uses the dedicated anchor if the field was left unassigned.
+                floatingTextAnchor = transform.Find("FloatingTextAnchor");
+            }
             skills = GetComponent<SkillManager>();
             PreloadFishItems();
             fishingOutfit = new SkillingOutfitProgress(new[]
@@ -101,15 +106,15 @@ namespace Skills.Fishing
                 Transform anchor = floatingTextAnchor != null ? floatingTextAnchor : transform;
                 if (inventory == null || !inventory.RemoveItem(currentSpot.def.BaitItemId))
                 {
-                    FloatingText.Show("You need bait", anchor.position);
+                    FloatingText.Show("You need bait", anchor.position, null, GatheringRewardProcessor.DefaultFloatingTextSize);
                     StopFishing();
                     return;
                 }
                 var baitItem = ItemDatabase.GetItem(currentSpot.def.BaitItemId);
                 if (baitItem != null)
-                    FloatingText.Show($"-1 {baitItem.itemName}", anchor.position);
+                    FloatingText.Show($"-1 {baitItem.itemName}", anchor.position, null, GatheringRewardProcessor.DefaultFloatingTextSize);
                 else
-                    FloatingText.Show("-1 bait", anchor.position);
+                    FloatingText.Show("-1 bait", anchor.position, null, GatheringRewardProcessor.DefaultFloatingTextSize);
             }
 
             float baseChance = 0.35f;
@@ -155,7 +160,11 @@ namespace Skills.Fishing
                     {
                         if (result.LeveledUp && result.Anchor != null)
                         {
-                            FloatingText.Show($"Fishing level {result.NewLevel}", result.Anchor.position);
+                            FloatingText.Show(
+                                $"Fishing level {result.NewLevel}",
+                                result.Anchor.position,
+                                null,
+                                GatheringRewardProcessor.DefaultFloatingTextSize);
                             OnLevelUp?.Invoke(result.NewLevel);
                         }
                     },
@@ -268,11 +277,11 @@ namespace Skills.Fishing
             var itemData = ItemDatabase.GetItem(res.item.ItemId);
             if (itemData == null || inventory == null || !inventory.AddItem(itemData, res.quantity))
             {
-                FloatingText.Show("Your inventory is full", anchor.position);
+                FloatingText.Show("Your inventory is full", anchor.position, null, GatheringRewardProcessor.DefaultFloatingTextSize);
                 return;
             }
 
-            FloatingText.Show($"+{res.quantity} {res.item.DisplayName}", anchor.position);
+            FloatingText.Show($"+{res.quantity} {res.item.DisplayName}", anchor.position, null, GatheringRewardProcessor.DefaultFloatingTextSize);
         }
 
         private FishingTool MapTool(FishingToolDefinition tool)
@@ -319,7 +328,7 @@ namespace Skills.Fishing
                 if (inventory == null || !inventory.HasItem(spot.def.BaitItemId))
                 {
                     Transform anchor = floatingTextAnchor != null ? floatingTextAnchor : transform;
-                    FloatingText.Show("You need bait", anchor.position);
+                    FloatingText.Show("You need bait", anchor.position, null, GatheringRewardProcessor.DefaultFloatingTextSize);
                     return;
                 }
             }

--- a/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
@@ -57,6 +57,11 @@ namespace Skills.Mining
                 inventory = GetComponent<Inventory.Inventory>();
             if (equipment == null)
                 equipment = GetComponent<Equipment>();
+            if (floatingTextAnchor == null)
+            {
+                // Cache the floating text anchor automatically so popups appear at head height.
+                floatingTextAnchor = transform.Find("FloatingTextAnchor");
+            }
             skills = GetComponent<SkillManager>();
             PreloadOreItems();
             miningOutfit = new SkillingOutfitProgress(new[]
@@ -148,7 +153,11 @@ namespace Skills.Mining
                         {
                             if (result.LeveledUp && result.Anchor != null)
                             {
-                                FloatingText.Show($"Mining level {result.NewLevel}", result.Anchor.position);
+                                FloatingText.Show(
+                                    $"Mining level {result.NewLevel}",
+                                    result.Anchor.position,
+                                    null,
+                                    GatheringRewardProcessor.DefaultFloatingTextSize);
                                 OnLevelUp?.Invoke(result.NewLevel);
                             }
                         },

--- a/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
@@ -56,6 +56,11 @@ namespace Skills.Woodcutting
                 inventory = GetComponent<Inventory.Inventory>();
             if (equipment == null)
                 equipment = GetComponent<Equipment>();
+            if (floatingTextAnchor == null)
+            {
+                // Auto-cache the floating text anchor if it wasn't assigned in the inspector.
+                floatingTextAnchor = transform.Find("FloatingTextAnchor");
+            }
             skills = GetComponent<SkillManager>();
             PreloadLogItems();
             woodcuttingOutfit = new SkillingOutfitProgress(new[]
@@ -140,7 +145,11 @@ namespace Skills.Woodcutting
                     {
                         if (result.LeveledUp && result.Anchor != null)
                         {
-                            FloatingText.Show($"Woodcutting level {result.NewLevel}", result.Anchor.position);
+                            FloatingText.Show(
+                                $"Woodcutting level {result.NewLevel}",
+                                result.Anchor.position,
+                                null,
+                                GatheringRewardProcessor.DefaultFloatingTextSize);
                             OnLevelUp?.Invoke(result.NewLevel);
                         }
                     },


### PR DESCRIPTION
## Summary
- normalize gathering-related floating text size so cooking and woodcutting match fishing and mining
- automatically resolve missing floating text anchors on skill behaviours to respect the player's FloatingTextAnchor transform
- update cooking object feedback to use the shared gathering floating text style

## Testing
- not run (Unity editor not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68c9c4f54048832e884f01ec2dd7ef77