### PR TITLE
Correct OSRS window resolution to 1024x768

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -260,7 +260,7 @@ MonoBehaviour:
   size: 20
   slotSize: {x: 32, y: 32}
   slotSpacing: {x: 4, y: 4}
-  referenceResolution: {x: 640, y: 360}
+  referenceResolution: {x: 1024, y: 768}
   columns: 4
   useSharedUIRoot: 1
   slotFrameSprite: {fileID: 0}
@@ -490,7 +490,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   slotSize: {x: 32, y: 32}
   slotSpacing: {x: 4, y: 4}
-  referenceResolution: {x: 640, y: 360}
+  referenceResolution: {x: 1024, y: 768}
   slotFrameSprite: {fileID: 0}
   emptySlotColor: {r: 1, g: 1, b: 1, a: 1}
   windowColor: {r: 0.15, g: 0.15, b: 0.15, a: 0.95}

--- a/Assets/Prefabs/SceneObjects/ShopUI.prefab
+++ b/Assets/Prefabs/SceneObjects/ShopUI.prefab
@@ -46,7 +46,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   slotSize: {x: 32, y: 32}
   slotSpacing: {x: 4, y: 4}
-  referenceResolution: {x: 640, y: 360}
+  referenceResolution: {x: 1024, y: 768}
   slotFrameSprite: {fileID: 0}
   emptySlotColor: {r: 1, g: 1, b: 1, a: 0.25}
   windowColor: {r: 0.15, g: 0.15, b: 0.15, a: 0.95}

--- a/Assets/Scripts/Bank/BankUI.cs
+++ b/Assets/Scripts/Bank/BankUI.cs
@@ -17,7 +17,7 @@ namespace BankSystem
     {
         public Vector2 slotSize = new Vector2(32f, 32f);
         public Vector2 slotSpacing = new Vector2(4f, 4f);
-        public Vector2 referenceResolution = new Vector2(640f, 360f);
+        public Vector2 referenceResolution = new Vector2(1024f, 768f);
         public Color emptySlotColor = new Color(1f, 1f, 1f, 0f);
 
         [Header("Stack Count Colors")]

--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -29,6 +29,15 @@ namespace Core
         private BycatchManager bycatchManager;
         private Coroutine autosaveRoutine;
 
+        [Header("Window Configuration")]
+        [SerializeField]
+        [Tooltip("OSRS-style fixed window dimensions. Defaults to the 1024x768 client layout.")]
+        private Vector2 osrsWindowedResolution = new Vector2(1024f, 768f);
+
+        [SerializeField]
+        [Tooltip("When enabled the editor will also enforce the fixed window size during Play Mode.")]
+        private bool applyResolutionInEditorPlayMode = false;
+
         private const float AutosaveInterval = 10f;
 
         /// <summary>
@@ -43,6 +52,8 @@ namespace Core
 
         protected override void Awake()
         {
+            ConfigureWindowMode();
+
             if (Instance != null && Instance != this)
             {
                 Destroy(gameObject);
@@ -54,6 +65,24 @@ namespace Core
             Instance = this;
 
             CacheServices(false);
+        }
+
+        /// <summary>
+        /// Forces the game to start in a fixed-size window that mirrors OSRS' 4:3 aspect ratio.
+        /// Ensures the runtime resolution is deterministic so UI layouts align perfectly.
+        /// </summary>
+        private void ConfigureWindowMode()
+        {
+            // Clamp to sane minimums to avoid invalid resolution requests.
+            var width = Mathf.Max(1, Mathf.RoundToInt(osrsWindowedResolution.x));
+            var height = Mathf.Max(1, Mathf.RoundToInt(osrsWindowedResolution.y));
+
+            Screen.fullScreenMode = FullScreenMode.Windowed;
+
+            if (!Application.isEditor || applyResolutionInEditorPlayMode)
+            {
+                Screen.SetResolution(width, height, FullScreenMode.Windowed);
+            }
         }
 
         private void Start()

--- a/Assets/Scripts/Inventory/Equipment.cs
+++ b/Assets/Scripts/Inventory/Equipment.cs
@@ -34,7 +34,7 @@ namespace Inventory
         public Vector2 slotSpacing = new(4f, 4f);
 
         [Tooltip("Reference resolution for the UI Canvas.")]
-        public Vector2 referenceResolution = new(640f, 360f);
+        public Vector2 referenceResolution = new(1024f, 768f);
 
         [Tooltip("Optional frame sprite for slots (9 sliced).")]
         public Sprite slotFrameSprite;

--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -51,8 +51,8 @@ namespace Inventory
         public Vector2 slotSize = new Vector2(32, 32);
         [Tooltip("Spacing between slots in UI pixels.")]
         public Vector2 slotSpacing = new Vector2(4, 4);
-        [Tooltip("Reference resolution for Canvas Scaler (use even numbers).")]
-        public Vector2 referenceResolution = new Vector2(640, 360);
+        [Tooltip("Reference resolution for Canvas Scaler.")]
+        public Vector2 referenceResolution = new Vector2(1024f, 768f);
         [Tooltip("Number of columns in the slot grid.")]
         public int columns = 2;
         [Tooltip("Reuse a shared UI root across multiple inventories.")]

--- a/Assets/Scripts/Shop/ShopUI.cs
+++ b/Assets/Scripts/Shop/ShopUI.cs
@@ -18,7 +18,7 @@ namespace ShopSystem
         [Header("Layout")]
         public Vector2 slotSize = new Vector2(32, 32);
         public Vector2 slotSpacing = new Vector2(4, 4);
-        public Vector2 referenceResolution = new Vector2(640, 360);
+        public Vector2 referenceResolution = new Vector2(1024f, 768f);
         public Sprite slotFrameSprite;
         public Color emptySlotColor = new Color(1f, 1f, 1f, 0.25f);
 

--- a/Assets/Scripts/UI/InterfaceTabButtons.cs
+++ b/Assets/Scripts/UI/InterfaceTabButtons.cs
@@ -13,6 +13,8 @@ namespace UI
     /// </summary>
     public class InterfaceTabButtons : MonoBehaviour
     {
+        private static readonly Vector2 FixedWindowResolution = new Vector2(1024f, 768f);
+
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
         private static void Init()
         {
@@ -36,7 +38,7 @@ namespace UI
 
             var scaler = gameObject.AddComponent<CanvasScaler>();
             scaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
-            scaler.referenceResolution = new Vector2(1920f, 1080f);
+            scaler.referenceResolution = FixedWindowResolution;
             scaler.screenMatchMode = CanvasScaler.ScreenMatchMode.MatchWidthOrHeight;
             scaler.matchWidthOrHeight = 0.5f;
 

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -42,10 +42,10 @@ PlayerSettings:
   m_SplashScreenLogos: []
   m_VirtualRealitySplashScreen: {fileID: 0}
   m_HolographicTrackingLossScreen: {fileID: 0}
-  defaultScreenWidth: 1920
-  defaultScreenHeight: 1080
-  defaultScreenWidthWeb: 960
-  defaultScreenHeightWeb: 600
+  defaultScreenWidth: 1024
+  defaultScreenHeight: 768
+  defaultScreenWidthWeb: 1024
+  defaultScreenHeightWeb: 768
   m_StereoRenderingPath: 0
   m_ActiveColorSpace: 1
   unsupportedMSAAFallback: 0


### PR DESCRIPTION
## Summary
- update GameManager to lock the window to the 1024x768 OSRS client resolution
- retune inventory, equipment, bank, shop, and interface tab UI canvases/prefabs to the 1024x768 reference size
- align Unity player settings defaults with the 1024x768 fixed window configuration

## Testing
- not run (Unity editor/CI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cacb722f38832e8c26270f5e4044a0