### PR TITLE
Add floating text follow anchors

### DIFF
--- a/Assets/Scripts/Inventory/Equipment.cs
+++ b/Assets/Scripts/Inventory/Equipment.cs
@@ -327,7 +327,7 @@ namespace Inventory
                     if (skillManager.GetLevel(req.skill) < req.level)
                     {
                         Transform anchor = floatingTextAnchor != null ? floatingTextAnchor : transform;
-                        FloatingText.Show($"You need {req.level} {req.skill} to wield this", anchor.position);
+                        FloatingText.Show($"You need {req.level} {req.skill} to wield this", anchor);
                         return false;
                     }
                 }

--- a/Assets/Scripts/Skills/Common/GatheringController.cs
+++ b/Assets/Scripts/Skills/Common/GatheringController.cs
@@ -438,7 +438,7 @@ namespace Skills.Common
                 return;
 
             Transform anchor = FeedbackAnchor != null ? FeedbackAnchor : transform;
-            FloatingText.Show(message, anchor.position);
+            FloatingText.Show(message, anchor);
         }
 
         /// <summary>

--- a/Assets/Scripts/Skills/Common/GatheringRewardProcessor.cs
+++ b/Assets/Scripts/Skills/Common/GatheringRewardProcessor.cs
@@ -114,7 +114,7 @@ namespace Skills.Common
                     ? "Your inventory is full"
                     : context.inventoryFullMessage;
                 if (anchor != null)
-                    FloatingText.Show(fullMessage, anchor.position, null, DefaultFloatingTextSize);
+                    FloatingText.Show(fullMessage, anchor, null, DefaultFloatingTextSize);
                 result.InventoryFull = true;
                 result.NewLevel = result.PreviousLevel;
                 context.onFailure?.Invoke(result);
@@ -133,7 +133,7 @@ namespace Skills.Common
                     ? context.rewardMessageFormatter(result.QuantityAwarded)
                     : $"+{result.QuantityAwarded} {displayName}";
                 if (!string.IsNullOrEmpty(rewardMessage))
-                    FloatingText.Show(rewardMessage, anchor.position, null, DefaultFloatingTextSize);
+                    FloatingText.Show(rewardMessage, anchor, null, DefaultFloatingTextSize);
             }
 
             context.onItemsGranted?.Invoke(result);
@@ -221,7 +221,7 @@ namespace Skills.Common
             if (delaySeconds > 0f)
                 yield return new WaitForSeconds(delaySeconds);
             if (anchor != null)
-                FloatingText.Show($"+{xp} XP", anchor.position, null, DefaultFloatingTextSize);
+                FloatingText.Show($"+{xp} XP", anchor, null, DefaultFloatingTextSize);
         }
     }
 }

--- a/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
+++ b/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
@@ -134,7 +134,7 @@ namespace Skills.Cooking
             bool burned = UnityEngine.Random.value < burnChance;
             if (burned)
             {
-                FloatingText.Show("Burned", anchor.position, null, GatheringRewardProcessor.DefaultFloatingTextSize);
+                FloatingText.Show("Burned", anchor, null, GatheringRewardProcessor.DefaultFloatingTextSize);
             }
             else
             {
@@ -170,7 +170,7 @@ namespace Skills.Cooking
                         {
                             FloatingText.Show(
                                 $"Cooking level {result.NewLevel}",
-                                result.Anchor.position,
+                                result.Anchor,
                                 null,
                                 GatheringRewardProcessor.DefaultFloatingTextSize);
                             OnLevelUp?.Invoke(result.NewLevel);

--- a/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
@@ -106,15 +106,15 @@ namespace Skills.Fishing
                 Transform anchor = floatingTextAnchor != null ? floatingTextAnchor : transform;
                 if (inventory == null || !inventory.RemoveItem(currentSpot.def.BaitItemId))
                 {
-                    FloatingText.Show("You need bait", anchor.position, null, GatheringRewardProcessor.DefaultFloatingTextSize);
+                    FloatingText.Show("You need bait", anchor, null, GatheringRewardProcessor.DefaultFloatingTextSize);
                     StopFishing();
                     return;
                 }
                 var baitItem = ItemDatabase.GetItem(currentSpot.def.BaitItemId);
                 if (baitItem != null)
-                    FloatingText.Show($"-1 {baitItem.itemName}", anchor.position, null, GatheringRewardProcessor.DefaultFloatingTextSize);
+                    FloatingText.Show($"-1 {baitItem.itemName}", anchor, null, GatheringRewardProcessor.DefaultFloatingTextSize);
                 else
-                    FloatingText.Show("-1 bait", anchor.position, null, GatheringRewardProcessor.DefaultFloatingTextSize);
+                    FloatingText.Show("-1 bait", anchor, null, GatheringRewardProcessor.DefaultFloatingTextSize);
             }
 
             float baseChance = 0.35f;
@@ -162,7 +162,7 @@ namespace Skills.Fishing
                         {
                             FloatingText.Show(
                                 $"Fishing level {result.NewLevel}",
-                                result.Anchor.position,
+                                result.Anchor,
                                 null,
                                 GatheringRewardProcessor.DefaultFloatingTextSize);
                             OnLevelUp?.Invoke(result.NewLevel);
@@ -277,11 +277,11 @@ namespace Skills.Fishing
             var itemData = ItemDatabase.GetItem(res.item.ItemId);
             if (itemData == null || inventory == null || !inventory.AddItem(itemData, res.quantity))
             {
-                FloatingText.Show("Your inventory is full", anchor.position, null, GatheringRewardProcessor.DefaultFloatingTextSize);
+                FloatingText.Show("Your inventory is full", anchor, null, GatheringRewardProcessor.DefaultFloatingTextSize);
                 return;
             }
 
-            FloatingText.Show($"+{res.quantity} {res.item.DisplayName}", anchor.position, null, GatheringRewardProcessor.DefaultFloatingTextSize);
+            FloatingText.Show($"+{res.quantity} {res.item.DisplayName}", anchor, null, GatheringRewardProcessor.DefaultFloatingTextSize);
         }
 
         private FishingTool MapTool(FishingToolDefinition tool)
@@ -328,7 +328,7 @@ namespace Skills.Fishing
                 if (inventory == null || !inventory.HasItem(spot.def.BaitItemId))
                 {
                     Transform anchor = floatingTextAnchor != null ? floatingTextAnchor : transform;
-                    FloatingText.Show("You need bait", anchor.position, null, GatheringRewardProcessor.DefaultFloatingTextSize);
+                    FloatingText.Show("You need bait", anchor, null, GatheringRewardProcessor.DefaultFloatingTextSize);
                     return;
                 }
             }

--- a/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
@@ -155,7 +155,7 @@ namespace Skills.Mining
                             {
                                 FloatingText.Show(
                                     $"Mining level {result.NewLevel}",
-                                    result.Anchor.position,
+                                    result.Anchor,
                                     null,
                                     GatheringRewardProcessor.DefaultFloatingTextSize);
                                 OnLevelUp?.Invoke(result.NewLevel);

--- a/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
@@ -147,7 +147,7 @@ namespace Skills.Woodcutting
                         {
                             FloatingText.Show(
                                 $"Woodcutting level {result.NewLevel}",
-                                result.Anchor.position,
+                                result.Anchor,
                                 null,
                                 GatheringRewardProcessor.DefaultFloatingTextSize);
                             OnLevelUp?.Invoke(result.NewLevel);

--- a/Assets/Scripts/UI/FloatingTextPool.cs
+++ b/Assets/Scripts/UI/FloatingTextPool.cs
@@ -12,7 +12,7 @@ namespace UI
     public class FloatingTextPool : MonoBehaviour
     {
         /// <summary>
-        /// Global accessor so <see cref="FloatingText.Show(string, Vector3, Color?, float?, Sprite)"/> can locate the pool.
+        /// Global accessor so <see cref="FloatingText"/> helpers can locate the active pool instance.
         /// </summary>
         public static FloatingTextPool Instance { get; private set; }
 

--- a/Assets/Scripts/UI/MagicUI.cs
+++ b/Assets/Scripts/UI/MagicUI.cs
@@ -210,7 +210,7 @@ namespace UI
             if (skills != null && skills.GetLevel(SkillType.Magic) < spell.requiredMagicLevel)
             {
                 var anchor = loadout.transform.Find("FloatingTextAnchor") ?? loadout.transform;
-                FloatingText.Show($"You need a Magic level of {spell.requiredMagicLevel} to use this spell", anchor.position);
+                FloatingText.Show($"You need a Magic level of {spell.requiredMagicLevel} to use this spell", anchor);
                 return;
             }
 

--- a/Assets/Scripts/UI/PetLevelBarContextMenuExtender.cs
+++ b/Assets/Scripts/UI/PetLevelBarContextMenuExtender.cs
@@ -197,7 +197,7 @@ namespace Pets
                 var anchorChild = player.transform.Find("FloatingTextAnchor");
                 if (anchorChild != null)
                     anchor = anchorChild;
-                FloatingText.Show($"+{totalXp} XP", anchor.position);
+                FloatingText.Show($"+{totalXp} XP", anchor);
             }
         }
 


### PR DESCRIPTION
## Summary
- update FloatingText so pooled entries can follow a Transform anchor with drifting offset
- add a convenience overload for Showing floating text from a Transform and reset follow references when pooling
- switch skill, UI, and equipment call sites to provide their floating text anchor transforms when available

## Testing
- not run (Unity editor play mode required)


------
https://chatgpt.com/codex/tasks/task_e_68c9cae50a04832e85426f76f932cf1e