### PR TITLE
Add level up sounds for defence, hitpoints, and strength

### DIFF
--- a/Assets/Scripts/Audio/SoundEffect.cs
+++ b/Assets/Scripts/Audio/SoundEffect.cs
@@ -15,6 +15,31 @@ namespace Audio
         AttackLevelUp,
 
         /// <summary>
+        /// Played when the player gains a Defence level.
+        /// </summary>
+        DefenceLevelUp,
+
+        /// <summary>
+        /// Played when the player gains a Hitpoints level between levels 2 and 49.
+        /// </summary>
+        HitpointsLevelUpLow,
+
+        /// <summary>
+        /// Played when the player gains a Hitpoints level between levels 50 and 99.
+        /// </summary>
+        HitpointsLevelUpHigh,
+
+        /// <summary>
+        /// Played when the player gains a Strength level between levels 2 and 49.
+        /// </summary>
+        StrengthLevelUpLow,
+
+        /// <summary>
+        /// Played when the player gains a Strength level between levels 50 and 99.
+        /// </summary>
+        StrengthLevelUpHigh,
+
+        /// <summary>
         /// Ambient hit when chopping trees. Reserved for future use.
         /// </summary>
         TreeChop

--- a/Assets/Scripts/Audio/SoundManager.cs
+++ b/Assets/Scripts/Audio/SoundManager.cs
@@ -53,6 +53,11 @@ namespace Audio
         private readonly Dictionary<SoundEffect, string> soundFileMap = new()
         {
             { SoundEffect.AttackLevelUp, "02_Attack_Level_Up" },
+            { SoundEffect.DefenceLevelUp, "03_Defence_Level_Up" },
+            { SoundEffect.HitpointsLevelUpLow, "04_Hitpoints_Level_Up_2_49" },
+            { SoundEffect.HitpointsLevelUpHigh, "05_Hitpoints_Level_Up_50_99" },
+            { SoundEffect.StrengthLevelUpLow, "06_Strength_Level_Up_2_49" },
+            { SoundEffect.StrengthLevelUpHigh, "07_Strength_Level_Up_50_99" },
             { SoundEffect.TreeChop, "01_Tree_Chop" }
         };
 

--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -166,6 +166,30 @@ namespace Combat
                     // Trigger the OSRS-style level-up chime whenever the player gains an Attack level.
                     SoundManager.Instance.PlaySfx(SoundEffect.AttackLevelUp);
                     break;
+                case SkillType.Defence:
+                    // Mirror the Attack behaviour so Defence level ups use their dedicated chime.
+                    SoundManager.Instance.PlaySfx(SoundEffect.DefenceLevelUp);
+                    break;
+                case SkillType.Hitpoints:
+                {
+                    // Use different sounds for early (2-49) and late (50-99) Hitpoints milestones.
+                    if (level < 2)
+                        break;
+
+                    var hitpointsEffect = level >= 50 ? SoundEffect.HitpointsLevelUpHigh : SoundEffect.HitpointsLevelUpLow;
+                    SoundManager.Instance.PlaySfx(hitpointsEffect);
+                    break;
+                }
+                case SkillType.Strength:
+                {
+                    // Strength shares the tiered level-up audio used by Hitpoints.
+                    if (level < 2)
+                        break;
+
+                    var strengthEffect = level >= 50 ? SoundEffect.StrengthLevelUpHigh : SoundEffect.StrengthLevelUpLow;
+                    SoundManager.Instance.PlaySfx(strengthEffect);
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- register defence, hitpoints, and strength level-up clips with the central sound enum and manager
- trigger the appropriate chime when the player levels defence, hitpoints, or strength, with tiered audio for levels 2-49 vs 50-99

## Testing
- not run (Unity editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cd681053bc832eaa2fea971f7db37e