### PR TITLE
Ensure respawn point singleton clears when disabled

### DIFF
--- a/Assets/Scripts/World/RespawnPoint.cs
+++ b/Assets/Scripts/World/RespawnPoint.cs
@@ -12,9 +12,30 @@ namespace World
         /// </summary>
         public static RespawnPoint Current { get; private set; }
 
+        /// <summary>
+        /// Registers this respawn point as the current active point when enabled.
+        /// </summary>
         private void OnEnable()
         {
             Current = this;
+        }
+
+        /// <summary>
+        /// Clears the static reference when this respawn point is disabled.
+        /// </summary>
+        private void OnDisable()
+        {
+            if (Current == this)
+                Current = null;
+        }
+
+        /// <summary>
+        /// Ensures the static reference is cleared if the respawn point is destroyed.
+        /// </summary>
+        private void OnDestroy()
+        {
+            if (Current == this)
+                Current = null;
         }
     }
 }


### PR DESCRIPTION
## Summary
- clear the static RespawnPoint.Current reference when the owning object disables or is destroyed
- add XML documentation comments to explain the lifecycle handling

## Testing
- not run (Unity editor tests unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cecc0a3f74832eb6b17a47ae3c9360