### PR TITLE
Refine login screen setup to rely on serialized UI

### DIFF
--- a/Assets/Scripts/UI/Login/LoginScreenController.cs
+++ b/Assets/Scripts/UI/Login/LoginScreenController.cs
@@ -31,6 +31,9 @@ namespace UI.Login
         [SerializeField]
         private Image backgroundImage;
 
+        [SerializeField]
+        private Image loginPanelImage;
+
         [Header("Sprite Resources")]
         [SerializeField, Tooltip("Resources path for the fullscreen background sprite.")]
         private string backgroundSpritePath = "Sprites/LoginScreen/Background";
@@ -60,6 +63,7 @@ namespace UI.Login
         {
             legacyFont = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
             LoadLoginSprites();
+            ApplyLoadedSpritesToUi();
             EnsureUiHierarchy();
 
             ApplyLegacyFont(usernameField);
@@ -182,82 +186,23 @@ namespace UI.Login
 
         private void EnsureUiHierarchy()
         {
-            if (usernameField != null && passwordField != null && statusText != null && loginButton != null && backgroundImage != null)
-                return;
+            if (usernameField == null)
+                Debug.LogWarning("LoginScreenController is missing a reference to the username InputField.", this);
 
-            if (gameObject.layer != 5)
-                gameObject.layer = 5;
+            if (passwordField == null)
+                Debug.LogWarning("LoginScreenController is missing a reference to the password InputField.", this);
 
-            var canvas = GetComponent<Canvas>();
-            if (canvas == null)
-                canvas = gameObject.AddComponent<Canvas>();
-            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
-            canvas.pixelPerfect = false;
-            canvas.sortingOrder = 0;
+            if (statusText == null)
+                Debug.LogWarning("LoginScreenController is missing a reference to the status Text component.", this);
 
-            var scaler = GetComponent<CanvasScaler>();
-            if (scaler == null)
-                scaler = gameObject.AddComponent<CanvasScaler>();
-            scaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
-            scaler.referenceResolution = new Vector2(1920f, 1080f);
-            scaler.matchWidthOrHeight = 0.5f;
+            if (loginButton == null)
+                Debug.LogWarning("LoginScreenController is missing a reference to the login Button.", this);
 
-            if (GetComponent<GraphicRaycaster>() == null)
-                gameObject.AddComponent<GraphicRaycaster>();
+            if (backgroundImage == null)
+                Debug.LogWarning("LoginScreenController is missing a reference to the background Image.", this);
 
-            var rootRect = transform as RectTransform;
-            if (rootRect == null)
-                rootRect = gameObject.AddComponent<RectTransform>();
-
-            Sprite panelSprite = Resources.GetBuiltinResource<Sprite>("UISprite.psd");
-
-            var backgroundRect = CreateRectTransform("Background", rootRect,
-                new Vector2(0f, 0f), new Vector2(1f, 1f), new Vector2(0.5f, 0.5f),
-                Vector2.zero, Vector2.zero);
-            backgroundImage = backgroundRect.gameObject.AddComponent<Image>();
-            Sprite appliedBackgroundSprite = backgroundSprite != null ? backgroundSprite : panelSprite;
-            backgroundImage.sprite = appliedBackgroundSprite;
-            backgroundImage.type = Image.Type.Simple;
-            backgroundImage.color = backgroundSprite != null ? Color.white : new Color32(16, 12, 8, 255);
-            backgroundImage.preserveAspect = backgroundSprite != null;
-            backgroundImage.raycastTarget = false;
-            backgroundRect.SetAsFirstSibling();
-
-            Vector2 panelSize = GetSpriteSize(loginPanelSprite, new Vector2(640f, 440f));
-            var panelRect = CreateRectTransform("LoginPanel", rootRect,
-                new Vector2(0.5f, 0.5f), new Vector2(0.5f, 0.5f), new Vector2(0.5f, 0.5f),
-                Vector2.zero, panelSize);
-            var panelImage = panelRect.gameObject.AddComponent<Image>();
-            Sprite appliedPanelSprite = loginPanelSprite != null ? loginPanelSprite : panelSprite;
-            panelImage.sprite = appliedPanelSprite;
-            bool panelHasBorder = loginPanelSprite != null && loginPanelSprite.border.sqrMagnitude > 0f;
-            panelImage.type = panelHasBorder ? Image.Type.Sliced : Image.Type.Simple;
-            panelImage.color = loginPanelSprite != null ? Color.white : new Color32(28, 24, 20, 220);
-            panelRect.SetAsLastSibling();
-
-            var title = CreateText(panelRect, "Title", "RuneRealm Login", new Vector2(0.5f, 1f), new Vector2(0.5f, 1f), new Vector2(0.5f, 1f),
-                new Vector2(0f, -32f), new Vector2(520f, 48f), 34, TextAnchor.UpperCenter, FontStyle.Bold);
-            ApplyLegacyFont(title);
-
-            var usernameLabel = CreateText(panelRect, "UsernameLabel", "Username", new Vector2(0f, 1f), new Vector2(0f, 1f), new Vector2(0f, 1f),
-                new Vector2(40f, -110f), new Vector2(200f, 32f), 20, TextAnchor.MiddleLeft, FontStyle.Bold);
-            ApplyLegacyFont(usernameLabel);
-
-            usernameField = CreateInputField(panelRect, "UsernameInput", new Vector2(40f, -150f), false, "Enter username", panelSprite);
-
-            var passwordLabel = CreateText(panelRect, "PasswordLabel", "Password", new Vector2(0f, 1f), new Vector2(0f, 1f), new Vector2(0f, 1f),
-                new Vector2(40f, -210f), new Vector2(200f, 32f), 20, TextAnchor.MiddleLeft, FontStyle.Bold);
-            ApplyLegacyFont(passwordLabel);
-
-            passwordField = CreateInputField(panelRect, "PasswordInput", new Vector2(40f, -250f), true, "Enter password", panelSprite);
-
-            statusText = CreateText(panelRect, "StatusText", string.Empty, new Vector2(0.5f, 0f), new Vector2(0.5f, 0f), new Vector2(0.5f, 0f),
-                new Vector2(0f, 96f), new Vector2(560f, 80f), 18, TextAnchor.MiddleCenter, FontStyle.Normal);
-            ApplyLegacyFont(statusText);
-
-            loginButton = CreateButton(panelRect, "LoginButton", new Vector2(0.5f, 0f), new Vector2(0.5f, 0f), new Vector2(0.5f, 0f),
-                new Vector2(0f, 28f), new Vector2(220f, 56f), panelSprite, "Login");
-            ApplyLegacyFont(loginButton.GetComponentInChildren<Text>());
+            if (loginPanelImage == null)
+                Debug.LogWarning("LoginScreenController is missing a reference to the login panel Image.", this);
         }
 
         /// <summary>
@@ -268,6 +213,24 @@ namespace UI.Login
         {
             backgroundSprite = LoadSpriteFromResources(backgroundSpritePath);
             loginPanelSprite = LoadSpriteFromResources(loginPanelSpritePath);
+        }
+
+        /// <summary>
+        /// Applies the loaded sprites to the serialized UI components when available so the
+        /// art-authored assets appear without modifying the existing hierarchy.
+        /// </summary>
+        private void ApplyLoadedSpritesToUi()
+        {
+            if (backgroundSprite != null && backgroundImage != null)
+                backgroundImage.sprite = backgroundSprite;
+
+            if (loginPanelSprite != null && loginPanelImage != null)
+            {
+                loginPanelImage.sprite = loginPanelSprite;
+
+                if (loginPanelSprite.border.sqrMagnitude > 0f)
+                    loginPanelImage.type = Image.Type.Sliced;
+            }
         }
 
         /// <summary>
@@ -314,118 +277,5 @@ namespace UI.Login
             statusText.color = colour;
         }
 
-        /// <summary>
-        /// Converts a sprite's pixel rect into UI units so the RectTransform matches the
-        /// art-authored dimensions when rendered inside the canvas. Returns the provided
-        /// fallback when a sprite is unavailable.
-        /// </summary>
-        private Vector2 GetSpriteSize(Sprite sprite, Vector2 fallback)
-        {
-            if (sprite == null)
-                return fallback;
-
-            float pixelsPerUnit = sprite.pixelsPerUnit <= 0f ? 100f : sprite.pixelsPerUnit;
-            return sprite.rect.size / pixelsPerUnit;
-        }
-
-        private RectTransform CreateRectTransform(string name, RectTransform parent, Vector2 anchorMin, Vector2 anchorMax, Vector2 pivot, Vector2 anchoredPosition, Vector2 sizeDelta)
-        {
-            var go = new GameObject(name, typeof(RectTransform));
-            var rect = go.GetComponent<RectTransform>();
-            rect.SetParent(parent, false);
-            rect.anchorMin = anchorMin;
-            rect.anchorMax = anchorMax;
-            rect.pivot = pivot;
-            rect.anchoredPosition = anchoredPosition;
-            rect.sizeDelta = sizeDelta;
-            return rect;
-        }
-
-        private Text CreateText(RectTransform parent, string name, string content, Vector2 anchorMin, Vector2 anchorMax, Vector2 pivot, Vector2 anchoredPosition, Vector2 sizeDelta, int fontSize, TextAnchor alignment, FontStyle style)
-        {
-            var rect = CreateRectTransform(name, parent, anchorMin, anchorMax, pivot, anchoredPosition, sizeDelta);
-            rect.gameObject.AddComponent<CanvasRenderer>();
-            var text = rect.gameObject.AddComponent<Text>();
-            text.text = content;
-            text.fontSize = fontSize;
-            text.alignment = alignment;
-            text.fontStyle = style;
-            text.color = new Color32(212, 212, 212, 255);
-            text.supportRichText = false;
-            text.raycastTarget = false;
-            return text;
-        }
-
-        private InputField CreateInputField(RectTransform parent, string name, Vector2 anchoredPosition, bool isPassword, string placeholderText, Sprite backgroundSprite)
-        {
-            var rect = CreateRectTransform(name, parent, new Vector2(0f, 1f), new Vector2(0f, 1f), new Vector2(0f, 1f), anchoredPosition, new Vector2(360f, 44f));
-            rect.gameObject.AddComponent<CanvasRenderer>();
-            var image = rect.gameObject.AddComponent<Image>();
-            image.sprite = backgroundSprite;
-            image.type = Image.Type.Sliced;
-            image.color = new Color32(46, 40, 32, 255);
-
-            var field = rect.gameObject.AddComponent<InputField>();
-            field.targetGraphic = image;
-            field.lineType = InputField.LineType.SingleLine;
-            field.contentType = isPassword ? InputField.ContentType.Password : InputField.ContentType.Standard;
-            field.characterValidation = InputField.CharacterValidation.None;
-
-            var textRect = CreateRectTransform("Text", rect, new Vector2(0f, 0f), new Vector2(1f, 1f), new Vector2(0f, 0f), Vector2.zero, Vector2.zero);
-            textRect.offsetMin = new Vector2(12f, 8f);
-            textRect.offsetMax = new Vector2(-12f, -8f);
-            textRect.gameObject.AddComponent<CanvasRenderer>();
-            var text = textRect.gameObject.AddComponent<Text>();
-            text.text = string.Empty;
-            text.fontSize = 20;
-            text.alignment = TextAnchor.MiddleLeft;
-            text.supportRichText = false;
-            text.color = new Color32(238, 225, 171, 255);
-            text.raycastTarget = false;
-
-            var placeholderRect = CreateRectTransform("Placeholder", rect, new Vector2(0f, 0f), new Vector2(1f, 1f), new Vector2(0f, 0f), Vector2.zero, Vector2.zero);
-            placeholderRect.offsetMin = new Vector2(12f, 8f);
-            placeholderRect.offsetMax = new Vector2(-12f, -8f);
-            placeholderRect.gameObject.AddComponent<CanvasRenderer>();
-            var placeholder = placeholderRect.gameObject.AddComponent<Text>();
-            placeholder.text = placeholderText;
-            placeholder.fontStyle = FontStyle.Italic;
-            placeholder.fontSize = 20;
-            placeholder.alignment = TextAnchor.MiddleLeft;
-            placeholder.color = new Color32(150, 150, 150, 255);
-            placeholder.supportRichText = false;
-            placeholder.raycastTarget = false;
-
-            field.textComponent = text;
-            field.placeholder = placeholder;
-
-            return field;
-        }
-
-        private Button CreateButton(RectTransform parent, string name, Vector2 anchorMin, Vector2 anchorMax, Vector2 pivot, Vector2 anchoredPosition, Vector2 sizeDelta, Sprite backgroundSprite, string label)
-        {
-            var rect = CreateRectTransform(name, parent, anchorMin, anchorMax, pivot, anchoredPosition, sizeDelta);
-            rect.gameObject.AddComponent<CanvasRenderer>();
-            var image = rect.gameObject.AddComponent<Image>();
-            image.sprite = backgroundSprite;
-            image.type = Image.Type.Sliced;
-            image.color = new Color32(92, 58, 30, 255);
-
-            var button = rect.gameObject.AddComponent<Button>();
-            button.transition = Selectable.Transition.ColorTint;
-            var colors = button.colors;
-            colors.normalColor = new Color32(92, 58, 30, 255);
-            colors.highlightedColor = new Color32(120, 78, 40, 255);
-            colors.pressedColor = new Color32(70, 46, 24, 255);
-            colors.selectedColor = new Color32(120, 78, 40, 255);
-            colors.disabledColor = new Color32(50, 32, 18, 180);
-            button.colors = colors;
-
-            var text = CreateText(rect, "Text", label, new Vector2(0f, 0f), new Vector2(1f, 1f), new Vector2(0.5f, 0.5f), Vector2.zero, Vector2.zero, 24, TextAnchor.MiddleCenter, FontStyle.Bold);
-            ApplyLegacyFont(text);
-            text.color = new Color32(238, 225, 171, 255);
-
-            return button;
-        }
     }
 }


### PR DESCRIPTION
## Summary
- expose a serialized login panel image reference so the scene wiring can remain inspector-driven
- replace the runtime login UI construction with warning-based validation of the serialized hierarchy
- load and assign background and panel sprites directly onto the wired UI components when available

## Testing
- not run (Unity editor validation required)

------
https://chatgpt.com/codex/tasks/task_e_68cc3ebc664c832ea22c3e36ff12653b