### PR TITLE
Ensure PlayerMover unsubscribes scene load handler

### DIFF
--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -593,8 +593,10 @@ namespace Player
                     SceneManager.MoveGameObjectToScene(petToMove, scene);
                     petToMove = null;
                 }
-                SceneManager.sceneLoaded -= OnSceneLoaded;
             }
+
+            // Always unsubscribe after handling the scene load so duplicate registrations cannot accumulate.
+            SceneManager.sceneLoaded -= OnSceneLoaded;
         }
 
         private void OnTransitionStarted()


### PR DESCRIPTION
## Summary
- ensure PlayerMover removes its SceneManager.sceneLoaded handler regardless of whether saved data matches the loaded scene
- retain the player and active pet repositioning behaviour when a saved location is restored

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cece339014832eab7704593e96edc6