### PR TITLE
Add persistent scene gating helper and guard runtime singletons

### DIFF
--- a/Assets/Scripts/Combat/CombatWeaponHUD.cs
+++ b/Assets/Scripts/Combat/CombatWeaponHUD.cs
@@ -1,6 +1,8 @@
 using UnityEngine;
+using UnityEngine.SceneManagement;
 using Inventory;
 using UI;
+using World;
 
 namespace Combat
 {
@@ -9,6 +11,10 @@ namespace Combat
     /// </summary>
     public class CombatWeaponHUD : MonoBehaviour
     {
+        private static CombatWeaponHUD instance;
+        private static bool waitingForAllowedScene;
+        private static bool applicationIsQuitting;
+
         private CombatController controller;
         private Equipment equipment;
         private Transform target;
@@ -16,20 +22,108 @@ namespace Combat
         private SpriteRenderer weaponRenderer;
         private readonly Vector3 offset = new Vector3(0f, 0.75f, 0f);
         private bool spellActiveLastFrame;
+        private bool sceneGateSubscribed;
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
         private static void CreateInstance()
         {
-            if (UnityEngine.Object.FindObjectOfType<CombatWeaponHUD>() != null)
+            if (instance != null)
                 return;
 
-            var go = new GameObject("CombatWeaponHUD");
-            UnityEngine.Object.DontDestroyOnLoad(go);
+#if UNITY_2023_1_OR_NEWER
+            if (Object.FindFirstObjectByType<CombatWeaponHUD>() != null)
+#else
+            if (Object.FindObjectOfType<CombatWeaponHUD>() != null)
+#endif
+            {
+                // An instance already exists in the scene. Adopt it so the gating logic can manage
+                // persistence consistently.
+                CreateOrAdoptInstance();
+                return;
+            }
+
+            var activeScene = SceneManager.GetActiveScene();
+            if (!activeScene.IsValid() || !PersistentSceneGate.ShouldSpawnInScene(activeScene))
+            {
+                BeginWaitingForAllowedScene();
+                return;
+            }
+
+            CreateOrAdoptInstance();
+        }
+
+        private static void CreateOrAdoptInstance()
+        {
+            if (instance != null)
+                return;
+
+            StopWaitingForAllowedScene();
+
+            var existing = FindExistingInstance();
+            if (existing != null)
+            {
+                if (existing.gameObject.scene.name != "DontDestroyOnLoad")
+                    DontDestroyOnLoad(existing.gameObject);
+                instance = existing;
+                existing.EnsureSceneGateSubscription();
+                return;
+            }
+
+            var go = new GameObject(nameof(CombatWeaponHUD));
+            DontDestroyOnLoad(go);
             go.AddComponent<CombatWeaponHUD>();
+        }
+
+        private static CombatWeaponHUD FindExistingInstance()
+        {
+#if UNITY_2023_1_OR_NEWER
+            return Object.FindFirstObjectByType<CombatWeaponHUD>();
+#else
+            return Object.FindObjectOfType<CombatWeaponHUD>();
+#endif
+        }
+
+        private static void BeginWaitingForAllowedScene()
+        {
+            if (waitingForAllowedScene)
+                return;
+
+            waitingForAllowedScene = true;
+            PersistentSceneGate.SceneEvaluationChanged += HandleSceneEvaluationForBootstrap;
+        }
+
+        private static void StopWaitingForAllowedScene()
+        {
+            if (!waitingForAllowedScene)
+                return;
+
+            PersistentSceneGate.SceneEvaluationChanged -= HandleSceneEvaluationForBootstrap;
+            waitingForAllowedScene = false;
+        }
+
+        private static void HandleSceneEvaluationForBootstrap(Scene scene, bool allowed)
+        {
+            if (!allowed)
+                return;
+
+            if (scene != SceneManager.GetActiveScene())
+                return;
+
+            CreateOrAdoptInstance();
         }
 
         private void Awake()
         {
+            if (instance != null && instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            instance = this;
+            StopWaitingForAllowedScene();
+            EnsureSceneGateSubscription();
+
             controller = FindObjectOfType<CombatController>();
             if (controller != null)
                 controller.OnCombatTargetChanged += HandleTargetChanged;
@@ -74,6 +168,50 @@ namespace Combat
                 controller.OnCombatTargetChanged -= HandleTargetChanged;
             if (equipment != null)
                 equipment.OnEquipmentChanged -= HandleEquipmentChanged;
+
+            if (instance == this)
+            {
+                if (sceneGateSubscribed)
+                {
+                    PersistentSceneGate.SceneEvaluationChanged -= HandleSceneGateEvaluation;
+                    sceneGateSubscribed = false;
+                }
+
+                instance = null;
+
+                if (!applicationIsQuitting)
+                    BeginWaitingForAllowedScene();
+            }
+        }
+
+        private void OnApplicationQuit()
+        {
+            applicationIsQuitting = true;
+        }
+
+        private void EnsureSceneGateSubscription()
+        {
+            if (sceneGateSubscribed)
+                return;
+
+            PersistentSceneGate.SceneEvaluationChanged += HandleSceneGateEvaluation;
+            sceneGateSubscribed = true;
+        }
+
+        private void HandleSceneGateEvaluation(Scene scene, bool allowed)
+        {
+            if (instance != this)
+                return;
+
+            if (scene != SceneManager.GetActiveScene())
+                return;
+
+            if (allowed)
+                return;
+
+            PersistentSceneGate.SceneEvaluationChanged -= HandleSceneGateEvaluation;
+            sceneGateSubscribed = false;
+            Destroy(gameObject);
         }
 
         private void HandleEquipmentChanged(EquipmentSlot slot)

--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
+using World;
 
 namespace UI
 {
@@ -16,14 +18,30 @@ namespace UI
     {
         public static UIManager Instance { get; private set; }
 
+        private static bool waitingForAllowedScene;
+        private static bool applicationIsQuitting;
+
         private readonly List<IUIWindow> windows = new List<IUIWindow>();
+        private bool sceneGateSubscribed;
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         private static void Init()
         {
-            var go = new GameObject("UIManager");
-            DontDestroyOnLoad(go);
-            go.AddComponent<UIManager>();
+            var activeScene = SceneManager.GetActiveScene();
+            if (!activeScene.IsValid())
+            {
+                BeginWaitingForAllowedScene();
+                return;
+            }
+
+            if (PersistentSceneGate.ShouldSpawnInScene(activeScene))
+            {
+                CreateOrAdoptInstance();
+            }
+            else
+            {
+                BeginWaitingForAllowedScene();
+            }
         }
 
         private void Awake()
@@ -35,6 +53,31 @@ namespace UI
             }
             Instance = this;
             DontDestroyOnLoad(gameObject);
+
+            StopWaitingForAllowedScene();
+            EnsureSceneGateSubscription();
+        }
+
+        private void OnApplicationQuit()
+        {
+            applicationIsQuitting = true;
+        }
+
+        private void OnDestroy()
+        {
+            if (Instance == this)
+            {
+                if (sceneGateSubscribed)
+                {
+                    PersistentSceneGate.SceneEvaluationChanged -= HandleSceneGateEvaluation;
+                    sceneGateSubscribed = false;
+                }
+
+                Instance = null;
+
+                if (!applicationIsQuitting)
+                    BeginWaitingForAllowedScene();
+            }
         }
 
         public void RegisterWindow(IUIWindow window)
@@ -50,6 +93,91 @@ namespace UI
                 if (w != window && w.IsOpen)
                     w.Close();
             }
+        }
+
+        private static void CreateOrAdoptInstance()
+        {
+            if (Instance != null)
+                return;
+
+            StopWaitingForAllowedScene();
+
+            var existing = FindExistingManager();
+            if (existing != null)
+            {
+                Instance = existing;
+                if (existing.gameObject.scene.name != "DontDestroyOnLoad")
+                    DontDestroyOnLoad(existing.gameObject);
+                existing.EnsureSceneGateSubscription();
+                return;
+            }
+
+            var go = new GameObject(nameof(UIManager));
+            DontDestroyOnLoad(go);
+            go.AddComponent<UIManager>();
+        }
+
+        private static UIManager FindExistingManager()
+        {
+#if UNITY_2023_1_OR_NEWER
+            return Object.FindFirstObjectByType<UIManager>();
+#else
+            return Object.FindObjectOfType<UIManager>();
+#endif
+        }
+
+        private static void BeginWaitingForAllowedScene()
+        {
+            if (waitingForAllowedScene)
+                return;
+
+            waitingForAllowedScene = true;
+            PersistentSceneGate.SceneEvaluationChanged += HandleSceneEvaluationForBootstrap;
+        }
+
+        private static void StopWaitingForAllowedScene()
+        {
+            if (!waitingForAllowedScene)
+                return;
+
+            PersistentSceneGate.SceneEvaluationChanged -= HandleSceneEvaluationForBootstrap;
+            waitingForAllowedScene = false;
+        }
+
+        private static void HandleSceneEvaluationForBootstrap(Scene scene, bool allowed)
+        {
+            if (!allowed)
+                return;
+
+            if (scene != SceneManager.GetActiveScene())
+                return;
+
+            CreateOrAdoptInstance();
+        }
+
+        private void EnsureSceneGateSubscription()
+        {
+            if (sceneGateSubscribed)
+                return;
+
+            PersistentSceneGate.SceneEvaluationChanged += HandleSceneGateEvaluation;
+            sceneGateSubscribed = true;
+        }
+
+        private void HandleSceneGateEvaluation(Scene scene, bool allowed)
+        {
+            if (Instance != this)
+                return;
+
+            if (scene != SceneManager.GetActiveScene())
+                return;
+
+            if (allowed)
+                return;
+
+            PersistentSceneGate.SceneEvaluationChanged -= HandleSceneGateEvaluation;
+            sceneGateSubscribed = false;
+            Destroy(gameObject);
         }
     }
 }

--- a/Assets/Scripts/World/PersistentSceneGate.cs
+++ b/Assets/Scripts/World/PersistentSceneGate.cs
@@ -1,0 +1,141 @@
+using System;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace World
+{
+    /// <summary>
+    /// Centralises the logic for determining whether persistent singletons should exist in the
+    /// current scene. The gate caches the <see cref="PersistentObjectCatalog"/> so bootstrap
+    /// routines can avoid spawning long-lived services in menu or login scenes where they are not
+    /// required.
+    /// </summary>
+    public static class PersistentSceneGate
+    {
+        /// <summary>
+        /// Raised whenever Unity reports that a scene finished loading or when the active scene
+        /// changes. The boolean argument communicates whether persistent services are allowed in the
+        /// evaluated scene.
+        /// </summary>
+        public static event Action<Scene, bool> SceneEvaluationChanged;
+
+        private static PersistentObjectCatalog cachedCatalog;
+        private static bool attemptedCatalogLoad;
+        private static bool initialised;
+        private static bool? lastEvaluation;
+        private static Scene lastEvaluatedScene;
+
+        /// <summary>
+        /// Ensures the helper is initialised prior to the first scene load so any bootstrap code can
+        /// immediately query the active scene.
+        /// </summary>
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        private static void Initialise()
+        {
+            EnsureInitialised();
+        }
+
+        /// <summary>
+        /// Determines whether persistent services should be spawned within the provided scene.
+        /// </summary>
+        /// <param name="scene">Scene to evaluate.</param>
+        public static bool ShouldSpawnInScene(Scene scene)
+        {
+            EnsureInitialised();
+            return EvaluateScene(scene, broadcast: false);
+        }
+
+        /// <summary>
+        /// Returns the cached evaluation for the current active scene, recomputing the value if the
+        /// cached state is stale.
+        /// </summary>
+        public static bool IsActiveSceneAllowed
+        {
+            get
+            {
+                EnsureInitialised();
+                var activeScene = SceneManager.GetActiveScene();
+                if (lastEvaluation.HasValue && lastEvaluatedScene == activeScene)
+                    return lastEvaluation.Value;
+
+                return EvaluateScene(activeScene, broadcast: false);
+            }
+        }
+
+        /// <summary>
+        /// Forces a re-evaluation of the active scene and broadcasts the result to listeners. Useful
+        /// when bootstrap code needs to manually refresh the state after changing exclusion data at
+        /// runtime.
+        /// </summary>
+        public static void RefreshActiveScene()
+        {
+            EnsureInitialised();
+            var activeScene = SceneManager.GetActiveScene();
+            EvaluateScene(activeScene, broadcast: true);
+        }
+
+        private static void EnsureInitialised()
+        {
+            if (initialised)
+                return;
+
+            SceneManager.sceneLoaded += HandleSceneLoaded;
+            SceneManager.activeSceneChanged += HandleActiveSceneChanged;
+            initialised = true;
+
+            var activeScene = SceneManager.GetActiveScene();
+            if (activeScene.IsValid())
+                EvaluateScene(activeScene, broadcast: true);
+        }
+
+        private static void HandleSceneLoaded(Scene scene, LoadSceneMode mode)
+        {
+            EvaluateScene(scene, broadcast: true);
+        }
+
+        private static void HandleActiveSceneChanged(Scene oldScene, Scene newScene)
+        {
+            EvaluateScene(newScene, broadcast: true);
+        }
+
+        private static bool EvaluateScene(Scene scene, bool broadcast)
+        {
+            if (!scene.IsValid())
+            {
+                if (broadcast)
+                    SceneEvaluationChanged?.Invoke(scene, false);
+                return false;
+            }
+
+            bool allowed = IsSceneAllowed(scene);
+
+            lastEvaluatedScene = scene;
+            lastEvaluation = allowed;
+
+            if (broadcast)
+                SceneEvaluationChanged?.Invoke(scene, allowed);
+
+            return allowed;
+        }
+
+        private static bool IsSceneAllowed(Scene scene)
+        {
+            var catalog = GetCatalog();
+            if (catalog == null)
+                return true;
+
+            return catalog.ShouldSpawnInScene(scene.name);
+        }
+
+        private static PersistentObjectCatalog GetCatalog()
+        {
+            if (!attemptedCatalogLoad || cachedCatalog == null)
+            {
+                cachedCatalog = Resources.Load<PersistentObjectCatalog>(PersistentObjectBootstrap.CatalogResourcePath);
+                attemptedCatalogLoad = true;
+            }
+
+            return cachedCatalog;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a PersistentSceneGate utility that caches the persistent catalog and broadcasts scene eligibility
- gate UIManager, BuffTimerService, BuffHudManager, PetToastUI, CombatWeaponHUD, and AttackStyleUI so they defer creation in excluded scenes, tear down when disallowed, and resubscribe cleanly
- ensure each singleton drops temporary scene-loaded hooks once spawned and resumes listening when a scene needs them again

## Testing
- not run (Unity editor unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cd454a3640832ebb41822ea1f36050