### PR TITLE
Stabilize daily bycatch seed generation

### DIFF
--- a/Assets/Scripts/Skills/Fishing/Bycatch/BycatchManager.cs
+++ b/Assets/Scripts/Skills/Fishing/Bycatch/BycatchManager.cs
@@ -35,7 +35,7 @@ namespace Skills.Fishing
 
         public int GetStreak(WaterType wt)
         {
-            int today = DateTime.UtcNow.Date.GetHashCode();
+            int today = ComposeDailySeed();
             if (!_lastSeedDay.TryGetValue(wt, out int last) || last != today)
             {
                 _lastSeedDay[wt] = today;
@@ -46,7 +46,7 @@ namespace Skills.Fishing
 
         public void ApplyStreakResult(WaterType wt, BycatchResult res)
         {
-            int today = DateTime.UtcNow.Date.GetHashCode();
+            int today = ComposeDailySeed();
             _lastSeedDay[wt] = today;
             bool isRare = !res.IsNone && (res.Rarity == Rarity.Rare || res.Rarity == Rarity.UltraRare);
             if (isRare)
@@ -228,11 +228,38 @@ namespace Skills.Fishing
         {
             if (!useDailySeed)
                 return new System.Random();
-            int seed = DateTime.UtcNow.Date.GetHashCode();
-            seed = HashCombine(seed, ctx.playerIdHash);
-            seed = HashCombine(seed, ctx.nodeHash);
-            seed = HashCombine(seed, ctx.rollIndex);
+
+            int seed = ComposeDailySeed(stackalloc int[]
+            {
+                ctx.playerIdHash,
+                ctx.nodeHash,
+                ctx.rollIndex
+            });
             return new System.Random(seed);
+        }
+
+        /// <summary>
+        /// Builds a deterministic daily seed using the current UTC day ticks combined with contextual hashes.
+        /// </summary>
+        /// <param name="contextHashes">Optional hashes to fold into the final seed for per-entity determinism.</param>
+        internal static int ComposeDailySeed(ReadOnlySpan<int> contextHashes)
+        {
+            long ticks = DateTime.UtcNow.Date.Ticks;
+            unchecked
+            {
+                int seed = (int)(ticks ^ (ticks >> 32));
+                foreach (int hash in contextHashes)
+                    seed = HashCombine(seed, hash);
+                return seed;
+            }
+        }
+
+        /// <summary>
+        /// Convenience wrapper when no contextual hashes are required.
+        /// </summary>
+        internal static int ComposeDailySeed()
+        {
+            return ComposeDailySeed(ReadOnlySpan<int>.Empty);
         }
 
         private static int HashCombine(int a, int b)

--- a/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
@@ -341,22 +341,16 @@ namespace Skills.Fishing
         {
             if (bycatchManager != null && bycatchManager.useDailySeed)
             {
-                int seed = DateTime.UtcNow.Date.GetHashCode();
-                seed = HashCombine(seed, ctx.playerIdHash);
-                seed = HashCombine(seed, ctx.nodeHash);
-                seed = HashCombine(seed, ctx.rollIndex);
+                int seed = BycatchManager.ComposeDailySeed(stackalloc int[]
+                {
+                    ctx.playerIdHash,
+                    ctx.nodeHash,
+                    ctx.rollIndex
+                });
                 return new System.Random(seed);
             }
 
             return new System.Random();
-        }
-
-        private static int HashCombine(int a, int b)
-        {
-            unchecked
-            {
-                return (a * 397) ^ b;
-            }
         }
 
         public void StartFishing(FishableSpot spot, FishingToolDefinition tool)


### PR DESCRIPTION
## Summary
- add a shared helper on BycatchManager that converts the current UTC day ticks plus contextual hashes into a deterministic seed
- update streak tracking and RNG creation to rely on the shared helper so daily rolls reset consistently without platform-dependent hashes

## Testing
- not run (Unity editor required)


------
https://chatgpt.com/codex/tasks/task_e_68cefad91b68832eb91ed8dcce0e6651