### PR TITLE
Improve login resume flow and expose saved snapshot

### DIFF
--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -103,6 +103,24 @@ namespace Player
         // Ensure only one player persists across scene loads.
         private static PlayerMover instance;
 
+        /// <summary>
+        /// Provides global access to the active <see cref="PlayerMover"/> instance so external
+        /// systems can reposition the player without hunting through the scene hierarchy.
+        /// </summary>
+        public static PlayerMover Instance => instance;
+
+        /// <summary>
+        /// Tracks whether the login flow is orchestrating a resume so automatic saves are deferred
+        /// until the player has been placed at the desired coordinates.
+        /// </summary>
+        private static bool loginResumeActive;
+
+        /// <summary>
+        /// Snapshot captured during the login-driven resume sequence. This allows the mover to
+        /// expose the planned spawn data to other systems while saves are deferred.
+        /// </summary>
+        private static PlayerPositionSnapshot loginResumeSnapshot = PlayerPositionSnapshot.Empty;
+
         [Serializable]
         private class PositionData
         {
@@ -110,6 +128,49 @@ namespace Player
             public float y;
             public float z;
             public string scene;
+        }
+
+        /// <summary>
+        /// Data carrier that exposes the last persisted player scene and coordinates so callers can
+        /// query the save system without instantiating a mover.
+        /// </summary>
+        public readonly struct PlayerPositionSnapshot
+        {
+            /// <summary>
+            /// Name of the scene that owns the stored coordinates.
+            /// </summary>
+            public string SceneName { get; }
+
+            /// <summary>
+            /// World position the player occupied when the snapshot was taken.
+            /// </summary>
+            public Vector3 Position { get; }
+
+            /// <summary>
+            /// Indicates whether the snapshot originated from a valid save entry.
+            /// </summary>
+            public bool HasValidData { get; }
+
+            private PlayerPositionSnapshot(string sceneName, Vector3 position, bool hasValidData)
+            {
+                SceneName = string.IsNullOrEmpty(sceneName) ? string.Empty : sceneName;
+                Position = position;
+                HasValidData = hasValidData && !string.IsNullOrEmpty(SceneName);
+            }
+
+            /// <summary>
+            /// Returns an empty snapshot used when no persisted data exists for the active profile.
+            /// </summary>
+            public static PlayerPositionSnapshot Empty => new PlayerPositionSnapshot(string.Empty, Vector3.zero, false);
+
+            /// <summary>
+            /// Creates a snapshot pointing at the supplied scene and position. The caller controls
+            /// whether the payload should be considered a fully valid save entry.
+            /// </summary>
+            public static PlayerPositionSnapshot Create(string sceneName, Vector3 position, bool hasValidData)
+            {
+                return new PlayerPositionSnapshot(sceneName, position, hasValidData);
+            }
         }
 
         private const string PositionKey = "PlayerPosition";
@@ -132,6 +193,58 @@ namespace Player
         ///     Gathering controllers use this to determine if an automatically initiated walk is still in progress.
         /// </summary>
         public bool IsAutoMoving => isAutoMoving;
+
+        /// <summary>
+        /// Attempts to resolve the last persisted position payload without instantiating a mover.
+        /// </summary>
+        /// <param name="snapshot">Outputs the stored scene and coordinates when available.</param>
+        /// <returns>True when a saved snapshot exists for the active profile.</returns>
+        public static bool TryGetLastSavedSnapshot(out PlayerPositionSnapshot snapshot)
+        {
+            var data = SaveManager.Load<PositionData>(PositionKey);
+            if (data == null || string.IsNullOrEmpty(data.scene))
+            {
+                snapshot = PlayerPositionSnapshot.Empty;
+                return false;
+            }
+
+            snapshot = PlayerPositionSnapshot.Create(
+                data.scene,
+                new Vector3(data.x, data.y, data.z),
+                hasValidData: true);
+            return true;
+        }
+
+        /// <summary>
+        /// Flags that the login flow is about to resume a gameplay scene so automatic saves are
+        /// paused until the external placement logic completes.
+        /// </summary>
+        /// <param name="snapshot">Snapshot describing the desired resume location.</param>
+        public static void BeginLoginResume(PlayerPositionSnapshot snapshot)
+        {
+            loginResumeSnapshot = snapshot;
+            loginResumeActive = true;
+        }
+
+        /// <summary>
+        /// Clears the login resume guard so autosaves and movement persistence resume as normal.
+        /// </summary>
+        public static void CompleteLoginResume()
+        {
+            loginResumeSnapshot = PlayerPositionSnapshot.Empty;
+            loginResumeActive = false;
+        }
+
+        /// <summary>
+        /// Returns the snapshot currently being honoured by the login resume process.
+        /// </summary>
+        public static PlayerPositionSnapshot CurrentLoginResumeSnapshot => loginResumeSnapshot;
+
+        /// <summary>
+        /// Indicates whether the mover should defer automatic save writes while an external login
+        /// workflow positions the player.
+        /// </summary>
+        public static bool IsLoginResumeActive => loginResumeActive;
 
 #if ENABLE_INPUT_SYSTEM
         private InputAction moveAction;
@@ -535,9 +648,12 @@ namespace Player
         /// Optional scene identifier to store alongside the position. When null the
         /// active scene reported by <see cref="SceneManager"/> is used instead.
         /// </param>
-        public void SavePosition(string sceneNameOverride = null)
+        public void SavePosition(string sceneNameOverride = null, bool allowDuringLoginResume = false)
         {
             if (!resolvedActiveScenePosition)
+                return;
+
+            if (loginResumeActive && !allowDuringLoginResume)
                 return;
 
             Vector3 pos = transform.position;

--- a/Assets/Scripts/UI/Login/LoginScreenController.cs
+++ b/Assets/Scripts/UI/Login/LoginScreenController.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using Core.Save;
+using Player;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.SceneManagement;
@@ -78,6 +79,9 @@ namespace UI.Login
 
         private Coroutine loadRoutine;
         private GameObject lastSelectedInputField;
+        private bool loginResumeRequested;
+
+        private const float PlayerSpawnTimeout = 5f;
 
         private void Awake()
         {
@@ -136,6 +140,12 @@ namespace UI.Login
                 passwordField.onValueChanged.RemoveListener(HandleInputChanged);
 
             lastSelectedInputField = null;
+
+            if (loginResumeRequested)
+            {
+                PlayerMover.CompleteLoginResume();
+                loginResumeRequested = false;
+            }
         }
 
         private void Update()
@@ -201,27 +211,91 @@ namespace UI.Login
             SetStatus(activationMessage, successColour);
             SaveManager.LoadAll();
 
+            bool hasSnapshot = PlayerMover.TryGetLastSavedSnapshot(out var savedSnapshot);
+            string sceneToLoad = hasSnapshot && !string.IsNullOrEmpty(savedSnapshot.SceneName)
+                ? savedSnapshot.SceneName
+                : gameplaySceneName;
+
+            if (string.IsNullOrEmpty(sceneToLoad))
+                sceneToLoad = gameplaySceneName;
+
+            Vector3 spawnPosition = hasSnapshot ? savedSnapshot.Position : Vector3.zero;
+            var loginSnapshot = hasSnapshot
+                ? savedSnapshot
+                : PlayerMover.PlayerPositionSnapshot.Create(sceneToLoad, spawnPosition, hasValidData: false);
+
+            PlayerMover.BeginLoginResume(loginSnapshot);
+            loginResumeRequested = true;
+
             if (loadRoutine != null)
                 StopCoroutine(loadRoutine);
-            loadRoutine = StartCoroutine(LoadGameplayScene());
+            loadRoutine = StartCoroutine(LoadGameplayScene(sceneToLoad, spawnPosition, hasSnapshot));
         }
 
-        private IEnumerator LoadGameplayScene()
+        private IEnumerator LoadGameplayScene(string sceneToLoad, Vector3 spawnPosition, bool resumingFromSnapshot)
         {
-            SetStatus("Loading world...", infoColour);
+            SetStatus(resumingFromSnapshot ? "Restoring last location..." : "Preparing the overworld...", infoColour);
 
-            var operation = SceneManager.LoadSceneAsync(gameplaySceneName, LoadSceneMode.Single);
+            var operation = SceneManager.LoadSceneAsync(sceneToLoad, LoadSceneMode.Single);
             if (operation == null)
             {
-                SetStatus("Failed to load the overworld scene.", errorColour);
+                SetStatus($"Failed to load scene '{sceneToLoad}'.", errorColour);
                 if (loginButton != null)
                     loginButton.interactable = true;
+                if (loginResumeRequested)
+                {
+                    PlayerMover.CompleteLoginResume();
+                    loginResumeRequested = false;
+                }
+                loadRoutine = null;
                 yield break;
             }
 
             operation.allowSceneActivation = true;
             while (!operation.isDone)
                 yield return null;
+
+            float elapsed = 0f;
+            PlayerMover mover = PlayerMover.Instance;
+            while (mover == null && elapsed < PlayerSpawnTimeout)
+            {
+                mover = PlayerMover.Instance;
+                if (mover != null)
+                    break;
+
+                mover = FindObjectOfType<PlayerMover>();
+                if (mover != null)
+                    break;
+
+                elapsed += Time.unscaledDeltaTime;
+                yield return null;
+            }
+
+            if (mover == null)
+            {
+                Debug.LogError("LoginScreenController: PlayerMover was not found after loading the gameplay scene.", this);
+                SetStatus("Failed to spawn the player character.", errorColour);
+                if (loginButton != null)
+                    loginButton.interactable = true;
+                if (loginResumeRequested)
+                {
+                    PlayerMover.CompleteLoginResume();
+                    loginResumeRequested = false;
+                }
+                loadRoutine = null;
+                yield break;
+            }
+
+            mover.transform.position = spawnPosition;
+            mover.SavePosition(sceneToLoad, allowDuringLoginResume: true);
+
+            if (loginResumeRequested)
+            {
+                PlayerMover.CompleteLoginResume();
+                loginResumeRequested = false;
+            }
+
+            loadRoutine = null;
         }
 
         private void EnsureUiHierarchy()

--- a/PlaytestNotes_LoginFlow.md
+++ b/PlaytestNotes_LoginFlow.md
@@ -1,0 +1,18 @@
+# Login Flow Playtest Notes
+
+These scenarios help verify the revised login resume logic for both established accounts and brand-new profiles. Follow them whenever the login, save, or scene-loading code changes.
+
+## Returning Account
+1. Launch the project and authenticate with an existing account that has a saved location away from the overworld (e.g., log out inside an interior scene).
+2. After entering credentials, confirm the status text reports the authentication and that the loading message changes to “Restoring last location…”.
+3. Observe that the client loads the saved scene directly (the overworld should no longer flash first).
+4. Once the scene finishes loading, ensure the player character appears at the exact saved coordinates and that pets or followers align beside the player.
+5. Remain idle for at least 10 seconds so the autosave loop runs, then quit and relaunch. Verify the account still resumes in the same scene and position, confirming that the autosave loop resumed after placement.
+
+## New Account
+1. Launch the project and authenticate with a brand-new username/password combination so a fresh profile is created.
+2. Confirm the status text switches to “Preparing the overworld…” while loading.
+3. After the scene activates, verify that the player prefab spawns in the overworld at coordinates (0, 0, 0) before taking any movement input.
+4. Wait for at least 10 seconds so an autosave occurs, then return to the login screen and log in again. The new account should now resume in the overworld at the last saved position, demonstrating that the initial placement was persisted correctly.
+
+Document any deviations from the above behaviour so regressions can be triaged quickly.


### PR DESCRIPTION
## Summary
- add a public PlayerPositionSnapshot struct and helper APIs so systems can read the last saved scene/coordinates without instantiating PlayerMover
- gate PlayerMover saves during login-driven resumes so placement can complete before autosaves restart
- update the login screen to load the correct scene, position the player using the snapshot or a (0,0,0) default for new accounts, and document returning/new account playtests

## Testing
- not run (Unity editor required)

------
https://chatgpt.com/codex/tasks/task_e_68d011e05438832ebd5365284d9f3340