### PR TITLE
Use ticker-driven timing for poison controller

### DIFF
--- a/Assets/Scripts/Status/Poison/PoisonController.cs
+++ b/Assets/Scripts/Status/Poison/PoisonController.cs
@@ -1,13 +1,14 @@
 using UnityEngine;
 using Combat;
 using Status;
+using Util;
 
 namespace Status.Poison
 {
     /// <summary>
     /// Handles applying and updating poison on an entity.
     /// </summary>
-    public class PoisonController : MonoBehaviour
+    public class PoisonController : MonoBehaviour, ITickable
     {
         [Tooltip("Stats component implementing CombatTarget for this entity.")]
         [SerializeField] private MonoBehaviour statsComponent;
@@ -18,6 +19,9 @@ namespace Status.Poison
         private CombatController combat;
         private PoisonEffect active;
         private float immunityTimer;
+        private int ticksUntilNextDamage;
+        private int intervalTicks;
+        private bool tickerSubscribed;
 
         /// <summary>Invoked when poison deals damage.</summary>
         public event System.Action<int> OnPoisonTick;
@@ -51,13 +55,17 @@ namespace Status.Poison
         {
             if (IsImmune || cfg == null)
                 return;
+            if (stats != null && !stats.IsAlive)
+                return;
             if (active == null)
             {
                 active = new PoisonEffect(cfg);
-                active.OnPoisonTick += dmg => OnPoisonTick?.Invoke(dmg);
+                active.OnPoisonTick += HandlePoisonTick;
                 active.OnPoisonEnd += HandlePoisonEnded;
             }
             active.ApplyTo(stats);
+            ConfigureTickCadence(cfg, active.TickTimer);
+            SubscribeToTicker();
             NotifyBuffApplied(cfg);
         }
 
@@ -71,25 +79,56 @@ namespace Status.Poison
                 active.ForceEnd();
                 active = null;
             }
+            ticksUntilNextDamage = 0;
+            intervalTicks = 0;
+            UnsubscribeFromTicker();
             immunityTimer = Mathf.Max(immunityTimer, immunitySeconds);
+        }
+
+        /// <summary>
+        /// Recalculates the countdown using the active effect's current state. Used after save restores.
+        /// </summary>
+        public void RefreshTickCountdown()
+        {
+            if (active == null)
+            {
+                ticksUntilNextDamage = 0;
+                intervalTicks = 0;
+                UnsubscribeFromTicker();
+                return;
+            }
+
+            ConfigureTickCadence(active.Config, active.TickTimer);
+            SubscribeToTicker();
         }
 
         private void Update()
         {
             if (immunityTimer > 0f)
                 immunityTimer = Mathf.Max(0f, immunityTimer - Time.deltaTime);
-            if (active != null)
+        }
+
+        /// <inheritdoc />
+        public void OnTick()
+        {
+            if (active == null)
             {
-                if (stats != null && stats.IsAlive)
-                {
-                    active.Tick(Time.deltaTime, DealTrueDamageBridge);
-                }
-                else
-                {
-                    active.ForceEnd();
-                    active = null;
-                }
+                UnsubscribeFromTicker();
+                return;
             }
+
+            if (stats == null || !stats.IsAlive)
+            {
+                active.ForceEnd();
+                return;
+            }
+
+            if (ticksUntilNextDamage > 0)
+            {
+                ticksUntilNextDamage--;
+            }
+
+            active.Tick(Ticker.TickDuration, DealTrueDamageBridge);
         }
 
         private void OnDisable()
@@ -99,6 +138,9 @@ namespace Status.Poison
                 active.ForceEnd();
                 active = null;
             }
+            ticksUntilNextDamage = 0;
+            intervalTicks = 0;
+            UnsubscribeFromTicker();
         }
 
         /// <summary>
@@ -110,11 +152,68 @@ namespace Status.Poison
             return true;
         }
 
+        private void HandlePoisonTick(int damage)
+        {
+            ticksUntilNextDamage = intervalTicks;
+            OnPoisonTick?.Invoke(damage);
+        }
+
         private void HandlePoisonEnded()
         {
-            NotifyBuffRemoved(active != null ? active.Config : null);
+            var cfg = active != null ? active.Config : null;
+            UnsubscribeFromTicker();
+            ticksUntilNextDamage = 0;
+            intervalTicks = 0;
+            NotifyBuffRemoved(cfg);
             OnPoisonEnd?.Invoke();
             active = null;
+        }
+
+        /// <summary>
+        /// Ensures the controller is subscribed to the shared ticker while poison is active.
+        /// </summary>
+        private void SubscribeToTicker()
+        {
+            if (tickerSubscribed)
+                return;
+            if (Ticker.Instance == null)
+                return;
+            Ticker.Instance.Subscribe(this);
+            tickerSubscribed = true;
+        }
+
+        /// <summary>
+        /// Removes the controller from the shared ticker to avoid dangling callbacks.
+        /// </summary>
+        private void UnsubscribeFromTicker()
+        {
+            if (!tickerSubscribed)
+                return;
+            if (Ticker.Instance != null)
+            {
+                Ticker.Instance.Unsubscribe(this);
+            }
+            tickerSubscribed = false;
+        }
+
+        /// <summary>
+        /// Updates tick cadence data so damage aligns with the shared tick countdown.
+        /// </summary>
+        private void ConfigureTickCadence(PoisonConfig cfg, float currentTickTimer)
+        {
+            if (cfg == null)
+            {
+                ticksUntilNextDamage = 0;
+                intervalTicks = 0;
+                return;
+            }
+
+            float intervalSeconds = cfg.tickIntervalSeconds > 0f ? cfg.tickIntervalSeconds : DefaultPoisonInterval;
+            intervalTicks = Mathf.Max(1, Mathf.CeilToInt(intervalSeconds / Ticker.TickDuration));
+            float clampedTimer = Mathf.Clamp(currentTickTimer, 0f, intervalSeconds);
+            float remainingSeconds = Mathf.Max(0f, intervalSeconds - clampedTimer);
+            int remainingTicks = Mathf.CeilToInt(remainingSeconds / Ticker.TickDuration);
+            ticksUntilNextDamage = Mathf.Clamp(remainingTicks, 0, intervalTicks);
         }
 
         private void NotifyBuffApplied(PoisonConfig cfg)

--- a/Assets/Scripts/Status/Poison/PoisonSaveBridge.cs
+++ b/Assets/Scripts/Status/Poison/PoisonSaveBridge.cs
@@ -77,6 +77,7 @@ namespace Status.Poison
                         data.currentDamage,
                         data.ticksSinceDecay,
                         cfg.tickIntervalSeconds - data.timeToNextTick);
+                    controller.RefreshTickCountdown();
                     controller.ImmunityTimer = savedImmune;
                 }
             }


### PR DESCRIPTION
## Summary
- implement ITickable on PoisonController so poison logic advances on shared Ticker ticks
- add tick countdown tracking, subscription management, and cleanup when poison ends or controller disables
- refresh the saved poison state so restored effects resubscribe and align with the shared countdown

## Testing
- not run (Unity editor tests not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ca9726fb9c832eb0cd5c2f813e8416