### PR TITLE
Prevent frozen player auto-move and hold attacks

### DIFF
--- a/Assets/Scripts/NPC/Combat/NpcAttackOnClick.cs
+++ b/Assets/Scripts/NPC/Combat/NpcAttackOnClick.cs
@@ -1,6 +1,8 @@
+using System.Collections;
 using UnityEngine;
 using Combat;
 using Player;
+using Status.Freeze;
 using UI;
 
 namespace NPC
@@ -13,9 +15,25 @@ namespace NPC
     {
         private NpcCombatant combatant;
 
+        /// <summary>
+        /// Tracks any coroutine that is holding an attack command while the player is frozen so
+        /// multiple clicks do not spawn duplicate routines.
+        /// </summary>
+        private Coroutine heldAttackRoutine;
+
         private void Awake()
         {
             combatant = GetComponent<NpcCombatant>();
+        }
+
+        private void OnDisable()
+        {
+            // Ensure pending routines do not leak when this component is disabled or destroyed.
+            if (heldAttackRoutine != null)
+            {
+                StopCoroutine(heldAttackRoutine);
+                heldAttackRoutine = null;
+            }
         }
 
         private void OnMouseDown()
@@ -27,24 +45,101 @@ namespace NPC
             if (playerMover == null)
                 return;
 
+            if (heldAttackRoutine != null)
+            {
+                StopCoroutine(heldAttackRoutine);
+                heldAttackRoutine = null;
+            }
+
             var npcAttack = GetComponent<NpcAttackController>();
             var playerTarget = playerController.GetComponent<PlayerCombatTarget>();
             npcAttack?.BeginAttacking(playerTarget);
 
-            void AttemptAttack()
-            {
-                playerController.TryAttackTarget(combatant);
-            }
+            // Determine whether the player is currently frozen so we can decide how to handle
+            // the attack click. Frozen players should not be able to move but should retain the
+            // attack command so it can fire if the NPC walks into range.
+            var freezeController = playerController.GetComponent<FrozenStatusController>()
+                ?? playerMover.GetComponent<FrozenStatusController>();
+            bool playerFrozen = freezeController != null && freezeController.IsFrozen;
 
             float range = MagicUI.GetActiveSpellRange();
-            if (Vector2.Distance(playerController.transform.position, transform.position) > range)
+            float distance = Vector2.Distance(playerController.transform.position, transform.position);
+
+            // Always try to attack immediately when already in range; this covers both frozen and
+            // unfrozen states.
+            if (distance <= range)
             {
-                playerMover.MoveTo(transform, range, AttemptAttack);
+                playerController.TryAttackTarget(combatant);
+                return;
             }
-            else
+
+            if (playerFrozen)
             {
-                AttemptAttack();
+                // The player is frozen and out of range. Hold the attack command and repeatedly
+                // check whether the NPC moves into range or the freeze expires.
+                heldAttackRoutine = StartCoroutine(HoldAttackWhileFrozen(
+                    playerController,
+                    playerMover,
+                    freezeController,
+                    combatant));
+                return;
             }
+
+            // Default behaviour for mobile players remains unchanged – auto walk into range and
+            // fire once close enough.
+            playerMover.MoveTo(transform, range, () => playerController.TryAttackTarget(combatant));
+        }
+
+        /// <summary>
+        /// Waits while the player is frozen and out of spell range. Once the NPC moves close
+        /// enough or the freeze ends the stored attack command is executed automatically.
+        /// </summary>
+        private IEnumerator HoldAttackWhileFrozen(
+            CombatController playerController,
+            PlayerMover playerMover,
+            FrozenStatusController freezeController,
+            NpcCombatant target)
+        {
+            // Small guard to avoid running the routine when any critical dependency is missing.
+            if (playerController == null || playerMover == null || freezeController == null || target == null)
+            {
+                heldAttackRoutine = null;
+                yield break;
+            }
+
+            while (playerController != null && freezeController != null && freezeController.IsFrozen && target != null && target.IsAlive)
+            {
+                float range = MagicUI.GetActiveSpellRange();
+                float distance = Vector2.Distance(playerController.transform.position, target.transform.position);
+
+                // Attack immediately if the NPC wanders into range while the player is frozen.
+                if (distance <= range)
+                {
+                    if (playerController.TryAttackTarget(target))
+                        break;
+                }
+
+                yield return null;
+            }
+
+            if (playerController != null && freezeController != null && target != null && target.IsAlive)
+            {
+                float range = MagicUI.GetActiveSpellRange();
+                float distance = Vector2.Distance(playerController.transform.position, target.transform.position);
+
+                if (distance <= range)
+                {
+                    playerController.TryAttackTarget(target);
+                }
+                else if (!freezeController.IsFrozen && playerMover != null)
+                {
+                    // Once the freeze effect ends resume the standard auto movement logic so the
+                    // player chases the NPC if they are still out of range.
+                    playerMover.MoveTo(target.transform, range, () => playerController.TryAttackTarget(target));
+                }
+            }
+
+            heldAttackRoutine = null;
         }
     }
 }


### PR DESCRIPTION
## Summary
- stop NPC click handler from forcing movement when the player is frozen and out of spell range
- hold the queued spell attack until the NPC walks into range or the freeze expires, then resume normal auto-move

## Testing
- not run (Unity editor unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cbef539c18832ebef0e80f739702ff