### PR TITLE
Fix NPC retaliation timing

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -139,12 +139,6 @@ namespace Combat
                     return false;
                 StopCoroutine(attackRoutine);
             }
-            var npcAttack = (target as MonoBehaviour)?.GetComponent<NpcAttackController>();
-            if (npcAttack != null)
-            {
-                var playerTarget = GetComponent<PlayerCombatTarget>();
-                npcAttack.BeginAttacking(playerTarget);
-            }
             attackRoutine = StartCoroutine(AttackRoutine(target));
             if (PetDropSystem.GuardModeEnabled)
             {

--- a/Assets/Scripts/NPC/Combat/NpcAttackOnClick.cs
+++ b/Assets/Scripts/NPC/Combat/NpcAttackOnClick.cs
@@ -51,10 +51,6 @@ namespace NPC
                 heldAttackRoutine = null;
             }
 
-            var npcAttack = GetComponent<NpcAttackController>();
-            var playerTarget = playerController.GetComponent<PlayerCombatTarget>();
-            npcAttack?.BeginAttacking(playerTarget);
-
             // Determine whether the player is currently frozen so we can decide how to handle
             // the attack click. Frozen players should not be able to move but should retain the
             // attack command so it can fire if the NPC walks into range.


### PR DESCRIPTION
## Summary
- stop NPCs from auto-retaliating when clicked by the player
- rely on damage events to trigger NPC retaliation so they respond only after being hit

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cbf4f4d5ac832ea6ac709822eb3f58