### PR TITLE
Fix pets spawning at origin after scene loads

### DIFF
--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -640,6 +640,22 @@ namespace Player
                 }
             }
 
+            // Realign an active pet so it appears beside the player rather than
+            // lingering at the origin during scene swaps.  Without this pass the
+            // pet spawns at (0,0) because the player may not exist yet when the
+            // pet system restores its position during the load sequence.
+            var activePet = PetDropSystem.ActivePetObject;
+            if (activePet != null)
+            {
+                activePet.transform.position = transform.position;
+                var follower = activePet.GetComponent<PetFollower>();
+                if (follower != null)
+                    follower.SetPlayer(transform);
+
+                if (activePet.scene != scene)
+                    SceneManager.MoveGameObjectToScene(activePet, scene);
+            }
+
             var players = GameObject.FindGameObjectsWithTag("Player");
             foreach (var p in players)
             {


### PR DESCRIPTION
## Summary
- snap the active pet to the player's spawn location after a scene transition
- retarget the pet follower to the current player and move it into the loaded scene when needed

## Testing
- not run (Unity CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ced62c2af8832e897ab6d969256c92