### PR TITLE
Ensure status save bridges persist buff/poison state across shutdown

### DIFF
--- a/Assets/Scripts/Status/Poison/PoisonSaveBridge.cs
+++ b/Assets/Scripts/Status/Poison/PoisonSaveBridge.cs
@@ -9,6 +9,7 @@ namespace Status.Poison
     /// Persists <see cref="PoisonController"/> state using the <see cref="SaveManager"/>.
     /// </summary>
     [DisallowMultipleComponent]
+    [DefaultExecutionOrder(-100)]
     public class PoisonSaveBridge : MonoBehaviour, ISaveable
     {
         [SerializeField] private PoisonController controller;


### PR DESCRIPTION
## Summary
- ensure `PoisonSaveBridge` runs before `PoisonController` so poison state persists during shutdown
- lower `BuffStateSaveBridge` execution order and cache the latest buff snapshot when the timer service is unavailable to prevent losing buff saves

## Testing
- not run (Unity editor unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cad980fc48832eb84871d60746eabd