### PR TITLE
Add shared legacy font provider

### DIFF
--- a/Assets/Scripts/Bank/BankUI.cs
+++ b/Assets/Scripts/Bank/BankUI.cs
@@ -88,14 +88,7 @@ namespace BankSystem
             if (!PersistentSceneSingleton<BankUI>.HandleAwake(this))
                 return;
 
-            try
-            {
-                defaultFont = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
-            }
-            catch (ArgumentException)
-            {
-                defaultFont = null;
-            }
+            defaultFont = LegacyFontProvider.GetLegacyFont();
 
             stackCountFont = Resources.Load<Font>("ThaleahFat_TTF") ??
                              Resources.Load<Font>("ThaleahFAT_TTF") ??

--- a/Assets/Scripts/Dialogue/DialogueUI.cs
+++ b/Assets/Scripts/Dialogue/DialogueUI.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.EventSystems;
 using UnityEngine.InputSystem.UI;
+using UI;
 
 namespace Dialogue
 {
@@ -68,7 +69,7 @@ namespace Dialogue
             rect.anchorMax = anchorMax;
             rect.offsetMin = rect.offsetMax = offset;
             var txt = go.GetComponent<Text>();
-            txt.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            LegacyFontProvider.ApplyTo(txt);
             txt.alignment = TextAnchor.UpperLeft;
             txt.horizontalOverflow = HorizontalWrapMode.Wrap;
             txt.verticalOverflow = VerticalWrapMode.Overflow;

--- a/Assets/Scripts/Inventory/Equipment.cs
+++ b/Assets/Scripts/Inventory/Equipment.cs
@@ -671,15 +671,7 @@ namespace Inventory
             slotItemImages = new Image[equipped.Length];
             slotCountTexts = new Text[equipped.Length];
 
-            Font defaultFont = null;
-            try
-            {
-                defaultFont = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
-            }
-            catch (ArgumentException)
-            {
-                defaultFont = null;
-            }
+            Font defaultFont = LegacyFontProvider.GetLegacyFont();
 
             for (int i = 0; i < 15; i++)
             {

--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -319,16 +319,7 @@ namespace Inventory
             size = Mathf.Max(1, size);
 
             if (defaultFont == null)
-            {
-                try
-                {
-                    defaultFont = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
-                }
-                catch (ArgumentException)
-                {
-                    defaultFont = null;
-                }
-            }
+                defaultFont = LegacyFontProvider.GetLegacyFont();
 
             if (stackCountFont == null)
             {

--- a/Assets/Scripts/Inventory/StackSplitDialog.cs
+++ b/Assets/Scripts/Inventory/StackSplitDialog.cs
@@ -1,6 +1,7 @@
 using System;
 using UnityEngine;
 using UnityEngine.UI;
+using UI;
 
 namespace Inventory
 {
@@ -67,7 +68,7 @@ namespace Inventory
             var textGO = new GameObject("Text", typeof(Text));
             textGO.transform.SetParent(fieldGO.transform, false);
             var text = textGO.GetComponent<Text>();
-            text.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            LegacyFontProvider.ApplyTo(text);
             text.alignment = TextAnchor.MiddleLeft;
             text.text = "1";
             text.color = Color.black;
@@ -107,7 +108,7 @@ namespace Inventory
             var txtGO = new GameObject("Text", typeof(Text));
             txtGO.transform.SetParent(btnGO.transform, false);
             var txt = txtGO.GetComponent<Text>();
-            txt.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            LegacyFontProvider.ApplyTo(txt);
             txt.alignment = TextAnchor.MiddleCenter;
             txt.color = Color.black;
             txt.text = label;

--- a/Assets/Scripts/NPC/Combat/NpcHealthHUD.cs
+++ b/Assets/Scripts/NPC/Combat/NpcHealthHUD.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using UnityEngine;
 using UnityEngine.UI;
+using UI;
 
 namespace NPC
 {
@@ -79,7 +80,7 @@ namespace NPC
             var textGO = new GameObject("Text", typeof(Text));
             textGO.transform.SetParent(bg.transform, false);
             text = textGO.GetComponent<Text>();
-            text.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            LegacyFontProvider.ApplyTo(text);
             text.alignment = TextAnchor.MiddleCenter;
             text.color = Color.white;
             text.fontSize = 11;

--- a/Assets/Scripts/Pets/PetLevelBarHUD.cs
+++ b/Assets/Scripts/Pets/PetLevelBarHUD.cs
@@ -3,6 +3,7 @@ using UnityEngine.UI;
 using UnityEngine.EventSystems;
 using System.Collections;
 using Player;
+using UI;
 
 namespace Pets
 {
@@ -82,7 +83,7 @@ namespace Pets
             var textGO = new GameObject("Text", typeof(Text));
             textGO.transform.SetParent(bgGO.transform, false);
             instance.text = textGO.GetComponent<Text>();
-            instance.text.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            LegacyFontProvider.ApplyTo(instance.text);
             instance.text.alignment = TextAnchor.MiddleCenter;
             instance.text.color = Color.white;
             instance.text.fontSize = 11;

--- a/Assets/Scripts/Pets/PetLevelBarMenu.cs
+++ b/Assets/Scripts/Pets/PetLevelBarMenu.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
+using UI;
 
 namespace Pets
 {
@@ -102,7 +103,7 @@ namespace Pets
             textGO.transform.SetParent(go.transform, false);
             var txt = textGO.GetComponent<Text>();
             txt.text = label;
-            txt.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            LegacyFontProvider.ApplyTo(txt);
             txt.alignment = TextAnchor.MiddleCenter;
             txt.color = Color.white;
             var rect = txt.rectTransform;

--- a/Assets/Scripts/Pets/PetToastUI.cs
+++ b/Assets/Scripts/Pets/PetToastUI.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using UnityEngine.UI;
 using World;
+using UI;
 
 namespace Pets
 {
@@ -66,7 +67,7 @@ namespace Pets
                 var textGO = new GameObject("Text", typeof(Text));
                 textGO.transform.SetParent(transform, false);
                 existing = textGO.GetComponent<Text>();
-                existing.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+                LegacyFontProvider.ApplyTo(existing);
                 existing.alignment = TextAnchor.UpperCenter;
 
                 var rect = existing.rectTransform;

--- a/Assets/Scripts/Player/HealthHUD.cs
+++ b/Assets/Scripts/Player/HealthHUD.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
+using UI;
 
 namespace Player
 {
@@ -66,7 +67,7 @@ namespace Player
             var textGO = new GameObject("Text", typeof(Text));
             textGO.transform.SetParent(bgGO.transform, false);
             hud.text = textGO.GetComponent<Text>();
-            hud.text.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            LegacyFontProvider.ApplyTo(hud.text);
             hud.text.alignment = TextAnchor.MiddleCenter;
             hud.text.color = Color.white;
             hud.text.fontSize = 11;

--- a/Assets/Scripts/Quests/QuestUI.cs
+++ b/Assets/Scripts/Quests/QuestUI.cs
@@ -196,7 +196,7 @@ namespace Quests
             rect.anchorMax = anchorMax;
             rect.offsetMin = rect.offsetMax = offset;
             var txt = go.GetComponent<Text>();
-            txt.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            LegacyFontProvider.ApplyTo(txt);
             txt.alignment = TextAnchor.UpperLeft;
             txt.horizontalOverflow = HorizontalWrapMode.Wrap;
             txt.verticalOverflow = VerticalWrapMode.Overflow;

--- a/Assets/Scripts/Shop/ShopUI.cs
+++ b/Assets/Scripts/Shop/ShopUI.cs
@@ -170,6 +170,8 @@ namespace ShopSystem
             uiRoot.transform.SetParent(null, false);
             DontDestroyOnLoad(uiRoot);
 
+            Font runtimeFont = priceFont != null ? priceFont : LegacyFontProvider.GetLegacyFont();
+
             var canvas = uiRoot.GetComponent<Canvas>();
             canvas.renderMode = RenderMode.ScreenSpaceOverlay;
             canvas.pixelPerfect = true;
@@ -207,7 +209,7 @@ namespace ShopSystem
             GameObject closeTextGO = new GameObject("Text", typeof(Text));
             closeTextGO.transform.SetParent(closeButtonGO.transform, false);
             var closeText = closeTextGO.GetComponent<Text>();
-            closeText.font = priceFont != null ? priceFont : Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            closeText.font = runtimeFont;
             closeText.text = "X";
             closeText.alignment = TextAnchor.MiddleCenter;
             closeText.color = Color.white;
@@ -260,7 +262,7 @@ namespace ShopSystem
                 GameObject priceGO = new GameObject("Price", typeof(Text));
                 priceGO.transform.SetParent(slot.transform, false);
                 var priceText = priceGO.GetComponent<Text>();
-                priceText.font = priceFont != null ? priceFont : Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+                priceText.font = runtimeFont;
                 priceText.alignment = TextAnchor.LowerLeft;
                 priceText.color = priceColor;
                 priceText.raycastTarget = false;
@@ -287,7 +289,7 @@ namespace ShopSystem
             GameObject nameGO = new GameObject("Name", typeof(Text));
             nameGO.transform.SetParent(window.transform, false);
             shopNameText = nameGO.GetComponent<Text>();
-            shopNameText.font = priceFont != null ? priceFont : Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            shopNameText.font = runtimeFont;
             shopNameText.color = priceColor;
             shopNameText.alignment = TextAnchor.MiddleLeft;
             shopNameText.text = string.Empty;
@@ -302,7 +304,7 @@ namespace ShopSystem
             GameObject tooltipGO = new GameObject("Tooltip", typeof(Text));
             tooltipGO.transform.SetParent(window.transform, false);
             tooltipText = tooltipGO.GetComponent<Text>();
-            tooltipText.font = priceFont != null ? priceFont : Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            tooltipText.font = runtimeFont;
             tooltipText.color = priceColor;
             tooltipText.alignment = TextAnchor.MiddleLeft;
             tooltipText.text = string.Empty;

--- a/Assets/Scripts/Skills/SkillsUI.cs
+++ b/Assets/Scripts/Skills/SkillsUI.cs
@@ -207,7 +207,7 @@ namespace Skills
             var levelGo = new GameObject("LevelText");
             levelGo.transform.SetParent(skillGo.transform, false);
             var levelText = levelGo.AddComponent<Text>();
-            levelText.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            LegacyFontProvider.ApplyTo(levelText);
             levelText.color = Color.white;
 
             var xpGo = new GameObject("XpText");
@@ -228,7 +228,7 @@ namespace Skills
             totalGo.transform.SetParent(parent, false);
 
             totalLevelText = totalGo.AddComponent<Text>();
-            totalLevelText.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            LegacyFontProvider.ApplyTo(totalLevelText);
             totalLevelText.color = Color.white;
         }
 

--- a/Assets/Scripts/UI/FloatingText.cs
+++ b/Assets/Scripts/UI/FloatingText.cs
@@ -45,7 +45,7 @@ namespace UI
             instance.uiText.alignment = TextAnchor.MiddleCenter;
             instance.uiText.horizontalOverflow = HorizontalWrapMode.Overflow;
             instance.uiText.verticalOverflow = VerticalWrapMode.Overflow;
-            instance.uiText.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            LegacyFontProvider.ApplyTo(instance.uiText);
             instance.rectTransform = background != null ? parentGO.GetComponent<RectTransform>() : textGO.GetComponent<RectTransform>();
             instance.mainCamera = Camera.main;
 

--- a/Assets/Scripts/UI/HUD/BuffInfoBox.cs
+++ b/Assets/Scripts/UI/HUD/BuffInfoBox.cs
@@ -114,7 +114,7 @@ namespace UI.HUD
             component.iconImage = iconImage;
             iconImage.color = Color.clear;
 
-            var legacyFont = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            var legacyFont = LegacyFontProvider.GetLegacyFont();
 
             var nameGO = new GameObject("Name", typeof(Text));
             nameGO.layer = parentLayer;
@@ -169,7 +169,7 @@ namespace UI.HUD
 
         private void Awake()
         {
-            var legacyFont = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            var legacyFont = LegacyFontProvider.GetLegacyFont();
             if (nameText != null && nameText.font == null)
                 nameText.font = legacyFont;
             if (timerText != null && timerText.font == null)

--- a/Assets/Scripts/UI/HUD/BuffTooltipController.cs
+++ b/Assets/Scripts/UI/HUD/BuffTooltipController.cs
@@ -185,7 +185,7 @@ namespace UI.HUD
             fitter.horizontalFit = ContentSizeFitter.FitMode.PreferredSize;
             fitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
 
-            var legacyFont = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            var legacyFont = LegacyFontProvider.GetLegacyFont();
 
             var titleGO = new GameObject("Title", typeof(Text));
             titleGO.transform.SetParent(transform, false);

--- a/Assets/Scripts/UI/LegacyFontProvider.cs
+++ b/Assets/Scripts/UI/LegacyFontProvider.cs
@@ -1,0 +1,117 @@
+using System;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace UI
+{
+    /// <summary>
+    /// Provides cached access to the LegacyRuntime.ttf font that powers the OSRS-inspired UI skin.
+    /// Falls back to Arial if Unity cannot locate the built-in legacy asset so text rendering never breaks.
+    /// The helper also exposes convenience methods for wiring the font to Text and TMP components.
+    /// </summary>
+    public static class LegacyFontProvider
+    {
+        private const string LegacyFontResourceName = "LegacyRuntime.ttf";
+        private const string ArialFallbackResourceName = "Arial.ttf";
+
+        private static Font cachedLegacyFont;
+        private static bool attemptedLegacyFontLoad;
+
+        private static TMP_FontAsset cachedTmpFontAsset;
+        private static bool attemptedTmpFontLoad;
+
+        /// <summary>
+        /// Retrieve the cached LegacyRuntime font or load it from Unity's built-in resources when needed.
+        /// A single shared instance is reused so that UI construction scripts avoid redundant resource lookups.
+        /// </summary>
+        public static Font GetLegacyFont()
+        {
+            if (!attemptedLegacyFontLoad || cachedLegacyFont == null)
+            {
+                attemptedLegacyFontLoad = true;
+                cachedLegacyFont = TryLoadBuiltinFont(LegacyFontResourceName) ?? TryLoadBuiltinFont(ArialFallbackResourceName);
+            }
+
+            return cachedLegacyFont;
+        }
+
+        /// <summary>
+        /// Retrieve a cached TextMeshPro font asset that mirrors the legacy font. The helper lazily builds a
+        /// font asset from the underlying <see cref="Font"/> and reuses it across requests. If TextMeshPro is
+        /// not configured it gracefully falls back to the default TMP font asset so text continues to render.
+        /// </summary>
+        public static TMP_FontAsset GetLegacyTmpFontAsset()
+        {
+            if (!attemptedTmpFontLoad || cachedTmpFontAsset == null)
+            {
+                attemptedTmpFontLoad = true;
+
+                var legacyFont = GetLegacyFont();
+                if (legacyFont != null)
+                {
+                    cachedTmpFontAsset = TMP_FontAsset.CreateFontAsset(legacyFont);
+                    if (cachedTmpFontAsset != null)
+                        cachedTmpFontAsset.name = "LegacyRuntimeTMP";
+                }
+
+                if (cachedTmpFontAsset == null)
+                    cachedTmpFontAsset = TMP_Settings.defaultFontAsset;
+            }
+
+            return cachedTmpFontAsset;
+        }
+
+        /// <summary>
+        /// Assign the legacy font to a standard Unity <see cref="Text"/> component.
+        /// </summary>
+        /// <param name="uiText">Target component.</param>
+        /// <param name="overwriteExistingFont">When false the assignment is skipped if the component already exposes a font.</param>
+        /// <returns>True when a font was applied to the target.</returns>
+        public static bool ApplyTo(Text uiText, bool overwriteExistingFont = true)
+        {
+            if (uiText == null)
+                return false;
+
+            if (!overwriteExistingFont && uiText.font != null)
+                return false;
+
+            uiText.font = GetLegacyFont();
+            return uiText.font != null;
+        }
+
+        /// <summary>
+        /// Assign the legacy font to a <see cref="TMP_Text"/> component while respecting the overwrite flag.
+        /// </summary>
+        /// <param name="tmpText">Target TextMeshPro component.</param>
+        /// <param name="overwriteExistingFont">When false the helper will not replace an already-assigned asset.</param>
+        /// <returns>True when a font asset was assigned.</returns>
+        public static bool ApplyTo(TMP_Text tmpText, bool overwriteExistingFont = true)
+        {
+            if (tmpText == null)
+                return false;
+
+            if (!overwriteExistingFont && tmpText.font != null)
+                return false;
+
+            tmpText.font = GetLegacyTmpFontAsset();
+            return tmpText.font != null;
+        }
+
+        /// <summary>
+        /// Safely request a built-in font from Unity, catching the ArgumentException that is thrown when the
+        /// engine cannot locate the resource. Returning null allows the caller to choose a graceful fallback.
+        /// </summary>
+        private static Font TryLoadBuiltinFont(string resourceName)
+        {
+            try
+            {
+                return Resources.GetBuiltinResource<Font>(resourceName);
+            }
+            catch (ArgumentException)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/UI/Login/LoginScreenController.cs
+++ b/Assets/Scripts/UI/Login/LoginScreenController.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
+using UI;
 #if ENABLE_INPUT_SYSTEM
 using UnityEngine.InputSystem;
 #endif
@@ -76,21 +77,31 @@ namespace UI.Login
         private string gameplaySceneName = "OverWorld";
 
         private Coroutine loadRoutine;
-        private Font legacyFont;
         private GameObject lastSelectedInputField;
 
         private void Awake()
         {
-            legacyFont = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
             EnsureUiHierarchy();
 
-            ApplyLegacyFont(usernameField);
-            ApplyLegacyFont(passwordField);
-            ApplyLegacyFont(statusText);
+            if (usernameField != null)
+            {
+                LegacyFontProvider.ApplyTo(usernameField.textComponent);
+                if (usernameField.placeholder is Text usernamePlaceholder)
+                    LegacyFontProvider.ApplyTo(usernamePlaceholder);
+            }
+
+            if (passwordField != null)
+            {
+                LegacyFontProvider.ApplyTo(passwordField.textComponent);
+                if (passwordField.placeholder is Text passwordPlaceholder)
+                    LegacyFontProvider.ApplyTo(passwordPlaceholder);
+            }
+
+            LegacyFontProvider.ApplyTo(statusText);
             if (loginButton != null)
             {
                 var buttonLabel = loginButton.GetComponentInChildren<Text>();
-                ApplyLegacyFont(buttonLabel);
+                LegacyFontProvider.ApplyTo(buttonLabel);
             }
         }
 
@@ -299,13 +310,13 @@ namespace UI.Login
             int statusFontSize = Mathf.Clamp(Mathf.RoundToInt(statusSize.y * 0.28f), 18, 24);
             statusText = CreateText(panelRect, "StatusText", string.Empty, new Vector2(0.5f, 0.5f), new Vector2(0.5f, 0.5f), new Vector2(0.5f, 0.5f),
                 StatusTextAnchoredPosition, statusSize, statusFontSize, TextAnchor.MiddleCenter, FontStyle.Normal);
-            ApplyLegacyFont(statusText);
+            LegacyFontProvider.ApplyTo(statusText);
 
             Vector2 buttonPosition = CalculateAnchoredPosition(LoginButtonNormalizedCenter, panelSize);
             Vector2 buttonSize = CalculateSize(LoginButtonNormalizedSize, panelSize);
             loginButton = CreateButton(panelRect, "LoginButton", new Vector2(0.5f, 0.5f), new Vector2(0.5f, 0.5f), new Vector2(0.5f, 0.5f),
                 buttonPosition, buttonSize, buttonSprite, "Login");
-            ApplyLegacyFont(loginButton.GetComponentInChildren<Text>());
+            LegacyFontProvider.ApplyTo(loginButton.GetComponentInChildren<Text>());
         }
 
         /// <summary>
@@ -427,26 +438,6 @@ namespace UI.Login
             HandleLoginClicked();
         }
 
-        private void ApplyLegacyFont(InputField field)
-        {
-            if (field == null || legacyFont == null)
-                return;
-
-            if (field.textComponent != null)
-                field.textComponent.font = legacyFont;
-
-            if (field.placeholder is Text placeholderText)
-                placeholderText.font = legacyFont;
-        }
-
-        private void ApplyLegacyFont(Text text)
-        {
-            if (text == null || legacyFont == null)
-                return;
-
-            text.font = legacyFont;
-        }
-
         private void SetStatus(string message, Color colour)
         {
             if (statusText == null)
@@ -481,6 +472,7 @@ namespace UI.Login
             text.color = new Color32(212, 212, 212, 255);
             text.supportRichText = false;
             text.raycastTarget = false;
+            LegacyFontProvider.ApplyTo(text);
             return text;
         }
 
@@ -632,6 +624,7 @@ namespace UI.Login
             text.verticalOverflow = VerticalWrapMode.Truncate;
             text.color = new Color32(238, 225, 171, 255);
             text.raycastTarget = false;
+            LegacyFontProvider.ApplyTo(text);
 
             var placeholderRect = CreateRectTransform("Placeholder", rect, Vector2.zero, Vector2.one, new Vector2(0.5f, 0.5f), Vector2.zero, Vector2.zero);
             placeholderRect.offsetMin = new Vector2(24f, 14f);
@@ -645,6 +638,7 @@ namespace UI.Login
             placeholder.color = new Color32(150, 150, 150, 255);
             placeholder.supportRichText = false;
             placeholder.raycastTarget = false;
+            LegacyFontProvider.ApplyTo(placeholder);
 
             field.textComponent = text;
             field.placeholder = placeholder;
@@ -675,7 +669,6 @@ namespace UI.Login
 
             int fontSize = Mathf.Clamp(Mathf.RoundToInt(sizeDelta.y * 0.45f), 20, 30);
             var text = CreateText(rect, "Text", label, new Vector2(0f, 0f), new Vector2(1f, 1f), new Vector2(0.5f, 0.5f), Vector2.zero, Vector2.zero, fontSize, TextAnchor.MiddleCenter, FontStyle.Bold);
-            ApplyLegacyFont(text);
             text.color = new Color32(46, 32, 20, 255);
 
             return button;

--- a/Assets/Scripts/UI/MergeHudTimer.cs
+++ b/Assets/Scripts/UI/MergeHudTimer.cs
@@ -96,7 +96,7 @@ namespace UI
         private void ApplyFont()
         {
             var customFont = font ?? Resources.Load<Font>("ThaleahFAT_TTF") ?? Resources.Load<Font>("ThaleahFat_TTF");
-            text.font = customFont != null ? customFont : Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            text.font = customFont != null ? customFont : LegacyFontProvider.GetLegacyFont();
         }
 
         public void Show(TimeSpan remaining)

--- a/Assets/Scripts/UI/Settings/AudioSettingsUI.cs
+++ b/Assets/Scripts/UI/Settings/AudioSettingsUI.cs
@@ -1,4 +1,3 @@
-using System;
 using Audio;
 using UnityEngine;
 using UnityEngine.UI;
@@ -97,7 +96,7 @@ namespace UI.Settings
             if (!PersistentSceneSingleton<AudioSettingsUI>.HandleAwake(this))
                 return;
 
-            legacyFont = LoadLegacyFont();
+            legacyFont = LegacyFontProvider.GetLegacyFont();
             if (canvas == null || windowRoot == null || volumeSlider == null || muteToggle == null)
                 BuildUi();
 
@@ -558,19 +557,5 @@ namespace UI.Settings
             muteToggle = toggle;
         }
 
-        /// <summary>
-        /// Retrieve the default LegacyRuntime font while falling back gracefully if Unity cannot find it.
-        /// </summary>
-        private Font LoadLegacyFont()
-        {
-            try
-            {
-                return Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
-            }
-            catch (ArgumentException)
-            {
-                return Resources.GetBuiltinResource<Font>("Arial.ttf");
-            }
-        }
     }
 }


### PR DESCRIPTION
## Summary
- add a reusable LegacyFontProvider that caches LegacyRuntime.ttf with an Arial fallback and TMP support
- refactor UI scripts to request fonts through the provider instead of ad-hoc Resources calls
- remove redundant font loading helpers so bank, inventory, shop, login, audio settings, and other HUDs share the same cached font

## Testing
- not run (Unity editor required)


------
https://chatgpt.com/codex/tasks/task_e_68cf2013be2c832ea86c9eba88d52219