### PR TITLE
Set antifire buff icon

### DIFF
--- a/Assets/Scripts/Status/Antifire/AntifireProtectionController.cs
+++ b/Assets/Scripts/Status/Antifire/AntifireProtectionController.cs
@@ -99,7 +99,7 @@ namespace Status.Antifire
             {
                 type = BuffType.Antifire,
                 displayName = "Antifire",
-                iconId = string.Empty,
+                iconId = "antifire",
                 durationSeconds = StandardAntifireDurationSeconds,
                 recurringIntervalSeconds = 0f,
                 isRecurring = false,


### PR DESCRIPTION
## Summary
- set the antifire buff definition to reference the antifire HUD icon so the existing sprite is used

## Testing
- not run (Unity editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cabf62f2bc832e8eebf97441a336ba