### PR TITLE
Fix duplicate local variable name in NPC wanderer

### DIFF
--- a/Assets/Scripts/NPC/Movement/NpcWanderer.cs
+++ b/Assets/Scripts/NPC/Movement/NpcWanderer.cs
@@ -285,11 +285,12 @@ namespace NPC
         {
             if (_frozen)
             {
-                Vector2 pos = _rb != null ? _rb.position : (Vector2)transform.position;
+                // Maintain the frozen position without reusing the interpolated movement variable name below.
+                Vector2 frozenPosition = _rb != null ? _rb.position : (Vector2)transform.position;
                 if (_rb != null)
-                    _rb.MovePosition(pos);
+                    _rb.MovePosition(frozenPosition);
                 spriteAnimator?.UpdateVisuals(Vector2.zero);
-                _lastPos = pos;
+                _lastPos = frozenPosition;
                 return;
             }
 


### PR DESCRIPTION
## Summary
- rename the frozen state position variable in `NpcWanderer.Update` to avoid shadowing the interpolated position variable
- ensure the frozen branch updates the rigidbody and cached position using the new variable name

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cbe860409c832e8184a68a8d7cf6c5