### PR TITLE
Add skilling pet reward helper and integrate usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@
 - `GatheringInventoryHelper` (new) owns the shared `Resources.Load` cache for `ItemData` lookups and the pet overflow capacity rules. When adding or updating gathering skills call `GatheringInventoryHelper.CanAcceptGatheredItem` instead of duplicating inventory checks. Pass the per-skill dictionary field by reference so the helper can bind it to the shared cache, and supply the double-drop pet ID ("Beaver", "Heron", "Rock Golem", etc.) to keep bonus rolls consistent.
 - When a pet doubles resource output the helper will automatically probe the pet's `PetStorage` inventory. Ensure any new pets that offer a similar bonus have a matching `id` string and an attached `PetStorage` component so overflow routing continues to work.
 - `Skills/Outfits/SkillingOutfitRewarder` centralises the 1-in-2500 skilling outfit rolls. Pass the per-skill `SkillingOutfitProgress`, inventory, bank hook, toast strings, and RNG delegate so debug logging and sanity checks remain consistent across every gathering skill.
+- `Skills/Common/SkillingPetRewarder` wraps `PetDropSystem.TryRollPet` for gathering skills. Supply the source ID, `SkillManager`, best available anchor, and optional 1-in-N override so pet rolls stay consistent.
 
 ## Testing & Validation
 - Play mode and edit mode tests live in `Assets/Tests` (currently NUnit-based unit tests like `CookingSkillTests`, `NpcFactionTests`, `NpcElementalModifierTests`). Run them through the Unity Test Runner or an equivalent CLI invocation (`Unity -runTests`) whenever you touch gameplay logic.

--- a/Assets/Scripts/Skills/Common/SkillingPetRewarder.cs
+++ b/Assets/Scripts/Skills/Common/SkillingPetRewarder.cs
@@ -1,0 +1,57 @@
+using Pets;
+using Skills;
+using UnityEngine;
+
+namespace Skills.Common
+{
+    /// <summary>
+    /// Centralises the pet roll logic used by skilling actions so each skill can
+    /// simply forward its source identifier, the player's skills, and the world
+    /// location of the interaction. Handles basic validation and anchor
+    /// resolution before delegating to <see cref="PetDropSystem"/>.
+    /// </summary>
+    public static class SkillingPetRewarder
+    {
+        /// <summary>
+        /// Attempt to roll for a skilling pet using the player's Beastmaster
+        /// level. The helper short-circuits when the override chance is null or
+        /// non-positive and uses the provided transforms to derive the best
+        /// world position for the drop.
+        /// </summary>
+        /// <param name="sourceId">Pet drop table identifier (e.g. "woodcutting").</param>
+        /// <param name="skills">Player skill manager used for Beastmaster level queries.</param>
+        /// <param name="preferredAnchor">Primary transform used to position the pet roll.</param>
+        /// <param name="oneInNOverride">Optional 1-in-N override chance. Null or &lt;= 0 disables the roll.</param>
+        /// <param name="fallbackAnchor">Optional backup transform when the preferred anchor is missing.</param>
+        /// <returns>True if a pet was rolled and granted.</returns>
+        public static bool TryRollPet(string sourceId, SkillManager skills, Transform preferredAnchor, int? oneInNOverride = null, Transform fallbackAnchor = null)
+        {
+            if (string.IsNullOrEmpty(sourceId))
+                return false;
+            if (!oneInNOverride.HasValue || oneInNOverride.Value <= 0)
+                return false;
+
+            Transform anchor = preferredAnchor;
+            if (anchor == null)
+            {
+                anchor = fallbackAnchor != null ? fallbackAnchor : skills != null ? skills.transform : null;
+            }
+
+            Vector3 worldPosition;
+            if (anchor != null)
+            {
+                worldPosition = anchor.position;
+            }
+            else if (skills != null)
+            {
+                worldPosition = skills.transform.position;
+            }
+            else
+            {
+                worldPosition = Vector3.zero;
+            }
+
+            return PetDropSystem.TryRollPet(sourceId, worldPosition, skills, oneInNOverride.Value, out _);
+        }
+    }
+}

--- a/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
+++ b/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
@@ -169,8 +169,7 @@ namespace Skills.Cooking
                     onSuccess = result =>
                     {
                         int petChance = Mathf.Max(5000, 10000 - (level - 1) * 100);
-                        var anchorTransform = result.Anchor != null ? result.Anchor : transform;
-                        PetDropSystem.TryRollPet("cooking", anchorTransform.position, skills, petChance, out _);
+                        SkillingPetRewarder.TryRollPet("cooking", skills, result.Anchor ?? transform, petChance);
                         TryAwardCookingOutfitPiece();
                     },
                     onFailure = _ => StopCooking()

--- a/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
@@ -161,6 +161,11 @@ namespace Skills.Fishing
                     },
                     onSuccess = result =>
                     {
+                        int? petChance = fish != null ? fish.PetDropChance : (int?)null;
+                        Transform petAnchor = currentSpot != null
+                            ? currentSpot.transform
+                            : result.Anchor != null ? result.Anchor : transform;
+                        SkillingPetRewarder.TryRollPet("fishing", skills, petAnchor, petChance);
                         TryRollBycatch(result.Anchor);
                         TryAwardFishingOutfitPiece();
                     },

--- a/Assets/Scripts/Skills/Fishing/Data/FishDefinition.cs
+++ b/Assets/Scripts/Skills/Fishing/Data/FishDefinition.cs
@@ -15,11 +15,13 @@ namespace Skills.Fishing
         [Header("Rewards")]
         [SerializeField] private int xp = 10;
         [SerializeField] private string itemId;
+        [SerializeField] private int petDropChance = 0;
 
         public string Id => id;
         public string DisplayName => displayName;
         public int RequiredLevel => requiredLevel;
         public int Xp => xp;
         public string ItemId => itemId;
+        public int PetDropChance => petDropChance;
     }
 }

--- a/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
@@ -154,8 +154,12 @@ namespace Skills.Mining
                         },
                         onSuccess = result =>
                         {
-                            if (ore.PetDropChance > 0)
-                                PetDropSystem.TryRollPet("mining", currentRock.transform.position, skills, ore.PetDropChance, out _);
+                            int? petChance = ore != null ? ore.PetDropChance : (int?)null;
+                            SkillingPetRewarder.TryRollPet(
+                                "mining",
+                                skills,
+                                currentRock != null ? currentRock.transform : transform,
+                                petChance);
 
                             if (QuestManager.Instance != null && QuestManager.Instance.IsQuestActive("ToolsOfSurvival"))
                             {

--- a/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
@@ -146,8 +146,14 @@ namespace Skills.Woodcutting
                     },
                     onSuccess = result =>
                     {
-                        if (currentTree.def.PetDropChance > 0)
-                            PetDropSystem.TryRollPet("woodcutting", currentTree.transform.position, skills, currentTree.def.PetDropChance, out _);
+                        int? petChance = currentTree != null && currentTree.def != null
+                            ? currentTree.def.PetDropChance
+                            : (int?)null;
+                        SkillingPetRewarder.TryRollPet(
+                            "woodcutting",
+                            skills,
+                            currentTree != null ? currentTree.transform : transform,
+                            petChance);
 
                         if (QuestManager.Instance != null && QuestManager.Instance.IsQuestActive("ToolsOfSurvival"))
                         {


### PR DESCRIPTION
## Summary
- add a shared SkillingPetRewarder helper to keep skilling pet rolls consistent
- refactor woodcutting, mining, fishing, and cooking success hooks to route through the helper and expose fishing pet chances
- document the new helper in AGENTS.md for future gathering features

## Testing
- not run (Unity editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc0178f764832e879f37baf087b9b6