### PR TITLE
Add skill debug logging toggles

### DIFF
--- a/Assets/Scripts/Skills/AdminF2Menu.cs
+++ b/Assets/Scripts/Skills/AdminF2Menu.cs
@@ -5,8 +5,11 @@ using Player;
 using Beastmaster;
 using Pets;
 using BankSystem;
+using Skills.Cooking;
 using Skills.Fishing;
+using Skills.Mining;
 using Skills.Outfits;
+using Skills.Woodcutting;
 using Status;
 using Status.Antifire;
 using Status.Poison;
@@ -58,6 +61,11 @@ namespace Skills
 
         // Scroll position for the debug menu
         private Vector2 scrollPos;
+
+        private MiningSkill miningSkillBehaviour;
+        private WoodcuttingSkill woodcuttingSkillBehaviour;
+        private FishingSkill fishingSkillBehaviour;
+        private CookingSkill cookingSkillBehaviour;
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         private static void Bootstrap()
@@ -224,6 +232,14 @@ namespace Skills
                     }
                 }
             }
+            if (miningSkillBehaviour == null)
+                miningSkillBehaviour = FindObjectOfType<MiningSkill>();
+            if (woodcuttingSkillBehaviour == null)
+                woodcuttingSkillBehaviour = FindObjectOfType<WoodcuttingSkill>();
+            if (fishingSkillBehaviour == null)
+                fishingSkillBehaviour = FindObjectOfType<FishingSkill>();
+            if (cookingSkillBehaviour == null)
+                cookingSkillBehaviour = FindObjectOfType<CookingSkill>();
         }
 
         private void RefreshFields()
@@ -242,6 +258,11 @@ namespace Skills
             }
             if (mergeConfig == null)
                 mergeConfig = Resources.Load<MergeConfig>("MergeConfig");
+
+            miningSkillBehaviour = FindObjectOfType<MiningSkill>();
+            woodcuttingSkillBehaviour = FindObjectOfType<WoodcuttingSkill>();
+            fishingSkillBehaviour = FindObjectOfType<FishingSkill>();
+            cookingSkillBehaviour = FindObjectOfType<CookingSkill>();
 
             hpLevel = skillManager != null ? skillManager.GetLevel(SkillType.Hitpoints).ToString() : "";
             attackLevel = skillManager != null ? skillManager.GetLevel(SkillType.Attack).ToString() : "";
@@ -307,6 +328,29 @@ namespace Skills
                         GUILayout.Label("Locked (<50)");
                 }
             }
+
+            GUILayout.Space(10f);
+            GUILayout.Label("Skill Debug Logging");
+            DrawSkillDebugToggle(
+                "Mining Debug Logging",
+                () => miningSkillBehaviour != null,
+                () => miningSkillBehaviour.EnableDebugLogging,
+                value => miningSkillBehaviour.EnableDebugLogging = value);
+            DrawSkillDebugToggle(
+                "Woodcutting Debug Logging",
+                () => woodcuttingSkillBehaviour != null,
+                () => woodcuttingSkillBehaviour.EnableDebugLogging,
+                value => woodcuttingSkillBehaviour.EnableDebugLogging = value);
+            DrawSkillDebugToggle(
+                "Fishing Debug Logging",
+                () => fishingSkillBehaviour != null,
+                () => fishingSkillBehaviour.EnableDebugLogging,
+                value => fishingSkillBehaviour.EnableDebugLogging = value);
+            DrawSkillDebugToggle(
+                "Cooking Debug Logging",
+                () => cookingSkillBehaviour != null,
+                () => cookingSkillBehaviour.EnableDebugLogging,
+                value => cookingSkillBehaviour.EnableDebugLogging = value);
 
             if (GUILayout.Button("Apply"))
             {
@@ -448,6 +492,28 @@ namespace Skills
 
             if (showFreezePopup)
                 freezePopupRect = GUI.ModalWindow(0xF20F2, freezePopupRect, DrawFreezePopup, "Freeze Player");
+        }
+
+        /// <summary>
+        ///     Renders a toggle used to control runtime debug logging for a specific skill.
+        /// </summary>
+        /// <param name="label">Label describing the toggle.</param>
+        /// <param name="skillAvailable">Predicate that returns true when the skill component exists.</param>
+        /// <param name="getValue">Delegate that retrieves the current toggle state.</param>
+        /// <param name="setValue">Delegate that applies a new toggle state.</param>
+        private void DrawSkillDebugToggle(string label, Func<bool> skillAvailable, Func<bool> getValue, Action<bool> setValue)
+        {
+            bool available = skillAvailable();
+            bool previousEnabled = GUI.enabled;
+            GUI.enabled = available && previousEnabled;
+
+            bool current = available ? getValue() : false;
+            bool updated = GUILayout.Toggle(current, label);
+
+            if (available && updated != current)
+                setValue(updated);
+
+            GUI.enabled = previousEnabled;
         }
 
         /// <summary>

--- a/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
+++ b/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
@@ -22,6 +22,8 @@ namespace Skills.Cooking
         [SerializeField] private Inventory.Inventory inventory;
         [SerializeField] private Equipment equipment;
         [SerializeField] private Transform floatingTextAnchor;
+        [SerializeField, Tooltip("Enables verbose debug logging for cooking actions.")]
+        private bool enableDebugLogging;
 
         private SkillManager skills;
         private CookableRecipe currentRecipe;
@@ -39,6 +41,15 @@ namespace Skills.Cooking
         public float Xp => skills != null ? skills.GetXp(SkillType.Cooking) : 0f;
         public bool IsCooking => currentRecipe != null && itemsRemaining > 0;
         public float CookProgressNormalized => CookIntervalTicks <= 1 ? 0f : (float)cookProgress / (CookIntervalTicks - 1);
+
+        /// <summary>
+        ///     Gets or sets the runtime flag controlling verbose debug logging for this skill.
+        /// </summary>
+        public bool EnableDebugLogging
+        {
+            get => enableDebugLogging;
+            set => enableDebugLogging = value;
+        }
 
         private void Awake()
         {
@@ -71,6 +82,7 @@ namespace Skills.Cooking
             currentRecipe = recipe;
             itemsRemaining = quantity;
             cookProgress = 0;
+            LogDebug($"Started cooking {recipe.cookedItemId} x{quantity}");
             OnStartCooking?.Invoke(recipe);
         }
 
@@ -81,14 +93,18 @@ namespace Skills.Cooking
             currentRecipe = null;
             itemsRemaining = 0;
             cookProgress = 0;
+            LogDebug("Stopped cooking");
             OnStopCooking?.Invoke();
         }
+
+        protected override bool LogTickerSubscription => enableDebugLogging;
 
         protected override void HandleTick()
         {
             if (!IsCooking)
                 return;
             cookProgress++;
+            LogDebug($"Cooking tick: {cookProgress}/{CookIntervalTicks}");
             if (cookProgress >= CookIntervalTicks)
             {
                 cookProgress = 0;
@@ -109,12 +125,14 @@ namespace Skills.Cooking
         {
             if (currentRecipe == null || inventory == null)
             {
+                LogDebug("Cooking aborted because recipe or inventory reference was lost.");
                 StopCooking();
                 return;
             }
 
             if (!inventory.RemoveItem(currentRecipe.rawItemId))
             {
+                LogDebug("Failed to remove raw ingredient; stopping cooking session.");
                 StopCooking();
                 return;
             }
@@ -129,6 +147,7 @@ namespace Skills.Cooking
             if (burned)
             {
                 FloatingText.Show("Burned", anchor.position);
+                LogDebug($"Burned {currentRecipe.cookedItemId} (burn chance {burnChance:P2})");
             }
             else
             {
@@ -171,6 +190,8 @@ namespace Skills.Cooking
                 var rewardResult = GatheringRewardProcessor.Process(context);
                 if (!rewardResult.Success)
                     return;
+
+                LogDebug($"Successfully cooked {cookedName} (burn chance {burnChance:P2})");
             }
 
             if (itemsRemaining <= 0)
@@ -196,6 +217,18 @@ namespace Skills.Cooking
                 "Cooking",
                 "You've received a piece of cooking outfit",
                 "A piece of cooking outfit has been added to your bank");
+        }
+
+        /// <summary>
+        ///     Emits a formatted debug message when <see cref="enableDebugLogging"/> is enabled.
+        /// </summary>
+        /// <param name="message">Message to output to the Unity console.</param>
+        private void LogDebug(string message)
+        {
+            if (!enableDebugLogging)
+                return;
+
+            Debug.Log($"[CookingSkill] {message}");
         }
     }
 }

--- a/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
@@ -23,6 +23,9 @@ namespace Skills.Fishing
         private BycatchManager bycatchManager;
         private bool waitingForServices;
 
+        [SerializeField, Tooltip("Enables verbose debug logging for fishing actions.")]
+        private bool enableDebugLogging;
+
         private FishableSpot currentSpot;
         private FishingToolDefinition currentTool;
         private int catchProgress;
@@ -45,6 +48,15 @@ namespace Skills.Fishing
         public FishingToolDefinition CurrentTool => currentTool;
         public float CatchProgressNormalized => currentIntervalTicks <= 1 ? 0f : (float)catchProgress / (currentIntervalTicks - 1);
         public int CurrentCatchIntervalTicks => currentIntervalTicks;
+
+        /// <summary>
+        ///     Gets or sets the runtime flag controlling verbose debug logging for this skill.
+        /// </summary>
+        public bool EnableDebugLogging
+        {
+            get => enableDebugLogging;
+            set => enableDebugLogging = value;
+        }
 
         private SkillManager skills;
 
@@ -78,6 +90,8 @@ namespace Skills.Fishing
             }
             SaveManager.Unregister(fishingOutfit);
         }
+
+        protected override bool LogTickerSubscription => enableDebugLogging;
 
         /// <summary>
         /// Attempts to resolve the bycatch manager from the <see cref="GameManager"/> when available
@@ -134,6 +148,7 @@ namespace Skills.Fishing
                 return;
             }
             catchProgress++;
+            LogDebug($"Fishing tick: {catchProgress}/{currentIntervalTicks}");
             if (catchProgress >= currentIntervalTicks)
             {
                 catchProgress = 0;
@@ -146,6 +161,7 @@ namespace Skills.Fishing
             var fish = GetRandomFish(currentSpot.def);
             if (fish == null)
             {
+                LogDebug("No eligible fish could be selected; stopping.");
                 StopFishing();
                 return;
             }
@@ -155,6 +171,7 @@ namespace Skills.Fishing
                 if (inventory == null || !inventory.RemoveItem(currentSpot.def.BaitItemId))
                 {
                     FloatingText.Show("You need bait", anchor.position);
+                    LogDebug("Bait requirement not met; cancelling fishing session.");
                     StopFishing();
                     return;
                 }
@@ -222,8 +239,13 @@ namespace Skills.Fishing
                     return;
 
                 currentSpot.OnFishCaught();
+                LogDebug($"Caught {fish.DisplayName} x{amount} (chance {chance:P2})");
                 if (currentSpot.IsDepleted)
                     StopFishing();
+            }
+            else
+            {
+                LogDebug($"Failed to catch fish at {currentSpot?.name ?? "unknown spot"} (chance {chance:P2})");
             }
         }
 
@@ -364,6 +386,7 @@ namespace Skills.Fishing
                 {
                     Transform anchor = floatingTextAnchor != null ? floatingTextAnchor : transform;
                     FloatingText.Show("You need bait", anchor.position);
+                    LogDebug("Unable to start fishing: missing bait.");
                     return;
                 }
             }
@@ -372,6 +395,7 @@ namespace Skills.Fishing
             catchProgress = 0;
             currentIntervalTicks = Mathf.Max(1, Mathf.RoundToInt(spot.def.CatchIntervalTicks / Mathf.Max(0.01f, tool.SwingSpeedMultiplier)));
             currentSpot.IsBusy = true;
+            LogDebug($"Started fishing {spot.name} with {tool.DisplayName}");
             OnStartFishing?.Invoke(spot);
         }
 
@@ -385,6 +409,7 @@ namespace Skills.Fishing
             currentTool = null;
             catchProgress = 0;
             currentIntervalTicks = 0;
+            LogDebug("Stopped fishing");
             OnStopFishing?.Invoke();
         }
 
@@ -422,6 +447,18 @@ namespace Skills.Fishing
         private void PreloadFishItems()
         {
             GatheringInventoryHelper.EnsureItemCache(ref fishItems);
+        }
+
+        /// <summary>
+        ///     Emits a formatted debug message when <see cref="enableDebugLogging"/> is enabled.
+        /// </summary>
+        /// <param name="message">Message to output to the Unity console.</param>
+        private void LogDebug(string message)
+        {
+            if (!enableDebugLogging)
+                return;
+
+            Debug.Log($"[FishingSkill] {message}");
         }
     }
 }

--- a/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
@@ -25,6 +25,8 @@ namespace Skills.Mining
         [SerializeField] private Inventory.Inventory inventory;
         [SerializeField] private Equipment equipment;
         [SerializeField] private Transform floatingTextAnchor;
+        [SerializeField, Tooltip("Enables verbose debug logging for mining tick processing.")]
+        private bool enableDebugLogging;
 
         private MineableRock currentRock;
         private PickaxeDefinition currentPickaxe;
@@ -50,6 +52,15 @@ namespace Skills.Mining
             => currentPickaxe == null || currentPickaxe.SwingSpeedTicks <= 1
                 ? 0f
                 : (float)swingProgress / (currentPickaxe.SwingSpeedTicks - 1);
+
+        /// <summary>
+        ///     Gets or sets the runtime flag controlling verbose debug logging for this skill.
+        /// </summary>
+        public bool EnableDebugLogging
+        {
+            get => enableDebugLogging;
+            set => enableDebugLogging = value;
+        }
 
         private void Awake()
         {
@@ -77,7 +88,7 @@ namespace Skills.Mining
         /// <summary>
         ///     Enables ticker logging so we can trace subscription timing during debugging sessions.
         /// </summary>
-        protected override bool LogTickerSubscription => true;
+        protected override bool LogTickerSubscription => enableDebugLogging;
 
         protected override void HandleTick()
         {
@@ -92,7 +103,7 @@ namespace Skills.Mining
             }
 
             swingProgress++;
-            Debug.Log($"Mining tick: {swingProgress}/{currentPickaxe.SwingSpeedTicks}");
+            LogDebug($"Mining tick: {swingProgress}/{currentPickaxe?.SwingSpeedTicks ?? 0}");
             if (swingProgress >= currentPickaxe.SwingSpeedTicks)
             {
                 swingProgress = 0;
@@ -176,6 +187,8 @@ namespace Skills.Mining
                     var rewardResult = GatheringRewardProcessor.Process(context);
                     if (!rewardResult.Success)
                         return;
+
+                    LogDebug($"Mined {oreName} x{amount} (chance {chance:P2})");
                 }
 
                 if (currentRock.IsDepleted)
@@ -183,7 +196,7 @@ namespace Skills.Mining
             }
             else
             {
-                Debug.Log($"Failed to mine {currentRock.name}");
+                LogDebug($"Failed to mine {currentRock?.name ?? "unknown rock"} (chance {chance:P2})");
             }
         }
 
@@ -195,7 +208,7 @@ namespace Skills.Mining
             currentRock = rock;
             currentPickaxe = pickaxe;
             swingProgress = 0;
-            Debug.Log($"Started mining {rock.name}");
+            LogDebug($"Started mining {rock.name} with {pickaxe.DisplayName}");
             OnStartMining?.Invoke(rock);
         }
 
@@ -204,7 +217,7 @@ namespace Skills.Mining
             if (!IsMining)
                 return;
 
-            Debug.Log("Stopped mining");
+            LogDebug("Stopped mining");
             currentRock = null;
             currentPickaxe = null;
             swingProgress = 0;
@@ -248,6 +261,18 @@ namespace Skills.Mining
         private void PreloadOreItems()
         {
             GatheringInventoryHelper.EnsureItemCache(ref oreItems);
+        }
+
+        /// <summary>
+        ///     Emits a formatted debug message when <see cref="enableDebugLogging"/> is enabled.
+        /// </summary>
+        /// <param name="message">Message to output to the Unity console.</param>
+        private void LogDebug(string message)
+        {
+            if (!enableDebugLogging)
+                return;
+
+            Debug.Log($"[MiningSkill] {message}");
         }
     }
 }

--- a/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
@@ -24,6 +24,8 @@ namespace Skills.Woodcutting
         [SerializeField] private Inventory.Inventory inventory;
         [SerializeField] private Equipment equipment;
         [SerializeField] private Transform floatingTextAnchor;
+        [SerializeField, Tooltip("Enables verbose debug logging for woodcutting actions.")]
+        private bool enableDebugLogging;
 
         private TreeNode currentTree;
         private AxeDefinition currentAxe;
@@ -49,6 +51,15 @@ namespace Skills.Woodcutting
         public AxeDefinition CurrentAxe => currentAxe;
         public float ChopProgressNormalized
             => currentIntervalTicks <= 1 ? 0f : (float)chopProgress / (currentIntervalTicks - 1);
+
+        /// <summary>
+        ///     Gets or sets the runtime flag controlling verbose debug logging for this skill.
+        /// </summary>
+        public bool EnableDebugLogging
+        {
+            get => enableDebugLogging;
+            set => enableDebugLogging = value;
+        }
 
         private void Awake()
         {
@@ -76,7 +87,7 @@ namespace Skills.Woodcutting
         /// <summary>
         ///     Enables ticker logging so we can trace subscription timing during debugging sessions.
         /// </summary>
-        protected override bool LogTickerSubscription => true;
+        protected override bool LogTickerSubscription => enableDebugLogging;
 
         protected override void HandleTick()
         {
@@ -90,6 +101,7 @@ namespace Skills.Woodcutting
             }
 
             chopProgress++;
+            LogDebug($"Woodcutting tick: {chopProgress}/{currentIntervalTicks}");
             if (chopProgress >= currentIntervalTicks)
             {
                 chopProgress = 0;
@@ -172,12 +184,13 @@ namespace Skills.Woodcutting
                     return;
 
                 currentTree.OnLogChopped();
+                LogDebug($"Chopped {logName} x{amount} (chance {chance:P2})");
                 if (currentTree.IsDepleted)
                     StopChopping();
             }
             else
             {
-                Debug.Log($"Failed to chop {currentTree.name}");
+                LogDebug($"Failed to chop {currentTree?.name ?? "unknown tree"} (chance {chance:P2})");
             }
         }
 
@@ -190,7 +203,7 @@ namespace Skills.Woodcutting
             currentAxe = axe;
             chopProgress = 0;
             currentIntervalTicks = Mathf.Max(1, Mathf.RoundToInt(tree.def.ChopIntervalTicks / Mathf.Max(0.01f, axe.SwingSpeedMultiplier)));
-            Debug.Log($"Started chopping {tree.name}");
+            LogDebug($"Started chopping {tree.name} with {axe.DisplayName}");
             currentTree.IsBusy = true;
             OnStartChopping?.Invoke(tree);
         }
@@ -200,7 +213,7 @@ namespace Skills.Woodcutting
             if (!IsChopping)
                 return;
 
-            Debug.Log("Stopped chopping");
+            LogDebug("Stopped chopping");
             if (currentTree != null)
                 currentTree.IsBusy = false;
             currentTree = null;
@@ -247,6 +260,18 @@ namespace Skills.Woodcutting
         private void PreloadLogItems()
         {
             GatheringInventoryHelper.EnsureItemCache(ref logItems);
+        }
+
+        /// <summary>
+        ///     Emits a formatted debug message when <see cref="enableDebugLogging"/> is enabled.
+        /// </summary>
+        /// <param name="message">Message to output to the Unity console.</param>
+        private void LogDebug(string message)
+        {
+            if (!enableDebugLogging)
+                return;
+
+            Debug.Log($"[WoodcuttingSkill] {message}");
         }
     }
 }


### PR DESCRIPTION
## Summary
- add per-skill debug logging flags and helper methods across mining, woodcutting, fishing, and cooking skills
- gate existing verbose logs behind the new flags and emit richer diagnostics when enabled
- surface runtime toggles for each skill in the F2 admin menu for convenient testing

## Testing
- not run (project is a Unity project without automated tests in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68cf0b44122c832e9a0eec3b5a676337