### PR TITLE
Adjust poison timers to use calculated lifetimes

### DIFF
--- a/Assets/Scripts/Status/Poison/PoisonSaveBridge.cs
+++ b/Assets/Scripts/Status/Poison/PoisonSaveBridge.cs
@@ -78,6 +78,7 @@ namespace Status.Poison
                         data.ticksSinceDecay,
                         cfg.tickIntervalSeconds - data.timeToNextTick);
                     controller.RefreshTickCountdown();
+                    controller.ResyncBuffTimerWithState();
                     controller.ImmunityTimer = savedImmune;
                 }
             }


### PR DESCRIPTION
## Summary
- derive poison lifetimes from configuration values so recurring HUD timers become fixed-duration countdowns
- cache and reuse buff definitions to ensure removal payloads match the applied timer
- resync poison buff timers after loading save data so the HUD reflects the remaining duration

## Testing
- Not run (Unity editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ca9f45fb08832e864bf2f7703f4729