### PR TITLE
Resolve PersistentSceneSingleton Object ambiguity

### DIFF
--- a/Assets/Scripts/World/PersistentSceneSingleton.cs
+++ b/Assets/Scripts/World/PersistentSceneSingleton.cs
@@ -1,6 +1,7 @@
 using System;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using Object = UnityEngine.Object;
 
 namespace World
 {


### PR DESCRIPTION
## Summary
- import UnityEngine.Object explicitly in PersistentSceneSingleton to avoid clashes with System.Object

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd63b5b76c832e9a7452444caaf15e