### PR TITLE
Retry skill lookup in gathering HUDs

### DIFF
--- a/Assets/Scripts/Skills/Fishing/UI/FishingHUD.cs
+++ b/Assets/Scripts/Skills/Fishing/UI/FishingHUD.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using Inventory;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -36,6 +37,10 @@ namespace Skills.Fishing
         private float segmentDuration = Ticker.TickDuration;
         // Keeps track of whether the bar should reset after being displayed at full progress for one tick.
         private bool awaitingResetTick;
+        // Coroutine used to poll for the fishing skill when the player spawns after the HUD has already initialised.
+        private Coroutine skillRefreshRoutine;
+        // Delay between retry attempts so we do not run FindObjectOfType every frame while waiting for the skill to exist.
+        private static readonly WaitForSecondsRealtime skillRetryDelay = new WaitForSecondsRealtime(0.5f);
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         private static void Bootstrap()
@@ -147,6 +152,7 @@ namespace Skills.Fishing
 
             HandleStop();
             DetachFromSkill();
+            CancelSkillRefreshRoutine();
         }
 
         private void EnsureProgressObjects()
@@ -280,15 +286,24 @@ namespace Skills.Fishing
         {
             var current = FindObjectOfType<FishingSkill>();
             if (current == skill)
+            {
+                if (current == null)
+                    EnsureSkillRefreshRoutine();
                 return;
+            }
 
             DetachFromSkill();
-            skill = current;
-            if (skill != null)
+
+            if (current == null)
             {
-                skill.OnStartFishing += HandleStart;
-                skill.OnStopFishing += HandleStop;
+                EnsureSkillRefreshRoutine();
+                return;
             }
+
+            CancelSkillRefreshRoutine();
+            skill = current;
+            skill.OnStartFishing += HandleStart;
+            skill.OnStopFishing += HandleStop;
         }
 
         private void DetachFromSkill()
@@ -297,13 +312,20 @@ namespace Skills.Fishing
             {
                 skill.OnStartFishing -= HandleStart;
                 skill.OnStopFishing -= HandleStop;
-                skill = null;
             }
+
+            skill = null;
         }
 
         private void Update()
         {
-            if (target == null || progressImage == null || skill == null)
+            if (skill == null)
+            {
+                EnsureSkillRefreshRoutine();
+                return;
+            }
+
+            if (target == null || progressImage == null)
                 return;
 
             progressRoot.transform.position = target.position + offset;
@@ -420,6 +442,7 @@ namespace Skills.Fishing
 
                 HandleStop();
                 DetachFromSkill();
+                CancelSkillRefreshRoutine();
 
                 if (Ticker.Instance != null)
                     Ticker.Instance.Unsubscribe(this);
@@ -460,6 +483,54 @@ namespace Skills.Fishing
 
             float remaining = Ticker.Instance.TimeUntilNextTick;
             return remaining > 0f ? remaining : Ticker.TickDuration;
+        }
+
+        /// <summary>
+        /// Starts a coroutine that periodically attempts to locate the fishing skill while the player object is still spawning.
+        /// </summary>
+        private void EnsureSkillRefreshRoutine()
+        {
+            if (!isActiveAndEnabled)
+                return;
+
+            if (skillRefreshRoutine != null)
+                return;
+
+            skillRefreshRoutine = StartCoroutine(AwaitSkillRoutine());
+        }
+
+        /// <summary>
+        /// Stops the retry coroutine if it is still running so the HUD does not leak when disabled or destroyed.
+        /// </summary>
+        private void CancelSkillRefreshRoutine()
+        {
+            if (skillRefreshRoutine == null)
+                return;
+
+            StopCoroutine(skillRefreshRoutine);
+            skillRefreshRoutine = null;
+        }
+
+        /// <summary>
+        /// Polls periodically for a <see cref="FishingSkill"/> instance and binds once it becomes available.
+        /// </summary>
+        private IEnumerator AwaitSkillRoutine()
+        {
+            while (isActiveAndEnabled)
+            {
+                var current = FindObjectOfType<FishingSkill>();
+                if (current != null)
+                {
+                    skill = current;
+                    skill.OnStartFishing += HandleStart;
+                    skill.OnStopFishing += HandleStop;
+                    break;
+                }
+
+                yield return skillRetryDelay;
+            }
+
+            skillRefreshRoutine = null;
         }
     }
 }

--- a/Assets/Scripts/Skills/Mining/UI/MiningUI.cs
+++ b/Assets/Scripts/Skills/Mining/UI/MiningUI.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using Inventory;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -41,6 +42,10 @@ namespace Skills.Mining
         private float segmentDuration = Ticker.TickDuration;
         // Tracks whether the bar should be reset after spending one full tick at 100%.
         private bool awaitingResetTick;
+        // Coroutine reference that polls for a mining skill when the player object spawns after the HUD has initialised.
+        private Coroutine skillRefreshRoutine;
+        // Delay used between retries so we only probe for the skill a few times per second instead of every frame.
+        private static readonly WaitForSecondsRealtime skillRetryDelay = new WaitForSecondsRealtime(0.5f);
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         private static void Bootstrap()
@@ -152,6 +157,7 @@ namespace Skills.Mining
 
             HandleStop();
             DetachFromSkill();
+            CancelSkillRefreshRoutine();
         }
 
         private void EnsureProgressObjects()
@@ -282,15 +288,24 @@ namespace Skills.Mining
         {
             var current = FindObjectOfType<MiningSkill>();
             if (current == skill)
+            {
+                if (current == null)
+                    EnsureSkillRefreshRoutine();
                 return;
+            }
 
             DetachFromSkill();
-            skill = current;
-            if (skill != null)
+
+            if (current == null)
             {
-                skill.OnStartMining += HandleStart;
-                skill.OnStopMining += HandleStop;
+                EnsureSkillRefreshRoutine();
+                return;
             }
+
+            CancelSkillRefreshRoutine();
+            skill = current;
+            skill.OnStartMining += HandleStart;
+            skill.OnStopMining += HandleStop;
         }
 
         private void DetachFromSkill()
@@ -299,13 +314,20 @@ namespace Skills.Mining
             {
                 skill.OnStartMining -= HandleStart;
                 skill.OnStopMining -= HandleStop;
-                skill = null;
             }
+
+            skill = null;
         }
 
         private void Update()
         {
-            if (target == null || progressImage == null || skill == null)
+            if (skill == null)
+            {
+                EnsureSkillRefreshRoutine();
+                return;
+            }
+
+            if (target == null || progressImage == null)
                 return;
 
             progressRoot.transform.position = target.position + offset;
@@ -422,6 +444,7 @@ namespace Skills.Mining
 
                 HandleStop();
                 DetachFromSkill();
+                CancelSkillRefreshRoutine();
 
                 if (Ticker.Instance != null)
                     Ticker.Instance.Unsubscribe(this);
@@ -462,6 +485,54 @@ namespace Skills.Mining
 
             float remaining = Ticker.Instance.TimeUntilNextTick;
             return remaining > 0f ? remaining : Ticker.TickDuration;
+        }
+
+        /// <summary>
+        /// Starts a coroutine that repeatedly attempts to locate the mining skill for late-spawned players.
+        /// </summary>
+        private void EnsureSkillRefreshRoutine()
+        {
+            if (!isActiveAndEnabled)
+                return;
+
+            if (skillRefreshRoutine != null)
+                return;
+
+            skillRefreshRoutine = StartCoroutine(AwaitSkillRoutine());
+        }
+
+        /// <summary>
+        /// Stops the retry coroutine so the HUD cleans up correctly when disabled or destroyed.
+        /// </summary>
+        private void CancelSkillRefreshRoutine()
+        {
+            if (skillRefreshRoutine == null)
+                return;
+
+            StopCoroutine(skillRefreshRoutine);
+            skillRefreshRoutine = null;
+        }
+
+        /// <summary>
+        /// Polls at intervals until a <see cref="MiningSkill"/> exists and then binds to its events.
+        /// </summary>
+        private IEnumerator AwaitSkillRoutine()
+        {
+            while (isActiveAndEnabled)
+            {
+                var current = FindObjectOfType<MiningSkill>();
+                if (current != null)
+                {
+                    skill = current;
+                    skill.OnStartMining += HandleStart;
+                    skill.OnStopMining += HandleStop;
+                    break;
+                }
+
+                yield return skillRetryDelay;
+            }
+
+            skillRefreshRoutine = null;
         }
     }
 }

--- a/Assets/Scripts/Skills/Woodcutting/UI/WoodcuttingHUD.cs
+++ b/Assets/Scripts/Skills/Woodcutting/UI/WoodcuttingHUD.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using Inventory;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -39,6 +40,10 @@ namespace Skills.Woodcutting
         private float segmentDuration = Ticker.TickDuration;
         // Flag used so we can hold the progress bar at 100% for a full tick before resetting back to 0.
         private bool awaitingResetTick;
+        // Coroutine reference used to poll for a late-spawned woodcutting skill so we can rebind automatically.
+        private Coroutine skillRefreshRoutine;
+        // Delay between successive retries when no skill is present in the scene yet.
+        private static readonly WaitForSecondsRealtime skillRetryDelay = new WaitForSecondsRealtime(0.5f);
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         private static void Bootstrap()
@@ -150,6 +155,7 @@ namespace Skills.Woodcutting
 
             HandleStop();
             DetachFromSkill();
+            CancelSkillRefreshRoutine();
         }
 
         private void EnsureProgressObjects()
@@ -283,15 +289,24 @@ namespace Skills.Woodcutting
         {
             var current = FindObjectOfType<WoodcuttingSkill>();
             if (current == skill)
+            {
+                if (current == null)
+                    EnsureSkillRefreshRoutine();
                 return;
+            }
 
             DetachFromSkill();
-            skill = current;
-            if (skill != null)
+
+            if (current == null)
             {
-                skill.OnStartChopping += HandleStart;
-                skill.OnStopChopping += HandleStop;
+                EnsureSkillRefreshRoutine();
+                return;
             }
+
+            CancelSkillRefreshRoutine();
+            skill = current;
+            skill.OnStartChopping += HandleStart;
+            skill.OnStopChopping += HandleStop;
         }
 
         private void DetachFromSkill()
@@ -300,13 +315,20 @@ namespace Skills.Woodcutting
             {
                 skill.OnStartChopping -= HandleStart;
                 skill.OnStopChopping -= HandleStop;
-                skill = null;
             }
+
+            skill = null;
         }
 
         private void Update()
         {
-            if (target == null || progressImage == null || skill == null)
+            if (skill == null)
+            {
+                EnsureSkillRefreshRoutine();
+                return;
+            }
+
+            if (target == null || progressImage == null)
                 return;
 
             progressRoot.transform.position = target.position + offset;
@@ -425,6 +447,7 @@ namespace Skills.Woodcutting
 
                 HandleStop();
                 DetachFromSkill();
+                CancelSkillRefreshRoutine();
 
                 if (Ticker.Instance != null)
                     Ticker.Instance.Unsubscribe(this);
@@ -465,6 +488,54 @@ namespace Skills.Woodcutting
 
             float remaining = Ticker.Instance.TimeUntilNextTick;
             return remaining > 0f ? remaining : Ticker.TickDuration;
+        }
+
+        /// <summary>
+        /// Ensures a coroutine is running to continually search for the woodcutting skill when it is not yet spawned.
+        /// </summary>
+        private void EnsureSkillRefreshRoutine()
+        {
+            if (!isActiveAndEnabled)
+                return;
+
+            if (skillRefreshRoutine != null)
+                return;
+
+            skillRefreshRoutine = StartCoroutine(AwaitSkillRoutine());
+        }
+
+        /// <summary>
+        /// Stops the retry coroutine to avoid leaking references when the HUD is disabled or destroyed.
+        /// </summary>
+        private void CancelSkillRefreshRoutine()
+        {
+            if (skillRefreshRoutine == null)
+                return;
+
+            StopCoroutine(skillRefreshRoutine);
+            skillRefreshRoutine = null;
+        }
+
+        /// <summary>
+        /// Polls the scene at intervals until a <see cref="WoodcuttingSkill"/> is available, then hooks into its events.
+        /// </summary>
+        private IEnumerator AwaitSkillRoutine()
+        {
+            while (isActiveAndEnabled)
+            {
+                var current = FindObjectOfType<WoodcuttingSkill>();
+                if (current != null)
+                {
+                    skill = current;
+                    skill.OnStartChopping += HandleStart;
+                    skill.OnStopChopping += HandleStop;
+                    break;
+                }
+
+                yield return skillRetryDelay;
+            }
+
+            skillRefreshRoutine = null;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add coroutine-driven retry loops in the fishing, woodcutting, and mining HUDs to reacquire their skills when player objects spawn late
- cancel the retry routines once a skill is found and on disable/destroy to avoid leaks, while keeping the existing event hookups intact

## Testing
- not run (project uses Unity editor for playmode validation)

------
https://chatgpt.com/codex/tasks/task_e_68cfbe44c104832e9441714730341fb6