### PR TITLE
Release saved scene handoff flags after direct load restore

### DIFF
--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -630,8 +630,17 @@ namespace Player
             var data = SaveManager.Load<PositionData>(PositionKey);
             if (data != null && scene.name == data.scene)
             {
-                if (ApplySavedPosition())
+                bool appliedSavedPosition = ApplySavedPosition();
+                if (appliedSavedPosition)
+                {
                     resolvedActiveScenePosition = true;
+
+                    // Clear the deferred load flags once the saved position has been restored so the
+                    // follow-up OnAfterSceneLoad pass can resume normal persistence handling.
+                    awaitingSavedSceneLoad = false;
+                    pendingSavedSceneName = null;
+                }
+
                 if (petToMove != null)
                 {
                     petToMove.transform.position = transform.position;
@@ -640,6 +649,13 @@ namespace Player
                         follower.SetPlayer(transform);
                     SceneManager.MoveGameObjectToScene(petToMove, scene);
                     petToMove = null;
+                }
+
+                if (appliedSavedPosition)
+                {
+                    // The saved-scene handoff has finished so this handler can be removed immediately.
+                    SceneManager.sceneLoaded -= OnSceneLoaded;
+                    return;
                 }
             }
 


### PR DESCRIPTION
## Summary
- clear the saved-scene handoff flags once PlayerMover reapplies a saved position during direct SceneManager loads
- ensure the scene-loaded handler unsubscribes immediately after completing the saved position restore so persistence can resume cleanly

## Testing
- Not run (Unity editor required)

------
https://chatgpt.com/codex/tasks/task_e_68d00ad40b9c832e81b7406134ffaf97