### PR TITLE
Handle respawns across scenes

### DIFF
--- a/Assets/Scripts/Player/PlayerRespawnSystem.cs
+++ b/Assets/Scripts/Player/PlayerRespawnSystem.cs
@@ -22,6 +22,10 @@ namespace Player
         private CombatController combatController;
         private PoisonController poisonController;
         private bool isRespawning;
+        private string cachedRespawnScene;
+        private string cachedSpawnPointId;
+        private Vector3 cachedFallbackPosition;
+        private bool hasCachedRespawnData;
 
         protected override void Awake()
         {
@@ -39,6 +43,12 @@ namespace Player
         {
             SceneManager.sceneLoaded += OnSceneLoaded;
             FindPlayer();
+
+            // When loading into a scene mid-session (e.g. via save), ensure the
+            // current respawn marker is captured even if it enabled before the
+            // respawn system finished bootstrapping.
+            if (RespawnPoint.Current != null)
+                RegisterRespawnPoint(RespawnPoint.Current);
         }
 
         private void OnDisable()
@@ -77,6 +87,23 @@ namespace Player
                 hitpoints.OnHealthChanged += HandleHealthChanged;
         }
 
+        /// <summary>
+        /// Captures the scene, spawn identifier and fallback position exposed by an
+        /// overworld <see cref="RespawnPoint"/> so the respawn routine can safely
+        /// restore the player even after the original scene unloads.
+        /// </summary>
+        public void RegisterRespawnPoint(RespawnPoint point)
+        {
+            if (point == null)
+                return;
+
+            cachedRespawnScene = point.SceneName;
+            var identifier = point.SpawnIdentifier;
+            cachedSpawnPointId = string.IsNullOrWhiteSpace(identifier) ? null : identifier;
+            cachedFallbackPosition = point.WorldPosition;
+            hasCachedRespawnData = true;
+        }
+
         private void HandleHealthChanged(int current, int max)
         {
             if (!isRespawning && current <= 0)
@@ -96,29 +123,115 @@ namespace Player
         {
             isRespawning = true;
 
-            // Refresh player references in case a new player instance spawned during respawn.
-            FindPlayer();
-            var hasPlayer = hitpoints != null;
+            try
+            {
+                // Always work with fresh component references because scene reloads or
+                // prefab swaps can replace the player object during death sequences.
+                FindPlayer();
 
-            var fader = GameManager.ScreenFader;
-            if (fader != null)
-                yield return fader.FadeOut();
+                var fader = GameManager.ScreenFader;
+                string activeScene = SceneManager.GetActiveScene().name;
+                bool hasRespawnScene = !string.IsNullOrEmpty(cachedRespawnScene);
+                bool requiresSceneSwap = hasRespawnScene && cachedRespawnScene != activeScene;
+                bool usedTransitionManager = false;
 
-            if (RespawnPoint.Current != null && hasPlayer)
-                hitpoints.transform.position = RespawnPoint.Current.transform.position;
+                // If we are not changing scenes or no transition manager exists, fade
+                // out immediately to hide the respawn process.
+                if (!requiresSceneSwap || SceneTransitionManager.Instance == null)
+                {
+                    if (fader != null)
+                        yield return fader.FadeOut();
+                }
 
-            if (!hasPlayer)
+                if (requiresSceneSwap)
+                {
+                    if (SceneTransitionManager.Instance != null)
+                    {
+                        usedTransitionManager = true;
+                        yield return SceneTransitionManager.Instance.Transition(cachedRespawnScene, cachedSpawnPointId, null, false);
+                    }
+                    else
+                    {
+                        yield return LoadRespawnSceneDirectly(cachedRespawnScene);
+                    }
+                }
+
+                // Ensure our cached references point at any player instance that exists
+                // in the now-active scene.
+                FindPlayer();
+
+                if (hitpoints == null)
+                    yield break;
+
+                Vector3 targetPosition = hasCachedRespawnData ? cachedFallbackPosition : hitpoints.transform.position;
+                var currentRespawn = RespawnPoint.Current;
+                if (currentRespawn != null)
+                    targetPosition = currentRespawn.transform.position;
+
+                if (playerMover != null)
+                {
+                    playerMover.StopMovement();
+                    playerMover.transform.position = targetPosition;
+                }
+
+                if (hitpoints.transform.position != targetPosition)
+                    hitpoints.transform.position = targetPosition;
+
+                hitpoints.RestoreToFullHealth();
+
+                if (usedTransitionManager)
+                {
+                    // Wait for the fade handled by the transition manager so the
+                    // respawn does not release control while a transition is active.
+                    while (SceneTransitionManager.IsTransitioning)
+                        yield return null;
+                }
+                else if (fader != null)
+                {
+                    yield return fader.FadeIn();
+                }
+            }
+            finally
             {
                 isRespawning = false;
+            }
+        }
+
+        /// <summary>
+        /// Fallback scene loading flow used when the <see cref="SceneTransitionManager"/>
+        /// singleton is not present in the project.  The routine mirrors the
+        /// persistent-object handling that the manager performs so respawns continue
+        /// to work in stripped-down scenes (e.g. tests or debug setups).
+        /// </summary>
+        private IEnumerator LoadRespawnSceneDirectly(string sceneName)
+        {
+            if (string.IsNullOrEmpty(sceneName))
                 yield break;
+
+            // Promote existing persistent objects so they survive the scene change and
+            // can be moved into the newly loaded scene manually.
+            var persistentObjects = FindObjectsOfType<ScenePersistentObject>(true);
+            foreach (var persistent in persistentObjects)
+            {
+                if (persistent != null)
+                    persistent.OnBeforeSceneUnload();
             }
 
-            hitpoints.RestoreToFullHealth();
+            var loadOperation = SceneManager.LoadSceneAsync(sceneName, LoadSceneMode.Single);
+            while (loadOperation != null && !loadOperation.isDone)
+                yield return null;
 
-            if (fader != null)
-                yield return fader.FadeIn();
+            var loadedScene = SceneManager.GetSceneByName(sceneName);
+            if (loadedScene.IsValid())
+            {
+                SceneManager.SetActiveScene(loadedScene);
 
-            isRespawning = false;
+                foreach (var persistent in persistentObjects)
+                {
+                    if (persistent != null)
+                        persistent.OnAfterSceneLoad(loadedScene);
+                }
+            }
         }
     }
 }

--- a/Assets/Scripts/World/RespawnPoint.cs
+++ b/Assets/Scripts/World/RespawnPoint.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using Player;
 
 namespace World
 {
@@ -12,12 +13,54 @@ namespace World
         /// </summary>
         public static RespawnPoint Current { get; private set; }
 
+        [Tooltip("Optional SpawnPoint marker that shares this respawn location for scene transitions.")]
+        [SerializeField]
+        private SpawnPoint linkedSpawnPoint;
+
+        /// <summary>
+        /// Provides the identifier of an associated <see cref="SpawnPoint"/> if one is present.
+        /// </summary>
+        public string SpawnIdentifier => linkedSpawnPoint != null ? linkedSpawnPoint.id : null;
+
+        /// <summary>
+        /// Retrieves the Unity scene name that owns this respawn marker.
+        /// </summary>
+        public string SceneName => gameObject.scene.name;
+
+        /// <summary>
+        /// Returns the precise world-space position of the respawn marker.
+        /// </summary>
+        public Vector3 WorldPosition => transform.position;
+
+        private void Reset()
+        {
+            // Default the linked spawn point to the local component so designers do not
+            // need to wire the field manually when the SpawnPoint lives on the same object.
+            if (linkedSpawnPoint == null)
+                linkedSpawnPoint = GetComponent<SpawnPoint>();
+        }
+
+        private void Awake()
+        {
+            if (linkedSpawnPoint == null)
+                linkedSpawnPoint = GetComponent<SpawnPoint>();
+        }
+
         /// <summary>
         /// Registers this respawn point as the current active point when enabled.
         /// </summary>
         private void OnEnable()
         {
+            if (linkedSpawnPoint == null)
+                linkedSpawnPoint = GetComponent<SpawnPoint>();
+
             Current = this;
+
+            // Immediately notify the respawn system so it can cache the scene, spawn
+            // identifier and fallback position instead of relying solely on the static
+            // Current pointer.
+            if (PlayerRespawnSystem.Instance != null)
+                PlayerRespawnSystem.Instance.RegisterRespawnPoint(this);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- cache overworld respawn metadata (scene, spawn id, fallback position) when respawn points activate
- teach the player respawn system to transition scenes and reposition using the cached data before restoring health
- add a direct scene loading fallback so respawns work without the SceneTransitionManager instance

## Testing
- not run (Unity editor environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ced0f5109c832ea05bac8d9cd8931f