### PR TITLE
Allow blank persistent catalog exclusions

### DIFF
--- a/Assets/Scripts/World/PersistentObjectBootstrap.cs
+++ b/Assets/Scripts/World/PersistentObjectBootstrap.cs
@@ -252,7 +252,8 @@ namespace World
                 string rawName = excludedSceneNames[i];
                 if (string.IsNullOrWhiteSpace(rawName))
                 {
-                    excludedSceneNames.RemoveAt(i);
+                    // Keep blank inspector slots so designers can immediately enter a scene name.
+                    excludedSceneNames[i] = string.Empty;
                     continue;
                 }
 


### PR DESCRIPTION
## Summary
- preserve blank entries in the persistent scene exclusion list so new inspector rows remain available
- continue trimming and deduplicating populated entries for deterministic lookups

## Testing
- not run (editor-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cd417e03e4832eb8795ea85dd34f67