### PR TITLE
Ensure respawns restore full health events

### DIFF
--- a/Assets/Scripts/Player/PlayerHitpoints.cs
+++ b/Assets/Scripts/Player/PlayerHitpoints.cs
@@ -124,7 +124,22 @@ namespace Player
         {
             if (amount <= 0)
                 return;
+            if (currentHp + amount >= MaxHp)
+            {
+                RestoreToFullHealth();
+                return;
+            }
+
             currentHp = Mathf.Min(MaxHp, currentHp + amount);
+            OnHealthChanged?.Invoke(currentHp, MaxHp);
+        }
+
+        /// <summary>
+        /// Restores the player's hitpoints to their maximum value and notifies listeners.
+        /// </summary>
+        public void RestoreToFullHealth()
+        {
+            currentHp = MaxHp;
             OnHealthChanged?.Invoke(currentHp, MaxHp);
         }
 

--- a/Assets/Scripts/Player/PlayerRespawnSystem.cs
+++ b/Assets/Scripts/Player/PlayerRespawnSystem.cs
@@ -101,7 +101,7 @@ namespace Player
                 hitpoints.transform.position = RespawnPoint.Current.transform.position;
 
             if (hitpoints != null)
-                hitpoints.Heal(hitpoints.MaxHp);
+                hitpoints.RestoreToFullHealth();
 
             if (fader != null)
                 yield return fader.FadeIn();


### PR DESCRIPTION
## Summary
- add a RestoreToFullHealth helper on PlayerHitpoints to raise the usual events when filling HP
- route Heal and PlayerRespawnSystem to the new helper so respawns and maxed heals trigger immediate UI refreshes

## Testing
- not run (Unity editor unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cbcf79060c832e8b1557ae4fff7e55