### PR TITLE
Fix missing Unity serialization attribute references

### DIFF
--- a/Assets/Scripts/Core/Save/AccountProfileService.cs
+++ b/Assets/Scripts/Core/Save/AccountProfileService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Text;
+using UnityEngine;
 
 namespace Core.Save
 {


### PR DESCRIPTION
## Summary
- add the UnityEngine namespace import to AccountProfileService so SerializeField attributes compile after the latest update

## Testing
- not run (Unity editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc386f9d58832e9d3f6e12f4786298