### PR TITLE
Guard input callbacks with ENABLE_INPUT_SYSTEM

### DIFF
--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -184,6 +184,7 @@ namespace Player
             SceneTransitionManager.UnregisterPersistentObject(this);
         }
 
+#if ENABLE_INPUT_SYSTEM
         private void OnMovePerformed(InputAction.CallbackContext context)
         {
             // Cache the most recent movement vector supplied by the Player action map.


### PR DESCRIPTION
## Summary
- wrap the PlayerMover input callback methods in an ENABLE_INPUT_SYSTEM guard so they are only compiled when the new input system is available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce9efedb70832eae9502cab64a55b9