### PR TITLE
Refactor fishing and woodcutting nodes to ticked base

### DIFF
--- a/Assets/Scripts/Skills/Fishing/Core/FishableSpot.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishableSpot.cs
@@ -4,12 +4,13 @@ using System.Collections.Generic;
 using UnityEngine;
 using Util;
 using UI;
+using Skills.Common;
 using Random = UnityEngine.Random;
 
 namespace Skills.Fishing
 {
     [RequireComponent(typeof(Collider2D))]
-    public class FishableSpot : MonoBehaviour, ITickable
+    public class FishableSpot : TickedSkillBehaviour
     {
         [Header("Definition")]
         public FishingSpotDefinition def;
@@ -27,8 +28,6 @@ namespace Skills.Fishing
         public event Action<FishableSpot> OnSpotRespawned;
 
         private double respawnAt;
-        private bool _tickerSubscribed;
-        private Coroutine _tickerSubscriptionRoutine;
 
         private void Awake()
         {
@@ -42,76 +41,10 @@ namespace Skills.Fishing
             }
         }
 
-        private void OnEnable()
-        {
-            EnsureTickerSubscription();
-        }
-
-        private void OnDisable()
-        {
-            ReleaseTickerSubscription();
-        }
-
         /// <summary>
-        /// Makes sure the spot is registered with the <see cref="Ticker"/>. When loading into a scene
-        /// the ticker singleton might not exist yet, so this method waits for it before subscribing to
-        /// avoid missed ticks or duplicate registrations.
+        ///     Checks whether the spot should respawn on every game tick.
         /// </summary>
-        private void EnsureTickerSubscription()
-        {
-            if (_tickerSubscribed)
-                return;
-
-            if (Ticker.Instance != null)
-            {
-                Ticker.Instance.Subscribe(this);
-                _tickerSubscribed = true;
-            }
-            else if (_tickerSubscriptionRoutine == null && isActiveAndEnabled)
-            {
-                _tickerSubscriptionRoutine = StartCoroutine(WaitForTickerAndSubscribe());
-            }
-        }
-
-        /// <summary>
-        /// Removes the ticker subscription and cancels any pending waiters so the component stops
-        /// receiving ticks while disabled and does not leak routines across scene transitions.
-        /// </summary>
-        private void ReleaseTickerSubscription()
-        {
-            if (_tickerSubscriptionRoutine != null)
-            {
-                StopCoroutine(_tickerSubscriptionRoutine);
-                _tickerSubscriptionRoutine = null;
-            }
-
-            if (_tickerSubscribed && Ticker.Instance != null)
-            {
-                Ticker.Instance.Unsubscribe(this);
-            }
-
-            _tickerSubscribed = false;
-        }
-
-        /// <summary>
-        /// Coroutine that blocks until the ticker singleton is available before performing the
-        /// subscription. This mirrors the wanderer handling so fishing spots work after scene loads.
-        /// </summary>
-        private IEnumerator WaitForTickerAndSubscribe()
-        {
-            while (Ticker.Instance == null)
-                yield return null;
-
-            _tickerSubscriptionRoutine = null;
-
-            if (!isActiveAndEnabled)
-                yield break;
-
-            Ticker.Instance.Subscribe(this);
-            _tickerSubscribed = true;
-        }
-
-        public void OnTick()
+        protected override void HandleTick()
         {
             if (IsDepleted && Time.timeAsDouble >= respawnAt)
                 Respawn();


### PR DESCRIPTION
## Summary
- convert FishableSpot to inherit from TickedSkillBehaviour so respawn checks run through HandleTick and remove bespoke subscription code
- update TreeNode to leverage TickedSkillBehaviour for ticker management, keeping Start setup while shifting respawn checks into HandleTick

## Testing
- not run (Unity editor required)


------
https://chatgpt.com/codex/tasks/task_e_68cd8e66ed3c832e874cb442c89148e4