### PR TITLE
Add scene gate lifecycle guards to runtime UI singletons

### DIFF
--- a/Assets/Scripts/Books/BookProgressManager.cs
+++ b/Assets/Scripts/Books/BookProgressManager.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 using Core.Save;
+using World;
 
 namespace Books
 {
@@ -11,14 +13,82 @@ namespace Books
         private Dictionary<string, int> progress = new Dictionary<string, int>();
         private const string SaveKey = "BookProgress";
 
-        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
-        private static void Init()
+        private static bool waitingForAllowedScene;
+        private static bool applicationIsQuitting;
+
+        private bool sceneGateSubscribed;
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        private static void Bootstrap()
         {
-            if (FindObjectOfType<BookProgressManager>() != null)
+            var activeScene = SceneManager.GetActiveScene();
+            if (!activeScene.IsValid() || !PersistentSceneGate.ShouldSpawnInScene(activeScene))
+            {
+                BeginWaitingForAllowedScene();
                 return;
-            var go = new GameObject("BookProgressManager");
+            }
+
+            CreateOrAdoptInstance();
+        }
+
+        private static void CreateOrAdoptInstance()
+        {
+            if (Instance != null)
+                return;
+
+            StopWaitingForAllowedScene();
+
+            var existing = FindExistingInstance();
+            if (existing != null)
+            {
+                Instance = existing;
+                if (existing.gameObject.scene.name != "DontDestroyOnLoad")
+                    DontDestroyOnLoad(existing.gameObject);
+                existing.EnsureSceneGateSubscription();
+                return;
+            }
+
+            var go = new GameObject(nameof(BookProgressManager));
             DontDestroyOnLoad(go);
             go.AddComponent<BookProgressManager>();
+        }
+
+        private static BookProgressManager FindExistingInstance()
+        {
+#if UNITY_2023_1_OR_NEWER
+            return UnityEngine.Object.FindFirstObjectByType<BookProgressManager>();
+#else
+            return UnityEngine.Object.FindObjectOfType<BookProgressManager>();
+#endif
+        }
+
+        private static void BeginWaitingForAllowedScene()
+        {
+            if (waitingForAllowedScene)
+                return;
+
+            waitingForAllowedScene = true;
+            PersistentSceneGate.SceneEvaluationChanged += HandleSceneEvaluationForBootstrap;
+        }
+
+        private static void StopWaitingForAllowedScene()
+        {
+            if (!waitingForAllowedScene)
+                return;
+
+            PersistentSceneGate.SceneEvaluationChanged -= HandleSceneEvaluationForBootstrap;
+            waitingForAllowedScene = false;
+        }
+
+        private static void HandleSceneEvaluationForBootstrap(Scene scene, bool allowed)
+        {
+            if (!allowed)
+                return;
+
+            if (scene != SceneManager.GetActiveScene())
+                return;
+
+            CreateOrAdoptInstance();
         }
 
         private void Awake()
@@ -31,6 +101,9 @@ namespace Books
             Instance = this;
             DontDestroyOnLoad(gameObject);
             SaveManager.Register(this);
+
+            StopWaitingForAllowedScene();
+            EnsureSceneGateSubscription();
         }
 
         private void OnDestroy()
@@ -39,7 +112,46 @@ namespace Books
             {
                 SaveManager.Unregister(this);
                 Instance = null;
+
+                if (sceneGateSubscribed)
+                {
+                    PersistentSceneGate.SceneEvaluationChanged -= HandleSceneGateEvaluation;
+                    sceneGateSubscribed = false;
+                }
+
+                if (!applicationIsQuitting)
+                    BeginWaitingForAllowedScene();
             }
+        }
+
+        private void OnApplicationQuit()
+        {
+            applicationIsQuitting = true;
+        }
+
+        private void EnsureSceneGateSubscription()
+        {
+            if (sceneGateSubscribed)
+                return;
+
+            PersistentSceneGate.SceneEvaluationChanged += HandleSceneGateEvaluation;
+            sceneGateSubscribed = true;
+        }
+
+        private void HandleSceneGateEvaluation(Scene scene, bool allowed)
+        {
+            if (Instance != this)
+                return;
+
+            if (scene != SceneManager.GetActiveScene())
+                return;
+
+            if (allowed)
+                return;
+
+            PersistentSceneGate.SceneEvaluationChanged -= HandleSceneGateEvaluation;
+            sceneGateSubscribed = false;
+            Destroy(gameObject);
         }
 
         public int GetPage(string id)

--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -82,14 +82,32 @@ namespace UI
 
         public void RegisterWindow(IUIWindow window)
         {
+            if (window == null)
+                return;
+
             if (!windows.Contains(window))
                 windows.Add(window);
         }
 
+        public void UnregisterWindow(IUIWindow window)
+        {
+            if (window == null)
+                return;
+
+            windows.Remove(window);
+        }
+
         public void OpenWindow(IUIWindow window)
         {
-            foreach (var w in windows)
+            for (int i = windows.Count - 1; i >= 0; i--)
             {
+                var w = windows[i];
+                if (w == null)
+                {
+                    windows.RemoveAt(i);
+                    continue;
+                }
+
                 if (w != window && w.IsOpen)
                     w.Close();
             }


### PR DESCRIPTION
## Summary
- gate runtime UI singletons such as the admin menu, bank, book systems, tab buttons, magic, and skills UI behind `PersistentSceneGate` so they only spawn in allowed scenes and resubscribe when scenes change
- update fishing, mining, and woodcutting HUD controllers to wait for allowed scenes, rebind their skill events on scene load, and clean up helper game objects on teardown
- extend the minimap and UIManager to handle scene gating teardown, release transient resources, and unregister windows cleanly

## Testing
- not run (Unity editor / play mode tests unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cd4ea5f958832e8938bdf6a087c434