### PR TITLE
Adjust poison restoration for missing combat controller

### DIFF
--- a/Assets/Scripts/Status/Poison/PoisonSaveBridge.cs
+++ b/Assets/Scripts/Status/Poison/PoisonSaveBridge.cs
@@ -287,7 +287,7 @@ namespace Status.Poison
                     continue;
                 }
 
-                if (controller.HasCombatController && controller.HasAliveTarget)
+                if (controller.HasAliveTarget)
                     break;
 
                 yield return null;
@@ -322,7 +322,9 @@ namespace Status.Poison
                 if (controller != null && controller.isActiveAndEnabled)
                 {
                     controller.RefreshTickCountdown();
-                    controller.ResyncBuffTimerWithState();
+
+                    if (controller.HasCombatController)
+                        controller.ResyncBuffTimerWithState();
                 }
 
                 if (controller != null)
@@ -331,7 +333,9 @@ namespace Status.Poison
             else if (controller != null && controller.isActiveAndEnabled)
             {
                 controller.RefreshTickCountdown();
-                controller.ResyncBuffTimerWithState();
+
+                if (controller.HasCombatController)
+                    controller.ResyncBuffTimerWithState();
             }
 
             pendingResyncRoutine = null;


### PR DESCRIPTION
## Summary
- allow the poison restoration coroutine to resume once the target is alive instead of waiting for a combat controller
- guard HUD resync so it only fires when a combat controller is available while still restoring poison damage immediately

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb2a2a207c832e9f2185bc58c9282c