### PR TITLE
Refine buff HUD layout sizing and anchor

### DIFF
--- a/Assets/Prefabs/SceneObjects/BuffSystems.prefab
+++ b/Assets/Prefabs/SceneObjects/BuffSystems.prefab
@@ -59,8 +59,11 @@ MonoBehaviour:
   m_Name:
   m_EditorClassIdentifier:
   infoBoxPrefab: {fileID: 377000000000000005, guid: 9ef42ef0a57f4016b22d560d02f33959, type: 3}
-  anchoredOffset: {x: -8, y: -140}
-  verticalSpacing: 4
+  topPadding: 8
+  leftPadding: 8
+  verticalSpacing: 2
+  columns: 3
+  horizontalSpacing: 2
   ordering: []
   playExpiryNotification: 1
   expiryClip: {fileID: 0}

--- a/Assets/Prefabs/UI/Status/BuffInfoBox.prefab
+++ b/Assets/Prefabs/UI/Status/BuffInfoBox.prefab
@@ -40,7 +40,7 @@ RectTransform:
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 148, y: 40}
+  m_SizeDelta: {x: 32, y: 32}
   m_Pivot: {x: 1, y: 1}
 --- !u!222 &377000000000000002
 CanvasRenderer:
@@ -107,9 +107,9 @@ CanvasGroup:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5846359844436729055}
   m_Enabled: 1
-  m_Alpha: 1
-  m_Interactable: 1
-  m_BlocksRaycasts: 1
+  m_Alpha: 0.92
+  m_Interactable: 0
+  m_BlocksRaycasts: 0
   m_IgnoreParentGroups: 0
 --- !u!1 &5846359844436729056
 GameObject:
@@ -143,11 +143,11 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 377000000000000001}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.5}
-  m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 12, y: 0}
-  m_SizeDelta: {x: 20, y: 20}
-  m_Pivot: {x: 0, y: 0.5}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 28, y: 28}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &377000000000000102
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -166,8 +166,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 0
@@ -218,11 +218,11 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 377000000000000001}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.5}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -12, y: -4}
-  m_SizeDelta: {x: -32, y: -14}
-  m_Pivot: {x: 1, y: 1}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -1}
+  m_SizeDelta: {x: 30, y: 9}
+  m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &377000000000000202
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -244,7 +244,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Text
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 0.95686275, b: 0.8627451, a: 1}
+  m_Color: {r: 1, g: 0.9411765, b: 0.73333335, a: 1}
   m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -253,15 +253,15 @@ MonoBehaviour:
       m_Calls: []
   m_FontData:
     m_Font: {fileID: 12800000, guid: 6dc49ea977bb85a49ac4df5338f901f4, type: 3}
-    m_FontSize: 14
+    m_FontSize: 7
     m_FontStyle: 0
     m_BestFit: 0
     m_MinSize: 1
     m_MaxSize: 40
-    m_Alignment: 0
+    m_Alignment: 1
     m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
+    m_RichText: 0
+    m_HorizontalOverflow: 1
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: 
@@ -297,11 +297,11 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 377000000000000001}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: -12, y: 8}
-  m_SizeDelta: {x: -32, y: -18}
-  m_Pivot: {x: 1, y: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 1}
+  m_SizeDelta: {x: 30, y: 9}
+  m_Pivot: {x: 0.5, y: 0}
 --- !u!222 &377000000000000302
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -320,10 +320,10 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
+  m_Name:
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Text
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 0.83137256, g: 0.83137256, b: 0.83137256, a: 1}
   m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -332,14 +332,14 @@ MonoBehaviour:
       m_Calls: []
   m_FontData:
     m_Font: {fileID: 12800000, guid: 6dc49ea977bb85a49ac4df5338f901f4, type: 3}
-    m_FontSize: 12
+    m_FontSize: 6
     m_FontStyle: 0
     m_BestFit: 0
     m_MinSize: 1
     m_MaxSize: 40
-    m_Alignment: 8
+    m_Alignment: 7
     m_AlignByGeometry: 0
-    m_RichText: 1
+    m_RichText: 0
     m_HorizontalOverflow: 1
     m_VerticalOverflow: 0
     m_LineSpacing: 1

--- a/Assets/Scripts/UI/HUD/BuffHudManager.cs
+++ b/Assets/Scripts/UI/HUD/BuffHudManager.cs
@@ -20,10 +20,11 @@ namespace UI.HUD
         public static BuffHudManager Instance => instance;
 
         [SerializeField] private BuffInfoBox infoBoxPrefab;
-        [SerializeField] private Vector2 anchoredOffset = new Vector2(-8f, -140f);
-        [SerializeField] private float verticalSpacing = 4f;
+        [SerializeField] private float topPadding = 8f;
+        [SerializeField] private float leftPadding = 8f;
+        [SerializeField] private float verticalSpacing = 2f;
         [SerializeField] private int columns = 3;
-        [SerializeField] private float horizontalSpacing = 4f;
+        [SerializeField] private float horizontalSpacing = 2f;
         [SerializeField] private BuffType[] ordering;
         [SerializeField] private bool playExpiryNotification = true;
         [SerializeField] private AudioClip expiryClip;
@@ -399,7 +400,12 @@ namespace UI.HUD
                 container.pivot = new Vector2(1f, 1f);
             }
 
-            container.anchoredPosition = anchoredOffset;
+            float anchorWidth = anchor.rect.width;
+            if (anchorWidth <= 0f)
+                anchorWidth = anchor.sizeDelta.x;
+
+            container.anchoredPosition = new Vector2(-(anchorWidth + leftPadding), -topPadding);
+            LayoutBoxes();
         }
 
         private void EnsurePersistence()

--- a/Assets/Scripts/UI/HUD/BuffInfoBox.cs
+++ b/Assets/Scripts/UI/HUD/BuffInfoBox.cs
@@ -31,9 +31,9 @@ namespace UI.HUD
             if (parent == null)
                 throw new System.ArgumentNullException(nameof(parent));
 
-            const float slotSize = 64f;
-            const float iconSize = 56f;
-            const float textPadding = 2f;
+            const float slotSize = 32f;
+            const float iconSize = 28f;
+            const float textPadding = 1f;
 
             // Root object that mimics the prefab layout.  The anchors/pivot align
             // with the HUD expectation of stacking boxes downward from the
@@ -93,7 +93,7 @@ namespace UI.HUD
             nameGO.transform.SetParent(frameGO.transform, false);
             var nameText = nameGO.GetComponent<Text>();
             nameText.font = legacyFont;
-            nameText.fontSize = 14;
+            nameText.fontSize = 7;
             nameText.alignment = TextAnchor.UpperCenter;
             nameText.color = new Color32(255, 240, 187, 255);
             nameText.raycastTarget = false;
@@ -105,7 +105,7 @@ namespace UI.HUD
             nameRect.anchorMax = new Vector2(0.5f, 1f);
             nameRect.pivot = new Vector2(0.5f, 1f);
             nameRect.anchoredPosition = new Vector2(0f, -textPadding);
-            nameRect.sizeDelta = new Vector2(slotSize - (textPadding * 2f), 18f);
+            nameRect.sizeDelta = new Vector2(slotSize - (textPadding * 2f), 9f);
             component.nameText = nameText;
 
             nameText.text = string.Empty;
@@ -116,7 +116,7 @@ namespace UI.HUD
 
             var timerText = timerGO.GetComponent<Text>();
             timerText.font = legacyFont;
-            timerText.fontSize = 12;
+            timerText.fontSize = 6;
             timerText.alignment = TextAnchor.LowerCenter;
             timerText.color = new Color32(212, 212, 212, 255);
             timerText.raycastTarget = false;
@@ -129,7 +129,7 @@ namespace UI.HUD
             timerRect.anchorMax = new Vector2(0.5f, 0f);
             timerRect.pivot = new Vector2(0.5f, 0f);
             timerRect.anchoredPosition = new Vector2(0f, textPadding);
-            timerRect.sizeDelta = new Vector2(slotSize - (textPadding * 2f), 18f);
+            timerRect.sizeDelta = new Vector2(slotSize - (textPadding * 2f), 9f);
             component.timerText = timerText;
 
             component.normalTimerColor = timerText.color;


### PR DESCRIPTION
## Summary
- replace the hard-coded anchored offset with positive top/left padding values so the buff HUD can align with the minimap width
- shrink runtime-created buff info boxes and match the prefab so every slot is half the previous size with smaller fonts and padding
- lower the default grid spacing to keep the condensed layout tight and update prefabs that reference the manager settings

## Testing
- not run (UI layout change only)


------
https://chatgpt.com/codex/tasks/task_e_68caacd9900c832eb6761b5333894e24