### PR TITLE
Add audio cues for skill level ups and player death

### DIFF
--- a/Assets/Scripts/Audio/SoundEffect.cs
+++ b/Assets/Scripts/Audio/SoundEffect.cs
@@ -15,6 +15,46 @@ namespace Audio
         AttackLevelUp,
 
         /// <summary>
+        /// Played when the player gains a Defence level.
+        /// </summary>
+        DefenceLevelUp,
+
+        /// <summary>
+        /// Played when the player gains a Magic level.
+        /// </summary>
+        MagicLevelUp,
+
+        /// <summary>
+        /// Played when the player gains a Mining level.
+        /// </summary>
+        MiningLevelUp,
+
+        /// <summary>
+        /// Played when the player gains a Woodcutting level.
+        /// </summary>
+        WoodcuttingLevelUp,
+
+        /// <summary>
+        /// Played when the player gains a Fishing level.
+        /// </summary>
+        FishingLevelUp,
+
+        /// <summary>
+        /// Played when the player gains a Cooking level.
+        /// </summary>
+        CookingLevelUp,
+
+        /// <summary>
+        /// Played when the player gains a Beastmaster level. Reuses the defence level up chime.
+        /// </summary>
+        BeastmasterLevelUp,
+
+        /// <summary>
+        /// Played when the player dies.
+        /// </summary>
+        PlayerDeath,
+
+        /// <summary>
         /// Ambient hit when chopping trees. Reserved for future use.
         /// </summary>
         TreeChop

--- a/Assets/Scripts/Audio/SoundManager.cs
+++ b/Assets/Scripts/Audio/SoundManager.cs
@@ -53,6 +53,14 @@ namespace Audio
         private readonly Dictionary<SoundEffect, string> soundFileMap = new()
         {
             { SoundEffect.AttackLevelUp, "02_Attack_Level_Up" },
+            { SoundEffect.DefenceLevelUp, "03_Defence_Level_Up" },
+            { SoundEffect.MagicLevelUp, "09_Magic_Level_Up" },
+            { SoundEffect.MiningLevelUp, "08_Mining_Level_Up" },
+            { SoundEffect.WoodcuttingLevelUp, "09_Woodcutting_Level_Up" },
+            { SoundEffect.FishingLevelUp, "11_Fishing_Level_Up" },
+            { SoundEffect.CookingLevelUp, "10_Cooking_Level_Up" },
+            { SoundEffect.BeastmasterLevelUp, "03_Defence_Level_Up" },
+            { SoundEffect.PlayerDeath, "12_You_Are_Dead" },
             { SoundEffect.TreeChop, "01_Tree_Chop" }
         };
 

--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -160,11 +160,30 @@ namespace Combat
             switch (type)
             {
                 case SkillType.Magic:
+                    // Keep spell damage data in sync and play the corresponding level-up chime.
                     MagicUI.UpdateStrikeMaxHits(level);
+                    SoundManager.Instance.PlaySfx(SoundEffect.MagicLevelUp);
                     break;
                 case SkillType.Attack:
-                    // Trigger the OSRS-style level-up chime whenever the player gains an Attack level.
                     SoundManager.Instance.PlaySfx(SoundEffect.AttackLevelUp);
+                    break;
+                case SkillType.Defence:
+                    SoundManager.Instance.PlaySfx(SoundEffect.DefenceLevelUp);
+                    break;
+                case SkillType.Mining:
+                    SoundManager.Instance.PlaySfx(SoundEffect.MiningLevelUp);
+                    break;
+                case SkillType.Woodcutting:
+                    SoundManager.Instance.PlaySfx(SoundEffect.WoodcuttingLevelUp);
+                    break;
+                case SkillType.Fishing:
+                    SoundManager.Instance.PlaySfx(SoundEffect.FishingLevelUp);
+                    break;
+                case SkillType.Cooking:
+                    SoundManager.Instance.PlaySfx(SoundEffect.CookingLevelUp);
+                    break;
+                case SkillType.Beastmaster:
+                    SoundManager.Instance.PlaySfx(SoundEffect.BeastmasterLevelUp);
                     break;
             }
         }

--- a/Assets/Scripts/Player/PlayerRespawnSystem.cs
+++ b/Assets/Scripts/Player/PlayerRespawnSystem.cs
@@ -4,6 +4,7 @@ using UnityEngine.SceneManagement;
 using Core;
 using World;
 using Combat;
+using Audio;
 using Status;
 using Status.Poison;
 
@@ -85,6 +86,8 @@ namespace Player
                 poisonController?.CurePoison(0f);
                 if (BuffTimerService.Instance != null && hitpoints != null)
                     BuffTimerService.Instance.RemoveAllBuffs(hitpoints.gameObject, BuffEndReason.Manual);
+                // Play the classic OSRS-style death jingle before beginning the respawn sequence.
+                SoundManager.Instance.PlaySfx(SoundEffect.PlayerDeath);
                 StartCoroutine(RespawnRoutine());
             }
         }


### PR DESCRIPTION
## Summary
- map new skill level up and death effects in the shared SoundEffect enum and SoundManager lookup
- trigger the new audio cues from the player combat controller so Magic, Mining, Woodcutting, Fishing, Cooking, Defence, and Beastmaster levels now chime
- play the death jingle when the respawn system handles player death

## Testing
- not run (Unity Test Runner unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68cd6b775648832eb119de2908fcb182