### PR TITLE
Revert script updates to pre-753 state

### DIFF
--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -66,12 +66,6 @@ namespace Player
         /// <summary>Tracks whether the previous frame considered the player to be moving.</summary>
         private bool wasMoving;
         /// <summary>
-        ///     Tracks whether this mover has resolved a position that belongs to the currently
-        ///     active scene.  Autosave calls only write while the flag is true so cross-scene
-        ///     staging windows cannot overwrite the stored metadata with mismatched scene names.
-        /// </summary>
-        private bool resolvedActiveScenePosition;
-        /// <summary>
         /// Timer used while the player is moving to trigger periodic position saves so autosaves are
         /// always close to the most recent location.
         /// </summary>
@@ -82,19 +76,6 @@ namespace Player
         /// </summary>
         private bool registeredWithSaveManager;
         /// <summary>
-        ///     Indicates whether the mover has initiated a scene swap in order to honour the saved
-        ///     position payload. While true, any intermediate scene loads must avoid persisting their
-        ///     default coordinates, otherwise the saved profile would be overwritten with staging
-        ///     scene metadata.
-        /// </summary>
-        private bool awaitingSavedSceneLoad;
-        /// <summary>
-        ///     Name of the scene that should become active before persistence resumes. This allows
-        ///     the mover to detect when a saved-scene load is still in progress and defer
-        ///     SavePosition calls until the correct location is ready.
-        /// </summary>
-        private string pendingSavedSceneName;
-        /// <summary>
         /// Interval in seconds used to persist the position while movement is in progress. This
         /// keeps the stored location reasonably fresh without hammering the save file every frame.
         /// </summary>
@@ -103,24 +84,6 @@ namespace Player
         // Ensure only one player persists across scene loads.
         private static PlayerMover instance;
 
-        /// <summary>
-        /// Provides global access to the active <see cref="PlayerMover"/> instance so external
-        /// systems can reposition the player without hunting through the scene hierarchy.
-        /// </summary>
-        public static PlayerMover Instance => instance;
-
-        /// <summary>
-        /// Tracks whether the login flow is orchestrating a resume so automatic saves are deferred
-        /// until the player has been placed at the desired coordinates.
-        /// </summary>
-        private static bool loginResumeActive;
-
-        /// <summary>
-        /// Snapshot captured during the login-driven resume sequence. This allows the mover to
-        /// expose the planned spawn data to other systems while saves are deferred.
-        /// </summary>
-        private static PlayerPositionSnapshot loginResumeSnapshot = PlayerPositionSnapshot.Empty;
-
         [Serializable]
         private class PositionData
         {
@@ -128,49 +91,6 @@ namespace Player
             public float y;
             public float z;
             public string scene;
-        }
-
-        /// <summary>
-        /// Data carrier that exposes the last persisted player scene and coordinates so callers can
-        /// query the save system without instantiating a mover.
-        /// </summary>
-        public readonly struct PlayerPositionSnapshot
-        {
-            /// <summary>
-            /// Name of the scene that owns the stored coordinates.
-            /// </summary>
-            public string SceneName { get; }
-
-            /// <summary>
-            /// World position the player occupied when the snapshot was taken.
-            /// </summary>
-            public Vector3 Position { get; }
-
-            /// <summary>
-            /// Indicates whether the snapshot originated from a valid save entry.
-            /// </summary>
-            public bool HasValidData { get; }
-
-            private PlayerPositionSnapshot(string sceneName, Vector3 position, bool hasValidData)
-            {
-                SceneName = string.IsNullOrEmpty(sceneName) ? string.Empty : sceneName;
-                Position = position;
-                HasValidData = hasValidData && !string.IsNullOrEmpty(SceneName);
-            }
-
-            /// <summary>
-            /// Returns an empty snapshot used when no persisted data exists for the active profile.
-            /// </summary>
-            public static PlayerPositionSnapshot Empty => new PlayerPositionSnapshot(string.Empty, Vector3.zero, false);
-
-            /// <summary>
-            /// Creates a snapshot pointing at the supplied scene and position. The caller controls
-            /// whether the payload should be considered a fully valid save entry.
-            /// </summary>
-            public static PlayerPositionSnapshot Create(string sceneName, Vector3 position, bool hasValidData)
-            {
-                return new PlayerPositionSnapshot(sceneName, position, hasValidData);
-            }
         }
 
         private const string PositionKey = "PlayerPosition";
@@ -193,58 +113,6 @@ namespace Player
         ///     Gathering controllers use this to determine if an automatically initiated walk is still in progress.
         /// </summary>
         public bool IsAutoMoving => isAutoMoving;
-
-        /// <summary>
-        /// Attempts to resolve the last persisted position payload without instantiating a mover.
-        /// </summary>
-        /// <param name="snapshot">Outputs the stored scene and coordinates when available.</param>
-        /// <returns>True when a saved snapshot exists for the active profile.</returns>
-        public static bool TryGetLastSavedSnapshot(out PlayerPositionSnapshot snapshot)
-        {
-            var data = SaveManager.Load<PositionData>(PositionKey);
-            if (data == null || string.IsNullOrEmpty(data.scene))
-            {
-                snapshot = PlayerPositionSnapshot.Empty;
-                return false;
-            }
-
-            snapshot = PlayerPositionSnapshot.Create(
-                data.scene,
-                new Vector3(data.x, data.y, data.z),
-                hasValidData: true);
-            return true;
-        }
-
-        /// <summary>
-        /// Flags that the login flow is about to resume a gameplay scene so automatic saves are
-        /// paused until the external placement logic completes.
-        /// </summary>
-        /// <param name="snapshot">Snapshot describing the desired resume location.</param>
-        public static void BeginLoginResume(PlayerPositionSnapshot snapshot)
-        {
-            loginResumeSnapshot = snapshot;
-            loginResumeActive = true;
-        }
-
-        /// <summary>
-        /// Clears the login resume guard so autosaves and movement persistence resume as normal.
-        /// </summary>
-        public static void CompleteLoginResume()
-        {
-            loginResumeSnapshot = PlayerPositionSnapshot.Empty;
-            loginResumeActive = false;
-        }
-
-        /// <summary>
-        /// Returns the snapshot currently being honoured by the login resume process.
-        /// </summary>
-        public static PlayerPositionSnapshot CurrentLoginResumeSnapshot => loginResumeSnapshot;
-
-        /// <summary>
-        /// Indicates whether the mover should defer automatic save writes while an external login
-        /// workflow positions the player.
-        /// </summary>
-        public static bool IsLoginResumeActive => loginResumeActive;
 
 #if ENABLE_INPUT_SYSTEM
         private InputAction moveAction;
@@ -644,27 +512,15 @@ namespace Player
         /// <summary>
         /// Persist the player's current position to the active save profile.
         /// </summary>
-        /// <param name="sceneNameOverride">
-        /// Optional scene identifier to store alongside the position. When null the
-        /// active scene reported by <see cref="SceneManager"/> is used instead.
-        /// </param>
-        public void SavePosition(string sceneNameOverride = null, bool allowDuringLoginResume = false)
+        public void SavePosition()
         {
-            if (!resolvedActiveScenePosition)
-                return;
-
-            if (loginResumeActive && !allowDuringLoginResume)
-                return;
-
             Vector3 pos = transform.position;
             var data = new PositionData
             {
                 x = pos.x,
                 y = pos.y,
                 z = pos.z,
-                scene = string.IsNullOrEmpty(sceneNameOverride)
-                    ? SceneManager.GetActiveScene().name
-                    : sceneNameOverride
+                scene = SceneManager.GetActiveScene().name
             };
             SaveManager.Save(PositionKey, data);
         }
@@ -674,9 +530,6 @@ namespace Player
         /// </summary>
         public void Save()
         {
-            if (!resolvedActiveScenePosition)
-                return;
-
             SavePosition();
         }
 
@@ -691,19 +544,9 @@ namespace Player
 
         private void LoadPosition()
         {
-            resolvedActiveScenePosition = false;
-
-            awaitingSavedSceneLoad = false;
-            pendingSavedSceneName = null;
-
             var data = SaveManager.Load<PositionData>(PositionKey);
             if (data == null)
-            {
-                // No saved metadata exists yet, so treat the authored scene placement as resolved
-                // to allow fresh profiles to persist their first position snapshot.
-                resolvedActiveScenePosition = true;
                 return;
-            }
             if (isTransitioning)
                 return;
             if (SceneTransitionManager.IsTransitioning)
@@ -711,11 +554,7 @@ namespace Player
 
             if (SceneManager.GetActiveScene().name == data.scene)
             {
-                if (ApplySavedPosition())
-                    resolvedActiveScenePosition = true;
-
-                awaitingSavedSceneLoad = false;
-                pendingSavedSceneName = null;
+                ApplySavedPosition();
 
                 var pet = PetDropSystem.ActivePetObject;
                 if (pet != null)
@@ -728,8 +567,6 @@ namespace Player
             }
             else
             {
-                awaitingSavedSceneLoad = true;
-                pendingSavedSceneName = data.scene;
                 SceneManager.sceneLoaded += OnSceneLoaded;
                 var pet = PetDropSystem.ActivePetObject;
                 if (pet != null)
@@ -746,17 +583,7 @@ namespace Player
             var data = SaveManager.Load<PositionData>(PositionKey);
             if (data != null && scene.name == data.scene)
             {
-                bool appliedSavedPosition = ApplySavedPosition();
-                if (appliedSavedPosition)
-                {
-                    resolvedActiveScenePosition = true;
-
-                    // Clear the deferred load flags once the saved position has been restored so the
-                    // follow-up OnAfterSceneLoad pass can resume normal persistence handling.
-                    awaitingSavedSceneLoad = false;
-                    pendingSavedSceneName = null;
-                }
-
+                ApplySavedPosition();
                 if (petToMove != null)
                 {
                     petToMove.transform.position = transform.position;
@@ -765,13 +592,6 @@ namespace Player
                         follower.SetPlayer(transform);
                     SceneManager.MoveGameObjectToScene(petToMove, scene);
                     petToMove = null;
-                }
-
-                if (appliedSavedPosition)
-                {
-                    // The saved-scene handoff has finished so this handler can be removed immediately.
-                    SceneManager.sceneLoaded -= OnSceneLoaded;
-                    return;
                 }
             }
 
@@ -782,7 +602,6 @@ namespace Player
         private void OnTransitionStarted()
         {
             isTransitioning = true;
-            resolvedActiveScenePosition = false;
             HandleForcedIdle();
         }
 
@@ -792,27 +611,17 @@ namespace Player
         }
 
         /// <summary>
-        /// Applies the provided position payload to the player if valid.
-        /// </summary>
-        /// <param name="data">Persisted position data captured from <see cref="SavePosition"/>.</param>
-        /// <returns>True when a non-null payload was applied to the transform.</returns>
-        private bool ApplyPositionData(PositionData data)
-        {
-            if (data == null)
-                return false;
-
-            transform.position = new Vector3(data.x, data.y, data.z);
-            return true;
-        }
-
-        /// <summary>
         /// Attempts to move the player to the coordinates stored in the active save profile.
         /// </summary>
         /// <returns>True when a saved location existed and was applied.</returns>
         private bool ApplySavedPosition()
         {
             var data = SaveManager.Load<PositionData>(PositionKey);
-            return ApplyPositionData(data);
+            if (data == null)
+                return false;
+
+            transform.position = new Vector3(data.x, data.y, data.z);
+            return true;
         }
 
         public override void OnBeforeSceneUnload()
@@ -825,105 +634,35 @@ namespace Player
             base.OnAfterSceneLoad(scene);
 
             // Track which positioning strategy ended up being used so we only persist when a valid
-            // location has been resolved for this scene.  The additional flag ensures we do not
-            // clobber saved metadata with coordinates from a different scene when the player is
-            // about to transition.
-            bool skipPositionResolution = awaitingSavedSceneLoad
-                && !string.IsNullOrEmpty(pendingSavedSceneName)
-                && !string.Equals(scene.name, pendingSavedSceneName, StringComparison.Ordinal);
+            // location has been resolved for this scene.
+            bool positionedFromSpawn = false;
+            bool positionedFromSave = false;
 
-            bool resolvedActiveSceneLocation = false;
-
-            if (!skipPositionResolution)
+            var spawnId = SceneTransitionManager.NextSpawnPoint;
+            bool spawnRequested = !string.IsNullOrEmpty(spawnId);
+            if (spawnRequested)
             {
-                bool positionedFromSpawn = false;
-                bool positionedFromSave = false;
-
-                var savedData = SaveManager.Load<PositionData>(PositionKey);
-                bool hasSavedPosition = savedData != null;
-                bool savedSceneMatches = hasSavedPosition && savedData.scene == scene.name;
-
-                var spawnId = SceneTransitionManager.NextSpawnPoint;
-                bool spawnRequested = !string.IsNullOrEmpty(spawnId);
-
-                // When we're resuming the exact scene captured in the save and no explicit spawn override
-                // is active, prefer the persisted coordinates so logout/login flows feel seamless.
-                if (savedSceneMatches && !spawnRequested)
+                var points = GameObject.FindObjectsOfType<SpawnPoint>();
+                foreach (var p in points)
                 {
-                    positionedFromSave = ApplyPositionData(savedData);
-                    resolvedActiveSceneLocation = positionedFromSave;
-                    if (positionedFromSave)
-                        resolvedActiveScenePosition = true;
-                }
-                else
-                {
-                    if (!spawnRequested && !hasSavedPosition)
+                    if (p.id == spawnId)
                     {
-                        // No saved data or spawn override exists, so the authored scene placement already
-                        // represents a valid location for this scene. Treat it as resolved so persistence can begin.
-                        resolvedActiveSceneLocation = true;
-                        resolvedActiveScenePosition = true;
-                    }
-                    else
-                    {
-                        if (spawnRequested)
-                        {
-                            var points = GameObject.FindObjectsOfType<SpawnPoint>();
-                            foreach (var p in points)
-                            {
-                                if (p.id == spawnId)
-                                {
-                                    transform.position = p.transform.position;
-                                    positionedFromSpawn = true;
-                                    resolvedActiveSceneLocation = true;
-                                    resolvedActiveScenePosition = true;
-                                    break;
-                                }
-                            }
-
-                            if (!positionedFromSpawn)
-                            {
-                                Debug.LogWarning($"SceneTransitionManager requested spawn point '{spawnId}' but no matching SpawnPoint was found in scene '{scene.name}'. Falling back to saved position if available.", this);
-                            }
-                        }
-
-                        if (!positionedFromSpawn && hasSavedPosition)
-                        {
-                            if (savedSceneMatches)
-                            {
-                                positionedFromSave = ApplyPositionData(savedData);
-
-                                // Only treat the fallback as a resolved active-scene location when the saved
-                                // data already targets the scene we just loaded.  Otherwise we would be
-                                // overwriting the saved scene identifier before the deferred LoadPosition call
-                                // has a chance to move the player into the correct interior.
-                                if (positionedFromSave)
-                                {
-                                    resolvedActiveSceneLocation = true;
-                                    resolvedActiveScenePosition = true;
-                                }
-                            }
-                            // When the saved scene differs keep the authored/default transform so the
-                            // deferred LoadPosition flow can relocate the mover after the correct scene loads.
-                        }
+                        transform.position = p.transform.position;
+                        positionedFromSpawn = true;
+                        break;
                     }
                 }
 
-                if (awaitingSavedSceneLoad && string.Equals(scene.name, pendingSavedSceneName, StringComparison.Ordinal))
+                if (!positionedFromSpawn)
                 {
-                    awaitingSavedSceneLoad = false;
-                    pendingSavedSceneName = null;
+                    Debug.LogWarning($"SceneTransitionManager requested spawn point '{spawnId}' but no matching SpawnPoint was found in scene '{scene.name}'. Falling back to saved position if available.", this);
                 }
             }
-            else
-            {
-                // The saved profile is directing us to another scene, so avoid persisting the staging
-                // coordinates. Reset movement tracking so SavePosition remains suppressed until the
-                // correct scene becomes active.
-                resolvedActiveScenePosition = false;
-                wasMoving = false;
-                movementSaveTimer = 0f;
-            }
+
+            if (!positionedFromSpawn)
+                positionedFromSave = ApplySavedPosition();
+
+            bool shouldPersistPosition = positionedFromSpawn || positionedFromSave;
 
             // Realign an active pet so it appears beside the player rather than
             // lingering at the origin during scene swaps.  Without this pass the
@@ -962,11 +701,8 @@ namespace Player
                 }
             }
 
-            // Persist the updated position only when we resolved a location that belongs to the
-            // active scene.  When the saved data targets another scene the deferred LoadPosition
-            // call will handle the swap without us touching the stored metadata here.
-            if (!skipPositionResolution && resolvedActiveSceneLocation)
-                SavePosition(scene.name);
+            if (shouldPersistPosition)
+                SavePosition();
         }
 
         /// <summary>
@@ -976,13 +712,6 @@ namespace Player
         /// <param name="isMoving">Whether the player is considered to be moving this frame.</param>
         private void HandleMovementPersistenceAfterUpdate(bool isMoving)
         {
-            if (!resolvedActiveScenePosition)
-            {
-                wasMoving = isMoving;
-                movementSaveTimer = 0f;
-                return;
-            }
-
             if (isMoving)
             {
                 movementSaveTimer += Time.unscaledDeltaTime;
@@ -1007,7 +736,7 @@ namespace Player
         /// </summary>
         private void HandleForcedIdle()
         {
-            if (wasMoving && resolvedActiveScenePosition)
+            if (wasMoving)
                 SavePosition();
 
             wasMoving = false;

--- a/Assets/Scripts/UI/Login/LoginScreenController.cs
+++ b/Assets/Scripts/UI/Login/LoginScreenController.cs
@@ -1,12 +1,13 @@
 using System.Collections;
 using Core.Save;
-using Player;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 using UI;
+#if ENABLE_INPUT_SYSTEM
 using UnityEngine.InputSystem;
+#endif
 
 namespace UI.Login
 {
@@ -76,30 +77,7 @@ namespace UI.Login
         private string gameplaySceneName = "OverWorld";
 
         private Coroutine loadRoutine;
-        private Coroutine postLoadRoutine; // Coroutine that waits for persistent gameplay services before finishing the login flow.
         private GameObject lastSelectedInputField;
-        private bool loginResumeRequested;
-        private bool loadHandlerActive; // Indicates whether the login resume handler should survive scene transitions.
-        private bool sceneLoadedHandlerRegistered; // Tracks the SceneManager.sceneLoaded subscription so we can unsubscribe safely.
-        private bool persistentDuringLoad; // True while this controller has been marked DontDestroyOnLoad for the active transition.
-        private string pendingSceneName; // Target scene that should be loaded following authentication.
-        private Vector3 pendingSpawnPosition; // Position that the PlayerMover should use after the gameplay scene is ready.
-
-        private const float PendingSpawnLogInterval = 2f;
-#if ENABLE_INPUT_SYSTEM
-        /// <summary>
-        /// Duration in seconds to wait after requesting a player join before concluding the spawn
-        /// request failed. This only covers the immediate validation window so genuine cold boots
-        /// can continue relying on the longer wait below.
-        /// </summary>
-        private const float PlayerJoinVerificationTimeout = 0.2f;
-#endif
-
-        /// <summary>
-        /// Message displayed when the player prefab fails to appear so the user is not left staring
-        /// at an indefinite loading prompt.
-        /// </summary>
-        private const string PlayerSpawnFailureStatus = "Player instantiation failed. Please try again.";
 
         private void Awake()
         {
@@ -158,12 +136,6 @@ namespace UI.Login
                 passwordField.onValueChanged.RemoveListener(HandleInputChanged);
 
             lastSelectedInputField = null;
-
-            if (loginResumeRequested && !loadHandlerActive)
-            {
-                PlayerMover.CompleteLoginResume();
-                loginResumeRequested = false;
-            }
         }
 
         private void Update()
@@ -229,460 +201,27 @@ namespace UI.Login
             SetStatus(activationMessage, successColour);
             SaveManager.LoadAll();
 
-            bool hasSnapshot = PlayerMover.TryGetLastSavedSnapshot(out var savedSnapshot);
-            string sceneToLoad = hasSnapshot && !string.IsNullOrEmpty(savedSnapshot.SceneName)
-                ? savedSnapshot.SceneName
-                : gameplaySceneName;
-
-            if (string.IsNullOrEmpty(sceneToLoad))
-                sceneToLoad = gameplaySceneName;
-
-            Vector3 spawnPosition = hasSnapshot ? savedSnapshot.Position : Vector3.zero;
-            var loginSnapshot = hasSnapshot
-                ? savedSnapshot
-                : PlayerMover.PlayerPositionSnapshot.Create(sceneToLoad, spawnPosition, hasValidData: false);
-
-            PlayerMover.BeginLoginResume(loginSnapshot);
-            loginResumeRequested = true;
-
-            if (postLoadRoutine != null)
-            {
-                StopCoroutine(postLoadRoutine);
-                postLoadRoutine = null;
-            }
-
-            if (sceneLoadedHandlerRegistered)
-            {
-                SceneManager.sceneLoaded -= HandleSceneLoaded;
-                sceneLoadedHandlerRegistered = false;
-            }
-
             if (loadRoutine != null)
                 StopCoroutine(loadRoutine);
-            loadRoutine = StartCoroutine(LoadGameplayScene(sceneToLoad, spawnPosition, hasSnapshot));
+            loadRoutine = StartCoroutine(LoadGameplayScene());
         }
 
-        private IEnumerator LoadGameplayScene(string sceneToLoad, Vector3 spawnPosition, bool resumingFromSnapshot)
+        private IEnumerator LoadGameplayScene()
         {
-            PrepareForSceneLoad(sceneToLoad, spawnPosition);
+            SetStatus("Loading world...", infoColour);
 
-            SetStatus(resumingFromSnapshot ? "Restoring last location..." : "Preparing the overworld...", infoColour);
-
-            var operation = SceneManager.LoadSceneAsync(sceneToLoad, LoadSceneMode.Single);
+            var operation = SceneManager.LoadSceneAsync(gameplaySceneName, LoadSceneMode.Single);
             if (operation == null)
             {
-                HandleSceneTransitionFailure($"Failed to load scene '{sceneToLoad}'.");
-                loadRoutine = null;
+                SetStatus("Failed to load the overworld scene.", errorColour);
+                if (loginButton != null)
+                    loginButton.interactable = true;
                 yield break;
             }
 
             operation.allowSceneActivation = true;
             while (!operation.isDone)
                 yield return null;
-
-            loadRoutine = null;
-        }
-
-        /// <summary>
-        /// Marks the controller as persistent, caches the requested spawn data, and subscribes to the
-        /// sceneLoaded callback so the post-load handler executes from a context that survives the
-        /// upcoming scene swap.
-        /// </summary>
-        private void PrepareForSceneLoad(string sceneToLoad, Vector3 spawnPosition)
-        {
-            pendingSceneName = sceneToLoad;
-            pendingSpawnPosition = spawnPosition;
-            loadHandlerActive = true;
-
-            if (!persistentDuringLoad)
-            {
-                DontDestroyOnLoad(gameObject);
-                persistentDuringLoad = true;
-            }
-
-            if (!sceneLoadedHandlerRegistered)
-            {
-                SceneManager.sceneLoaded += HandleSceneLoaded;
-                sceneLoadedHandlerRegistered = true;
-            }
-        }
-
-        /// <summary>
-        /// Starts the post-load coroutine once the requested gameplay scene finishes loading.
-        /// </summary>
-        private void HandleSceneLoaded(Scene scene, LoadSceneMode mode)
-        {
-            if (!loadHandlerActive)
-                return;
-
-            if (!string.Equals(scene.name, pendingSceneName))
-                return;
-
-            if (sceneLoadedHandlerRegistered)
-            {
-                SceneManager.sceneLoaded -= HandleSceneLoaded;
-                sceneLoadedHandlerRegistered = false;
-            }
-
-            if (postLoadRoutine != null)
-            {
-                StopCoroutine(postLoadRoutine);
-                postLoadRoutine = null;
-            }
-
-            postLoadRoutine = StartCoroutine(HandlePostSceneLoad());
-        }
-
-        /// <summary>
-        /// Waits for persistent gameplay services to finish bootstrapping before finalising the login
-        /// resume flow.
-        /// </summary>
-        private IEnumerator HandlePostSceneLoad()
-        {
-            // Track the resolved PlayerMover so both the short verification window and the existing
-            // long-running wait loop can share a common reference.
-            PlayerMover mover = null;
-#if ENABLE_INPUT_SYSTEM
-            // Poll for a PlayerInputManager so the player prefab can be spawned even when the
-            // scene takes a frame to bootstrap its persistent objects. While waiting we also
-            // watch for any active PlayerInput so duplicates are avoided when returning to the
-            // overworld mid-session. The coroutine now remains patient until the manager
-            // actually appears instead of aborting after an arbitrary timeout so cold boots on
-            // slower devices do not bounce players back to the login screen.
-            float managerLogTimer = 0f;
-            bool playerInputAlreadyPresent = false;
-            PlayerInputManager inputManager = null;
-            PlayerInput joinedPlayerInput = null;
-            while (loadHandlerActive)
-            {
-                playerInputAlreadyPresent = false;
-                foreach (var playerInput in PlayerInput.all)
-                {
-                    if (playerInput != null && playerInput.isActiveAndEnabled)
-                    {
-                        playerInputAlreadyPresent = true;
-                        break;
-                    }
-                }
-
-                if (playerInputAlreadyPresent)
-                    break;
-
-                inputManager = PlayerInputManager.instance;
-                if (inputManager == null)
-                    inputManager = Object.FindObjectOfType<PlayerInputManager>();
-
-                if (inputManager != null)
-                    break;
-
-                if (!IsPendingSceneStillLoaded())
-                {
-                    Debug.LogError("LoginScreenController: Pending gameplay scene unloaded before the PlayerInputManager became available.", this);
-                    HandleSceneTransitionFailure("The gameplay scene unloaded before input could initialise. Please try again.");
-                    postLoadRoutine = null;
-                    yield break;
-                }
-
-                yield return null;
-
-                managerLogTimer += Time.unscaledDeltaTime;
-                if (managerLogTimer >= PendingSpawnLogInterval)
-                {
-                    Debug.Log($"LoginScreenController: Waiting for PlayerInputManager in scene '{pendingSceneName}'.", this);
-                    managerLogTimer = 0f;
-                }
-            }
-
-            if (!loadHandlerActive)
-            {
-                postLoadRoutine = null;
-                yield break;
-            }
-
-            // If no PlayerInput existed when the manager became available, perform a final duplicate
-            // check before requesting a new player join. This protects against race conditions where
-            // the PlayerInput spawns naturally while we were yielding.
-            if (!playerInputAlreadyPresent && inputManager != null)
-            {
-                foreach (var playerInput in PlayerInput.all)
-                {
-                    if (playerInput != null && playerInput.isActiveAndEnabled)
-                    {
-                        playerInputAlreadyPresent = true;
-                        break;
-                    }
-                }
-
-                if (!playerInputAlreadyPresent)
-                {
-                    Debug.Log("LoginScreenController: Requesting PlayerInputManager to spawn the local player.", this);
-                    joinedPlayerInput = inputManager.JoinPlayer();
-
-                    if (joinedPlayerInput == null)
-                    {
-                        Debug.LogError("LoginScreenController: PlayerInputManager.JoinPlayer returned null. Unable to continue the login flow.", this);
-                        CleanupJoinedPlayerInput(joinedPlayerInput);
-                        HandleSceneTransitionFailure(PlayerSpawnFailureStatus);
-                        postLoadRoutine = null;
-                        yield break;
-                    }
-
-                    // Immediately verify that the spawned prefab carries the PlayerMover component.
-                    mover = ResolveMoverFromPlayerInput(joinedPlayerInput);
-                    if (mover == null)
-                    {
-                        float joinVerificationTimer = 0f;
-                        while (loadHandlerActive && joinVerificationTimer < PlayerJoinVerificationTimeout && mover == null)
-                        {
-                            if (!IsPendingSceneStillLoaded())
-                            {
-                                Debug.LogError("LoginScreenController: Gameplay scene unloaded while validating the newly spawned player.", this);
-                                CleanupJoinedPlayerInput(joinedPlayerInput);
-                                HandleSceneTransitionFailure(PlayerSpawnFailureStatus);
-                                postLoadRoutine = null;
-                                yield break;
-                            }
-
-                            // Allow a few frames for the prefab hierarchy to finish initialising
-                            // before concluding the spawn truly failed.
-                            yield return null;
-                            joinVerificationTimer += Time.unscaledDeltaTime;
-                            mover = ResolveMoverFromPlayerInput(joinedPlayerInput);
-
-                            if (mover == null)
-                                mover = PlayerMover.Instance;
-
-                            if (mover == null)
-                                mover = FindObjectOfType<PlayerMover>();
-                        }
-
-                        if (mover == null)
-                        {
-                            Debug.LogError("LoginScreenController: Spawned PlayerInput is missing a PlayerMover component.", this);
-                            CleanupJoinedPlayerInput(joinedPlayerInput);
-                            HandleSceneTransitionFailure(PlayerSpawnFailureStatus);
-                            postLoadRoutine = null;
-                            yield break;
-                        }
-                    }
-                }
-            }
-#endif
-
-            float moverLogTimer = 0f;
-            if (mover == null)
-                mover = PlayerMover.Instance;
-            if (mover == null)
-                mover = FindObjectOfType<PlayerMover>();
-
-            while (loadHandlerActive && mover == null)
-            {
-                if (!IsPendingSceneStillLoaded())
-                {
-                    Debug.LogError("LoginScreenController: Gameplay scene unloaded before the PlayerMover spawned.", this);
-                    HandleSceneTransitionFailure("The gameplay scene unloaded before the player prefab could spawn. Please try again.");
-                    postLoadRoutine = null;
-                    yield break;
-                }
-
-                yield return null;
-
-                moverLogTimer += Time.unscaledDeltaTime;
-                if (moverLogTimer >= PendingSpawnLogInterval)
-                {
-                    Debug.Log($"LoginScreenController: Waiting for PlayerMover in scene '{pendingSceneName}'.", this);
-                    moverLogTimer = 0f;
-                }
-
-                mover = PlayerMover.Instance;
-                if (mover == null)
-                    mover = FindObjectOfType<PlayerMover>();
-            }
-
-            if (!loadHandlerActive)
-            {
-                postLoadRoutine = null;
-                yield break;
-            }
-
-            if (mover == null)
-            {
-                Debug.LogError("LoginScreenController: PlayerMover never became available despite the gameplay scene staying loaded.", this);
-                HandleSceneTransitionFailure(PlayerSpawnFailureStatus);
-                postLoadRoutine = null;
-                yield break;
-            }
-
-            mover.transform.position = pendingSpawnPosition;
-            mover.SavePosition(pendingSceneName, allowDuringLoginResume: true);
-
-            if (loginResumeRequested)
-            {
-                PlayerMover.CompleteLoginResume();
-                loginResumeRequested = false;
-            }
-
-            CompleteSuccessfulSceneTransition();
-            postLoadRoutine = null;
-        }
-
-#if ENABLE_INPUT_SYSTEM
-        /// <summary>
-        /// Attempts to locate the <see cref="PlayerMover"/> associated with the provided
-        /// <see cref="PlayerInput"/>. The search covers the root, children, and parents so prefabs with
-        /// nested hierarchies are still supported.
-        /// </summary>
-        /// <param name="playerInput">Player input component spawned by the input manager.</param>
-        /// <returns>The resolved mover instance when available; otherwise null.</returns>
-        private static PlayerMover ResolveMoverFromPlayerInput(PlayerInput playerInput)
-        {
-            if (playerInput == null)
-                return null;
-
-            var mover = playerInput.GetComponent<PlayerMover>();
-            if (mover != null)
-                return mover;
-
-            mover = playerInput.GetComponentInChildren<PlayerMover>(true);
-            if (mover != null)
-                return mover;
-
-            return playerInput.GetComponentInParent<PlayerMover>();
-        }
-
-        /// <summary>
-        /// Releases the temporary <see cref="PlayerInput"/> that was spawned during a failed login
-        /// resume attempt. The cleanup prefers the <see cref="PlayerInputManager"/> so internal
-        /// bookkeeping remains consistent before falling back to a direct destroy when the manager
-        /// is no longer available.
-        /// </summary>
-        /// <param name="joinedPlayerInput">Player input instance that should be removed.</param>
-        private void CleanupJoinedPlayerInput(PlayerInput joinedPlayerInput)
-        {
-            if (joinedPlayerInput == null)
-                return;
-
-            var manager = PlayerInputManager.instance;
-            if (manager != null)
-            {
-                manager.RemovePlayer(joinedPlayerInput);
-                return;
-            }
-
-            Destroy(joinedPlayerInput.gameObject);
-        }
-#endif
-
-        /// <summary>
-        /// Determines whether the pending gameplay scene is still present and loaded. The login
-        /// resume flow only treats the transition as failed when the scene actually unloads or is
-        /// replaced, preventing false negatives when the bootstrap work simply takes longer than
-        /// expected on a cold start.
-        /// </summary>
-        private bool IsPendingSceneStillLoaded()
-        {
-            if (string.IsNullOrEmpty(pendingSceneName))
-                return false;
-
-            var activeScene = SceneManager.GetActiveScene();
-            if (activeScene.IsValid() && activeScene.name == pendingSceneName)
-                return true;
-
-            var pendingScene = SceneManager.GetSceneByName(pendingSceneName);
-            return pendingScene.IsValid() && pendingScene.isLoaded;
-        }
-
-        /// <summary>
-        /// Finalises the login flow once the player has been spawned and positioned in the gameplay
-        /// scene.
-        /// </summary>
-        private void CompleteSuccessfulSceneTransition()
-        {
-            loadHandlerActive = false;
-            pendingSceneName = null;
-            pendingSpawnPosition = Vector3.zero;
-
-            if (loginButton != null)
-                loginButton.interactable = true;
-
-            if (persistentDuringLoad)
-                persistentDuringLoad = false;
-
-            HideAndDestroyLoginUi();
-        }
-
-        /// <summary>
-        /// Restores the login UI so the player can retry when the gameplay scene fails to initialise
-        /// correctly.
-        /// </summary>
-        private void HandleSceneTransitionFailure(string message)
-        {
-            loadHandlerActive = false;
-
-            if (postLoadRoutine != null)
-                postLoadRoutine = null;
-
-            if (sceneLoadedHandlerRegistered)
-            {
-                SceneManager.sceneLoaded -= HandleSceneLoaded;
-                sceneLoadedHandlerRegistered = false;
-            }
-
-            SetStatus(message, errorColour);
-
-            if (loginButton != null)
-                loginButton.interactable = true;
-
-            if (loginResumeRequested)
-            {
-                PlayerMover.CompleteLoginResume();
-                loginResumeRequested = false;
-            }
-
-            pendingSceneName = null;
-            pendingSpawnPosition = Vector3.zero;
-
-            if (persistentDuringLoad)
-            {
-                SceneManager.MoveGameObjectToScene(gameObject, SceneManager.GetActiveScene());
-                persistentDuringLoad = false;
-            }
-        }
-
-        /// <summary>
-        /// Hides every login element before destroying the controller so the gameplay scene is free
-        /// from lingering menu visuals.
-        /// </summary>
-        private void HideAndDestroyLoginUi()
-        {
-            if (backgroundImage != null)
-                backgroundImage.enabled = false;
-
-            if (loginPanelImage != null)
-                loginPanelImage.enabled = false;
-
-            if (usernameField != null)
-                usernameField.gameObject.SetActive(false);
-
-            if (passwordField != null)
-                passwordField.gameObject.SetActive(false);
-
-            if (statusText != null)
-                statusText.gameObject.SetActive(false);
-
-            if (loginButton != null)
-                loginButton.gameObject.SetActive(false);
-
-            var canvas = GetComponent<Canvas>();
-            if (canvas != null)
-                canvas.enabled = false;
-
-            var raycaster = GetComponent<GraphicRaycaster>();
-            if (raycaster != null)
-                raycaster.enabled = false;
-
-            gameObject.SetActive(false);
-            Destroy(gameObject);
         }
 
         private void EnsureUiHierarchy()

--- a/Assets/Scripts/World/PersistentObjectBootstrap.cs
+++ b/Assets/Scripts/World/PersistentObjectBootstrap.cs
@@ -66,7 +66,7 @@ namespace World
                 return;
             }
 
-            EnsurePersistentObjects(SceneManager.GetActiveScene());
+            EnsurePersistentObjects();
         }
 
         private void OnEnable()
@@ -85,7 +85,7 @@ namespace World
         /// </summary>
         private void HandleSceneLoaded(Scene scene, LoadSceneMode mode)
         {
-            EnsurePersistentObjects(scene);
+            EnsurePersistentObjects();
         }
 
         /// <summary>
@@ -93,21 +93,15 @@ namespace World
         /// <see cref="ScenePersistentObject"/> so they register with
         /// <see cref="SceneTransitionManager"/> automatically.
         /// </summary>
-        /// <param name="scene">
-        /// Scene that triggered the spawn request. When invalid the active scene will be used instead.
-        /// </param>
-        private void EnsurePersistentObjects(Scene scene)
+        private void EnsurePersistentObjects()
         {
-            // Use the provided scene when available so the catalog can evaluate the correct
-            // context. When the scene is invalid (such as during the initial bootstrap) fall
-            // back to the currently active scene so menu/login gates still apply.
-            if (!scene.IsValid())
-                scene = SceneManager.GetActiveScene();
-
-            if (!scene.IsValid())
+            // Resolve the currently active scene so the catalog can opt-out of spawning
+            // persistent prefabs for non-gameplay contexts such as login or menus.
+            Scene activeScene = SceneManager.GetActiveScene();
+            if (!activeScene.IsValid())
                 return;
 
-            if (!catalog.ShouldSpawnInScene(scene.name))
+            if (!catalog.ShouldSpawnInScene(activeScene.name))
                 return;
 
             IReadOnlyList<GameObject> prefabs = catalog.Prefabs;


### PR DESCRIPTION
## Summary
- restore PlayerMover to the earlier implementation from commit 753
- reset LoginScreenController to the prior login flow and layout handling
- revert PersistentObjectBootstrap to its previous scene-gated prefab bootstrap logic

## Testing
- not run (Unity editor unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d05f08aae0832eabc3c821322e3892