### PR TITLE
Add shared daily time service

### DIFF
--- a/Assets/Scripts/Core/Time.meta
+++ b/Assets/Scripts/Core/Time.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2ab2d993d6e949a2a5ac463e517ff123
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Core/Time/DailyGameTimeService.cs
+++ b/Assets/Scripts/Core/Time/DailyGameTimeService.cs
@@ -1,0 +1,216 @@
+using System;
+using System.Collections;
+using UnityEngine;
+using Util;
+using World;
+
+namespace Core.Time
+{
+    /// <summary>
+    /// Cross-game service that caches the current UTC day so any feature (fishing, quests,
+    /// seasonal events, rotating shops, etc.) can coordinate deterministic day-based logic
+    /// without depending on fishing-specific helpers.
+    /// </summary>
+    /// <remarks>
+    /// The service is instantiated through <c>PersistentObjects.asset</c> which keeps it alive
+    /// across scene loads. It polls <see cref="Ticker"/> once per OSRS-style tick to detect
+    /// UTC day changes and raises <see cref="DayChanged"/> so interested systems can react
+    /// when the calendar rolls over.
+    /// </remarks>
+    [DisallowMultipleComponent]
+    public sealed class DailyGameTimeService : ScenePersistentObject, ITickable
+    {
+        private static DailyGameTimeService instance;
+
+        private DateTime cachedUtcDay;
+        private bool started;
+        private bool subscribedToTicker;
+        private Coroutine tickerSubscriptionRoutine;
+
+        /// <summary>
+        /// Event fired whenever <see cref="CurrentUtcDay"/> advances. Subscribers receive the
+        /// newly cached day so they can refresh daily quests, shop inventories, or seasonal
+        /// rotations in lockstep with the global calendar.
+        /// </summary>
+        public static event Action<DateTime> DayChanged;
+
+        /// <summary>
+        /// Returns the cached UTC calendar day. When the service has not booted yet the value
+        /// falls back to <see cref="DateTime.UtcNow"/> so callers can still resolve seeds early
+        /// during startup flows.
+        /// </summary>
+        public static DateTime CurrentUtcDay => instance != null ? instance.cachedUtcDay : DateTime.UtcNow.Date;
+
+        /// <summary>
+        /// Builds a deterministic daily seed using the cached UTC day ticks combined with
+        /// contextual hashes provided by the caller. This keeps daily rolls stable for a
+        /// calendar day while still allowing per-entity randomness.
+        /// </summary>
+        /// <param name="contextHashes">Hashes that should be folded into the daily seed.</param>
+        /// <returns>A reproducible seed that stays constant for the current UTC day.</returns>
+        public static int ComposeDailySeed(ReadOnlySpan<int> contextHashes)
+        {
+            long ticks = CurrentUtcDay.Ticks;
+
+            unchecked
+            {
+                int seed = (int)(ticks ^ (ticks >> 32));
+                foreach (int hash in contextHashes)
+                {
+                    seed = HashCombine(seed, hash);
+                }
+
+                return seed;
+            }
+        }
+
+        /// <summary>
+        /// Convenience overload when the caller does not need to supply additional context.
+        /// </summary>
+        public static int ComposeDailySeed()
+        {
+            return ComposeDailySeed(ReadOnlySpan<int>.Empty);
+        }
+
+        /// <inheritdoc />
+        protected override void Awake()
+        {
+            if (instance != null && instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            base.Awake();
+
+            instance = this;
+            cachedUtcDay = DateTime.UtcNow.Date;
+        }
+
+        private void Start()
+        {
+            started = true;
+            SubscribeToTicker();
+            EvaluateDayChange();
+        }
+
+        private void OnEnable()
+        {
+            if (instance == null)
+            {
+                instance = this;
+            }
+
+            if (started)
+            {
+                SubscribeToTicker();
+                EvaluateDayChange();
+            }
+        }
+
+        private void OnDisable()
+        {
+            UnsubscribeFromTicker();
+        }
+
+        private void OnDestroy()
+        {
+            if (instance == this)
+            {
+                UnsubscribeFromTicker();
+                instance = null;
+            }
+        }
+
+        /// <inheritdoc />
+        public void OnTick()
+        {
+            EvaluateDayChange();
+        }
+
+        private void SubscribeToTicker()
+        {
+            if (subscribedToTicker)
+            {
+                return;
+            }
+
+            if (Ticker.Instance == null)
+            {
+                if (tickerSubscriptionRoutine == null && isActiveAndEnabled)
+                {
+                    tickerSubscriptionRoutine = StartCoroutine(WaitForTickerAndSubscribe());
+                }
+                return;
+            }
+
+            Ticker.Instance.Subscribe(this);
+            subscribedToTicker = true;
+            EvaluateDayChange();
+        }
+
+        private void UnsubscribeFromTicker()
+        {
+            if (tickerSubscriptionRoutine != null)
+            {
+                StopCoroutine(tickerSubscriptionRoutine);
+                tickerSubscriptionRoutine = null;
+            }
+
+            if (!subscribedToTicker)
+            {
+                return;
+            }
+
+            if (Ticker.Instance != null)
+            {
+                Ticker.Instance.Unsubscribe(this);
+            }
+
+            subscribedToTicker = false;
+        }
+
+        private void EvaluateDayChange()
+        {
+            DateTime today = DateTime.UtcNow.Date;
+            if (today == cachedUtcDay)
+            {
+                return;
+            }
+
+            cachedUtcDay = today;
+            DayChanged?.Invoke(today);
+        }
+
+        /// <summary>
+        /// Waits for the global <see cref="Ticker"/> singleton to finish booting so the service can
+        /// receive OSRS tick callbacks even if it spawns before the ticker prefab.
+        /// </summary>
+        private IEnumerator WaitForTickerAndSubscribe()
+        {
+            while (Ticker.Instance == null)
+            {
+                yield return null;
+            }
+
+            tickerSubscriptionRoutine = null;
+
+            if (!isActiveAndEnabled || subscribedToTicker)
+            {
+                yield break;
+            }
+
+            Ticker.Instance.Subscribe(this);
+            subscribedToTicker = true;
+            EvaluateDayChange();
+        }
+
+        private static int HashCombine(int a, int b)
+        {
+            unchecked
+            {
+                return (a * 397) ^ b;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Core/Time/DailyGameTimeService.cs.meta
+++ b/Assets/Scripts/Core/Time/DailyGameTimeService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7f4ce2847e8841c3a608f70d9a85f7cb

--- a/Assets/Scripts/Skills/Fishing/Bycatch/BycatchManager.cs
+++ b/Assets/Scripts/Skills/Fishing/Bycatch/BycatchManager.cs
@@ -1,6 +1,6 @@
-using System;
 using System.Collections.Generic;
 using UnityEngine;
+using Core.Time;
 using World;
 
 namespace Skills.Fishing
@@ -35,7 +35,7 @@ namespace Skills.Fishing
 
         public int GetStreak(WaterType wt)
         {
-            int today = ComposeDailySeed();
+            int today = DailyGameTimeService.ComposeDailySeed();
             if (!_lastSeedDay.TryGetValue(wt, out int last) || last != today)
             {
                 _lastSeedDay[wt] = today;
@@ -46,7 +46,7 @@ namespace Skills.Fishing
 
         public void ApplyStreakResult(WaterType wt, BycatchResult res)
         {
-            int today = ComposeDailySeed();
+            int today = DailyGameTimeService.ComposeDailySeed();
             _lastSeedDay[wt] = today;
             bool isRare = !res.IsNone && (res.Rarity == Rarity.Rare || res.Rarity == Rarity.UltraRare);
             if (isRare)
@@ -229,7 +229,7 @@ namespace Skills.Fishing
             if (!useDailySeed)
                 return new System.Random();
 
-            int seed = ComposeDailySeed(stackalloc int[]
+            int seed = DailyGameTimeService.ComposeDailySeed(stackalloc int[]
             {
                 ctx.playerIdHash,
                 ctx.nodeHash,
@@ -238,36 +238,5 @@ namespace Skills.Fishing
             return new System.Random(seed);
         }
 
-        /// <summary>
-        /// Builds a deterministic daily seed using the current UTC day ticks combined with contextual hashes.
-        /// </summary>
-        /// <param name="contextHashes">Optional hashes to fold into the final seed for per-entity determinism.</param>
-        internal static int ComposeDailySeed(ReadOnlySpan<int> contextHashes)
-        {
-            long ticks = DateTime.UtcNow.Date.Ticks;
-            unchecked
-            {
-                int seed = (int)(ticks ^ (ticks >> 32));
-                foreach (int hash in contextHashes)
-                    seed = HashCombine(seed, hash);
-                return seed;
-            }
-        }
-
-        /// <summary>
-        /// Convenience wrapper when no contextual hashes are required.
-        /// </summary>
-        internal static int ComposeDailySeed()
-        {
-            return ComposeDailySeed(ReadOnlySpan<int>.Empty);
-        }
-
-        private static int HashCombine(int a, int b)
-        {
-            unchecked
-            {
-                return (a * 397) ^ b;
-            }
-        }
     }
 }

--- a/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
@@ -8,6 +8,7 @@ using Pets;
 using Core;
 using BankSystem;
 using Core.Save;
+using Core.Time;
 using Skills.Outfits;
 using Skills.Common;
 
@@ -341,7 +342,7 @@ namespace Skills.Fishing
         {
             if (bycatchManager != null && bycatchManager.useDailySeed)
             {
-                int seed = BycatchManager.ComposeDailySeed(stackalloc int[]
+                int seed = DailyGameTimeService.ComposeDailySeed(stackalloc int[]
                 {
                     ctx.playerIdHash,
                     ctx.nodeHash,


### PR DESCRIPTION
## Summary
- add the DailyGameTimeService singleton under Assets/Scripts/Core/Time to cache the UTC day, raise change events, and expose deterministic daily seed helpers
- update fishing systems to request their daily RNG seeds from the shared service instead of local helpers
- leave prefab creation and PersistentObjects.asset registration to be wired manually as requested

## Testing
- not run (Unity editor required)

------
https://chatgpt.com/codex/tasks/task_e_68cefd386124832eb111917e300e4e21