### PR TITLE
Ensure persistent bootstrap respects loaded scene

### DIFF
--- a/Assets/Scripts/World/PersistentObjectBootstrap.cs
+++ b/Assets/Scripts/World/PersistentObjectBootstrap.cs
@@ -66,7 +66,7 @@ namespace World
                 return;
             }
 
-            EnsurePersistentObjects();
+            EnsurePersistentObjects(SceneManager.GetActiveScene());
         }
 
         private void OnEnable()
@@ -85,7 +85,7 @@ namespace World
         /// </summary>
         private void HandleSceneLoaded(Scene scene, LoadSceneMode mode)
         {
-            EnsurePersistentObjects();
+            EnsurePersistentObjects(scene);
         }
 
         /// <summary>
@@ -93,15 +93,21 @@ namespace World
         /// <see cref="ScenePersistentObject"/> so they register with
         /// <see cref="SceneTransitionManager"/> automatically.
         /// </summary>
-        private void EnsurePersistentObjects()
+        /// <param name="scene">
+        /// Scene that triggered the spawn request. When invalid the active scene will be used instead.
+        /// </param>
+        private void EnsurePersistentObjects(Scene scene)
         {
-            // Resolve the currently active scene so the catalog can opt-out of spawning
-            // persistent prefabs for non-gameplay contexts such as login or menus.
-            Scene activeScene = SceneManager.GetActiveScene();
-            if (!activeScene.IsValid())
+            // Use the provided scene when available so the catalog can evaluate the correct
+            // context. When the scene is invalid (such as during the initial bootstrap) fall
+            // back to the currently active scene so menu/login gates still apply.
+            if (!scene.IsValid())
+                scene = SceneManager.GetActiveScene();
+
+            if (!scene.IsValid())
                 return;
 
-            if (!catalog.ShouldSpawnInScene(activeScene.name))
+            if (!catalog.ShouldSpawnInScene(scene.name))
                 return;
 
             IReadOnlyList<GameObject> prefabs = catalog.Prefabs;


### PR DESCRIPTION
## Summary
- forward the loaded scene to the persistent object bootstrap so additive scene loads trigger spawns
- allow the ensure routine to fall back to the active scene only when necessary while gating by scene name
- keep the initial awake bootstrap path by passing the current active scene explicitly

## Testing
- not run (Unity Editor required)


------
https://chatgpt.com/codex/tasks/task_e_68d01b1fd778832e9fc446eb47b68c3e