### PR TITLE
Align gathering HUD timers with ticker state

### DIFF
--- a/Assets/Scripts/Util/Ticker.cs
+++ b/Assets/Scripts/Util/Ticker.cs
@@ -13,6 +13,11 @@ namespace Util
 
         public static Ticker Instance { get; private set; }
 
+        /// <summary>
+        /// Time remaining before the next tick event is dispatched.
+        /// </summary>
+        public float TimeUntilNextTick => Mathf.Max(0f, TickDuration - timer);
+
         private readonly List<ITickable> subscribers = new List<ITickable>();
         private float timer;
         private bool paused;


### PR DESCRIPTION
## Summary
- expose the remaining time until the next tick via Ticker so HUDs can synchronize with the cadence
- initialize woodcutting, mining, and fishing progress interpolations from the ticker remainder and lerp against segment duration
- reset interpolation timing on ticks and stop events to avoid stale values between gathering attempts

## Testing
- not run (Unity editor only)


------
https://chatgpt.com/codex/tasks/task_e_68cc25a74e68832e89e499e9e7e56b8b