### PR TITLE
Ensure PlayerMover registers persistence lifecycle

### DIFF
--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -146,9 +146,12 @@ namespace Player
             SceneTransitionManager.TransitionCompleted += OnTransitionCompleted;
         }
 
-#if ENABLE_INPUT_SYSTEM
-        void OnEnable()
+        private void OnEnable()
         {
+            // Register this mover with the SceneTransitionManager so the player persists across scene swaps.
+            SceneTransitionManager.RegisterPersistentObject(this);
+
+#if ENABLE_INPUT_SYSTEM
             moveAction = InputActionResolver.Resolve(playerInput, moveActionReference, "Move", out moveActionEnabledByResolver);
 
             if (moveAction != null)
@@ -157,10 +160,12 @@ namespace Player
                 moveAction.canceled += OnMoveCanceled;
                 moveActionValue = moveAction.ReadValue<Vector2>();
             }
+#endif
         }
 
-        void OnDisable()
+        private void OnDisable()
         {
+#if ENABLE_INPUT_SYSTEM
             if (moveAction != null)
             {
                 moveAction.performed -= OnMovePerformed;
@@ -173,6 +178,10 @@ namespace Player
             moveAction = null;
             moveActionEnabledByResolver = false;
             moveActionValue = Vector2.zero;
+#endif
+
+            // Remove this mover from the persistence registry when disabled so duplicates do not accumulate.
+            SceneTransitionManager.UnregisterPersistentObject(this);
         }
 
         private void OnMovePerformed(InputAction.CallbackContext context)


### PR DESCRIPTION
## Summary
- register `PlayerMover` with the `SceneTransitionManager` during `OnEnable` before resolving input bindings
- unregister the mover in `OnDisable` after cleaning up the input action wiring so duplicates cannot accumulate

## Testing
- not run (Unity editor unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ce9dd06d28832e8adc201ebb43da3b