### PR TITLE
Use realtime wait for autosave loop

### DIFF
--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -97,7 +97,8 @@ namespace Core
 
         private IEnumerator AutoSaveLoop()
         {
-            var wait = new WaitForSeconds(AutosaveInterval);
+            // Use the realtime variant so autosaves still fire when the game is paused via Time.timeScale.
+            var wait = new WaitForSecondsRealtime(AutosaveInterval);
             while (true)
             {
                 yield return wait;


### PR DESCRIPTION
## Summary
- swap the autosave coroutine to WaitForSecondsRealtime so pauses via timeScale do not block saves

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cec737d6e4832e8742445565a9d89f