### PR TITLE
Ensure pet inventories use dedicated canvases

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -370,6 +370,65 @@ namespace Inventory
                 equipment = GetComponent<Equipment>();
         }
 
+        /// <summary>
+        /// Rebuilds the inventory UI on a dedicated canvas when shared canvas usage is disabled.
+        /// </summary>
+        public void ForceDedicatedUiRoot()
+        {
+            // Bail out immediately if this inventory still expects to use the shared canvas.
+            if (useSharedUIRoot)
+                return;
+
+            // Ensure backing arrays/fonts are prepared before we touch the UI.
+            EnsureInitialized();
+
+            bool shouldRebuild = uiRoot == null || (sharedUIRoot != null && ReferenceEquals(uiRoot, sharedUIRoot));
+            if (!shouldRebuild)
+            {
+                // We already own a dedicated canvas—just make sure slot visuals stay in sync.
+                if (items != null)
+                {
+                    for (int i = 0; i < items.Length; i++)
+                        UpdateSlotVisual(i);
+                }
+                return;
+            }
+
+            // Remember whether the UI was visible so we can restore the state after rebuilding.
+            bool wasOpen = uiRoot != null && uiRoot.activeSelf;
+
+            // Clean up any lingering UI state that pointed at the shared root.
+            HideDropMenu();
+            HideTooltip();
+
+            uiRoot = null;
+            dropMenu = null;
+            tooltip = null;
+            tooltipNameText = null;
+            tooltipDescriptionText = null;
+            slotImages = null;
+            slotCountTexts = null;
+            slotHighlights = null;
+
+            // Build a fresh dedicated canvas hierarchy for this inventory instance.
+            CreateUI();
+
+            if (uiRoot != null)
+            {
+                // Restore the previous visibility state and make sure runtime helpers are rebound.
+                uiRoot.SetActive(wasOpen);
+                if (dropMenu == null)
+                    dropMenu = uiRoot.GetComponentInChildren<InventoryDropMenu>(true);
+            }
+
+            // Update every slot so the newly created UI matches the saved inventory contents.
+            if (items != null)
+            {
+                for (int i = 0; i < items.Length; i++)
+                    UpdateSlotVisual(i);
+            }
+        }
+
         private void Start()
         {
             EnsureInitialized();

--- a/Assets/Scripts/Pets/PetStorage.cs
+++ b/Assets/Scripts/Pets/PetStorage.cs
@@ -66,14 +66,12 @@ namespace Pets
         private void CreateInventory()
         {
             inventory = gameObject.AddComponent<Inventory.Inventory>();
-            inventory.useSharedUIRoot = false;
             inventory.columns = 4;
             inventory.showCloseButton = false;
             inventory.emptySlotColor = Color.clear;
             inventory.centerOnScreen = true;
             inventory.size = GetSlotsForLevel(experience != null ? experience.Level : 1);
             inventory.saveKey = $"PetInv_{definition?.id}";
-            inventory.OnInventoryChanged += inventory.Save;
 
             // Match the look and feel of the player's inventory so tooltips use the same fonts
             var playerInv = GameObject.FindGameObjectWithTag("Player")?.GetComponent<Inventory.Inventory>();
@@ -98,6 +96,10 @@ namespace Pets
                     }
                 }
             }
+
+            inventory.useSharedUIRoot = false;
+            inventory.ForceDedicatedUiRoot();
+            inventory.OnInventoryChanged += inventory.Save;
         }
 
         private void HandleLevelChanged(int lvl)


### PR DESCRIPTION
## Summary
- add an Inventory.ForceDedicatedUiRoot helper that rebuilds a dedicated canvas when a shared root is still referenced
- update pet storage inventory setup to configure styling and force a dedicated UI root when the inventory component is created

## Testing
- Not Run (Unity editor required)


------
https://chatgpt.com/codex/tasks/task_e_68cfca386dbc832eb3ab6ba9b5fcf213