### PR TITLE
Add scene exclusions to persistent bootstrap

### DIFF
--- a/Assets/Resources/PersistentObjects.asset
+++ b/Assets/Resources/PersistentObjects.asset
@@ -32,3 +32,5 @@ MonoBehaviour:
   - {fileID: 1337000000000000000, guid: 24e6c0c2e5b54061bcf3d3e331bbb747, type: 3}
   - {fileID: 1450000000000000000, guid: b5491e846856443d99a8573cd56be3d9, type: 3}
   - {fileID: 3292544441928706444, guid: dbb802ba54777614f868b6f0b207cee2, type: 3}
+  excludedSceneNames:
+  - Login


### PR DESCRIPTION
## Summary
- add a serialized exclusion list and helper on `PersistentObjectCatalog` for case-insensitive scene checks
- update the bootstrapper to look at the active scene and skip spawning persistent prefabs when excluded
- flag the Login scene in the persistent object asset so login-only scenes stop instantiating gameplay prefabs

## Testing
- Not run (Unity editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cd3e6306c8832eb3bc9446d3bd3a4a