### PR TITLE
Refresh respawn references before restoring health

### DIFF
--- a/Assets/Scripts/Player/PlayerRespawnSystem.cs
+++ b/Assets/Scripts/Player/PlayerRespawnSystem.cs
@@ -93,15 +93,24 @@ namespace Player
         {
             isRespawning = true;
 
+            // Refresh player references in case a new player instance spawned during respawn.
+            FindPlayer();
+            var hasPlayer = hitpoints != null;
+
             var fader = GameManager.ScreenFader;
             if (fader != null)
                 yield return fader.FadeOut();
 
-            if (RespawnPoint.Current != null && hitpoints != null)
+            if (RespawnPoint.Current != null && hasPlayer)
                 hitpoints.transform.position = RespawnPoint.Current.transform.position;
 
-            if (hitpoints != null)
-                hitpoints.RestoreToFullHealth();
+            if (!hasPlayer)
+            {
+                isRespawning = false;
+                yield break;
+            }
+
+            hitpoints.RestoreToFullHealth();
 
             if (fader != null)
                 yield return fader.FadeIn();


### PR DESCRIPTION
## Summary
- refresh cached player component references when respawning to bind to the current player instance
- ensure respawn repositioning still occurs and always restore the player's health after a successful rebind

## Testing
- not run (Unity editor required)


------
https://chatgpt.com/codex/tasks/task_e_68cbd543df20832eb48c17cdd105f2e8