### PR TITLE
Handle missing equipment items on load

### DIFF
--- a/Assets/Scripts/Inventory/Equipment.cs
+++ b/Assets/Scripts/Inventory/Equipment.cs
@@ -560,8 +560,19 @@ namespace Inventory
                 var slot = data.slots[i];
                 if (!string.IsNullOrEmpty(slot.id))
                 {
-                    equipped[i].item = ItemDatabase.GetItem(slot.id);
-                    equipped[i].count = slot.count;
+                    // Attempt to resolve the saved item id; if it no longer exists we clear
+                    // the slot so stale counts are not preserved between loads.
+                    var resolvedItem = ItemDatabase.GetItem(slot.id);
+                    equipped[i].item = resolvedItem;
+                    if (resolvedItem != null)
+                    {
+                        equipped[i].count = slot.count;
+                    }
+                    else
+                    {
+                        equipped[i].count = 0;
+                        Debug.LogWarning($"Equipment.Load: Missing item '{slot.id}' for slot {(EquipmentSlot)(i + 1)}. Slot has been cleared to prevent invalid state.");
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
## Summary
- clear equipment slots during load when a saved item can no longer be resolved
- emit a warning so missing item data is visible during debugging

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cecd77767c832e80038913c3f6b67e