### PR TITLE
Refactor login flow for per-account saves

### DIFF
--- a/Assets/Scripts/Core/Save/AccountProfileService.cs
+++ b/Assets/Scripts/Core/Save/AccountProfileService.cs
@@ -1,373 +1,366 @@
+// Refactor: OSRS-style login with per-account saves; removed Overworld hop; atomic file IO; PBKDF2.
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
 using UnityEngine;
 
 namespace Core.Save
 {
     /// <summary>
-    /// Maintains a collection of player accounts and coordinates authentication so each
-    /// gameplay profile can be isolated inside <see cref="SaveManager"/>. Account data lives
-    /// alongside save files via <see cref="SaveManager.SaveGlobal"/> calls so credential
-    /// checks function before a profile is activated.
+    /// Handles account creation, authentication, and persistence using OSRS-style username and
+    /// password credentials. Each account is stored as an individual JSON file so save data can
+    /// be isolated per profile without a selection UI.
     /// </summary>
-    public static class AccountProfileService
+    public static class AccountManager
     {
-        private const string AccountsKey = "accounts";
-        private const int SaltSize = 32;
+        private const string BaseSavePath = "C:\Users\lewis\Documents\My-project\PlayerSave";
+        private const int SaltSizeBytes = 16;
+        private const int Pbkdf2Iterations = 100_000;
+        private const int Pbkdf2KeySizeBytes = 32;
+        private const string DefaultSceneName = "OverWorld";
 
-        private static AccountCollection cache;
-        private static AccountEntry activeAccount;
-
-        /// <summary>
-        /// Display name for the authenticated account. Returns an empty string when no
-        /// account has been activated yet.
-        /// </summary>
-        public static string ActiveDisplayName => activeAccount != null ? activeAccount.DisplayName : string.Empty;
-
-        /// <summary>
-        /// Normalised profile identifier for the active account. Falls back to the
-        /// <see cref="SaveManager.ActiveProfileId"/> value so legacy callers can check the
-        /// current profile even before <see cref="ActivateAccount"/> completes.
-        /// </summary>
-        public static string ActiveProfileId => activeAccount != null ? activeAccount.ProfileId : SaveManager.ActiveProfileId;
-
-        /// <summary>
-        /// Returns a read-only list of known accounts so login UIs can present existing
-        /// characters.
-        /// </summary>
-        public static IReadOnlyList<AccountEntry> Accounts
+        private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions
         {
-            get
-            {
-                var collection = EnsureCollection();
-                return collection.Accounts;
-            }
+            AllowTrailingCommas = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            IgnoreUnknownProperties = true,
+            IncludeFields = true,
+            PropertyNameCaseInsensitive = true,
+            ReadCommentHandling = JsonCommentHandling.Skip,
+            WriteIndented = true,
+        };
+
+        static AccountManager()
+        {
+            EnsureBaseDirectory();
         }
 
         /// <summary>
-        /// Attempts to authenticate or create an account with the provided credentials. Use
-        /// this overload when the caller is not interested in the detailed status message.
+        /// Sanitises the supplied username into a slug suitable for filenames and profile IDs.
+        /// Characters outside the [a-z0-9_-] range are discarded and whitespace becomes underscores.
         /// </summary>
-        public static bool TryAuthenticate(string username, string password, out bool created)
+        /// <param name="input">Raw username supplied by the player.</param>
+        /// <returns>Lowercase slug that can be used safely for filenames.</returns>
+        public static string SanitizeUsername(string input)
         {
-            return TryAuthenticate(username, password, out created, out _, out _);
-        }
-
-        /// <summary>
-        /// Attempts to authenticate the supplied credentials. A new account is created when
-        /// the username has not been seen before; otherwise the password must match the stored
-        /// hash. The method always normalises the username before storing it so profile IDs can
-        /// be used safely with <see cref="SaveManager"/>.
-        /// </summary>
-        /// <param name="username">Raw username entered by the player.</param>
-        /// <param name="password">Plain text password supplied by the player.</param>
-        /// <param name="created">Outputs true when an account was created during this call.</param>
-        /// <param name="entry">Outputs the account entry that matches the credentials.</param>
-        /// <param name="statusMessage">Describes the result in a player-friendly manner.</param>
-        /// <returns>True when the authentication succeeded.</returns>
-        public static bool TryAuthenticate(string username, string password, out bool created, out AccountEntry entry, out string statusMessage)
-        {
-            created = false;
-            entry = null;
-            statusMessage = string.Empty;
-
-            if (string.IsNullOrWhiteSpace(username))
-            {
-                statusMessage = "Enter a username to begin.";
-                return false;
-            }
-
-            if (string.IsNullOrEmpty(password))
-            {
-                statusMessage = "Enter your password.";
-                return false;
-            }
-
-            string displayName = username.Trim();
-            string normalized = NormalizeUsername(displayName);
-
-            if (string.IsNullOrEmpty(normalized))
-            {
-                statusMessage = "Usernames must include at least one letter or number.";
-                return false;
-            }
-
-            var collection = EnsureCollection();
-            entry = collection.FindByProfileId(normalized);
-
-            if (entry == null)
-            {
-                entry = CreateAccount(displayName, normalized, password);
-                collection.Add(entry);
-                created = true;
-                statusMessage = $"Created new account for {displayName}.";
-                SaveCollection();
-                return true;
-            }
-
-            byte[] saltBytes;
-            byte[] storedHash;
-            try
-            {
-                saltBytes = Convert.FromBase64String(entry.Salt);
-                storedHash = Convert.FromBase64String(entry.PasswordHash);
-            }
-            catch (Exception)
-            {
-                statusMessage = "Account data is corrupted. Please recreate the profile.";
-                return false;
-            }
-
-            var computedHash = HashPassword(saltBytes, password);
-
-            if (!ConstantTimeEquals(storedHash, computedHash))
-            {
-                statusMessage = "Incorrect password.";
-                return false;
-            }
-
-            entry.RefreshDisplayName(displayName);
-            statusMessage = $"Welcome back, {entry.DisplayName}.";
-            SaveCollection();
-            return true;
-        }
-
-        /// <summary>
-        /// Activates the supplied account by selecting its profile in the save manager and
-        /// recording the last-used identifier for future sessions.
-        /// </summary>
-        /// <param name="entry">Account that should become active.</param>
-        /// <returns>A user-facing status message describing the result.</returns>
-        public static string ActivateAccount(AccountEntry entry)
-        {
-            if (entry == null)
-                return "No account selected.";
-
-            SaveManager.SetActiveProfile(entry.ProfileId);
-            activeAccount = entry;
-
-            var collection = EnsureCollection();
-            collection.LastUsedProfileId = entry.ProfileId;
-            SaveCollection();
-
-            return $"Logged in as {entry.DisplayName}.";
-        }
-
-        /// <summary>
-        /// Returns the display name for the most recently used account, allowing UI layers to
-        /// pre-fill login forms.
-        /// </summary>
-        public static string GetLastUsedDisplayName()
-        {
-            var collection = EnsureCollection();
-            var entry = collection.FindByProfileId(collection.LastUsedProfileId);
-            return entry != null ? entry.DisplayName : string.Empty;
-        }
-
-        /// <summary>
-        /// Normalises a username so it is suitable for use as a profile identifier. Whitespace
-        /// is removed, characters are lowercased, and colon characters are replaced with
-        /// underscores so the save key prefix remains valid.
-        /// </summary>
-        public static string NormalizeUsername(string username)
-        {
-            if (string.IsNullOrWhiteSpace(username))
+            if (string.IsNullOrWhiteSpace(input))
                 return string.Empty;
 
-            string trimmed = username.Trim();
-            var builder = new StringBuilder(trimmed.Length);
-            for (int i = 0; i < trimmed.Length; i++)
+            var builder = new StringBuilder(input.Length);
+            bool previousUnderscore = false;
+
+            for (int i = 0; i < input.Length; i++)
             {
-                char c = char.ToLowerInvariant(trimmed[i]);
+                char c = char.ToLowerInvariant(input[i]);
+
                 if (char.IsWhiteSpace(c))
+                {
+                    if (!previousUnderscore && builder.Length > 0)
+                    {
+                        builder.Append('_');
+                        previousUnderscore = true;
+                    }
                     continue;
-                if (c == ':')
-                    c = '_';
-                builder.Append(c);
+                }
+
+                if (c >= 'a' && c <= 'z' || c >= '0' && c <= '9' || c == '-' || c == '_')
+                {
+                    builder.Append(c);
+                    previousUnderscore = c == '_';
+                }
             }
 
-            return builder.Length > 0 ? builder.ToString() : string.Empty;
+            return builder.ToString();
         }
 
-        private static AccountEntry CreateAccount(string displayName, string normalizedProfileId, string password)
+        /// <summary>
+        /// Resolves the JSON path for an account file using either the raw username or an existing slug.
+        /// </summary>
+        /// <param name="usernameOrSlug">Raw username entered by the player or a pre-sanitised slug.</param>
+        /// <returns>Absolute path to the JSON save file.</returns>
+        public static string GetAccountPath(string usernameOrSlug)
         {
-            var salt = new byte[SaltSize];
+            string slug = SanitizeUsername(usernameOrSlug);
+            return string.IsNullOrEmpty(slug)
+                ? Path.Combine(BaseSavePath, "account.json")
+                : Path.Combine(BaseSavePath, $"{slug}.json");
+        }
+
+        /// <summary>
+        /// Attempts to load an account save file using the provided username or slug.
+        /// </summary>
+        /// <param name="username">Raw username supplied by the player.</param>
+        /// <param name="save">Outputs the loaded account when successful.</param>
+        /// <returns>True when a matching account file was found and deserialised.</returns>
+        public static bool TryLoadAccount(string username, out AccountSave save)
+        {
+            save = null;
+
+            string slug = SanitizeUsername(username);
+            if (string.IsNullOrEmpty(slug))
+                return false;
+
+            string path = GetAccountPath(slug);
+            if (!File.Exists(path))
+                return false;
+
+            try
+            {
+                string json = File.ReadAllText(path, Encoding.UTF8);
+                var loaded = JsonSerializer.Deserialize<AccountSave>(json, SerializerOptions);
+                if (loaded == null)
+                    return false;
+
+                EnsureDefaults(loaded, slug, username);
+                save = loaded;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"AccountManager: Failed to load account '{slug}': {ex}");
+                save = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new account save with default data and hashed credentials.
+        /// </summary>
+        /// <param name="username">Username entered by the player.</param>
+        /// <param name="rawPassword">Plain text password to hash.</param>
+        /// <returns>Initialised account save ready for persistence.</returns>
+        public static AccountSave CreateNewAccount(string username, string rawPassword)
+        {
+            if (string.IsNullOrWhiteSpace(username))
+                throw new ArgumentException("Username is required.", nameof(username));
+            if (string.IsNullOrEmpty(rawPassword))
+                throw new ArgumentException("Password is required.", nameof(rawPassword));
+
+            string slug = SanitizeUsername(username);
+            if (string.IsNullOrEmpty(slug))
+                throw new ArgumentException("Username must include at least one valid character.", nameof(username));
+
+            var salt = new byte[SaltSizeBytes];
             RandomNumberGenerator.Fill(salt);
-            var hash = HashPassword(salt, password);
+            byte[] hash = HashPassword(rawPassword, salt);
 
-            return new AccountEntry(displayName, normalizedProfileId, Convert.ToBase64String(salt), Convert.ToBase64String(hash));
+            string now = DateTime.UtcNow.ToString("O");
+
+            var save = new AccountSave
+            {
+                schemaVersion = 1,
+                username = username.Trim(),
+                usernameSlug = slug,
+                passwordHash = Convert.ToBase64String(hash),
+                passwordSalt = Convert.ToBase64String(salt),
+                savedSceneName = DefaultSceneName,
+                savedX = 0f,
+                savedY = 0f,
+                createdAtUtc = now,
+                lastLoginUtc = now,
+                data = new AccountSave.AccountData
+                {
+                    version = SaveManager.SaveDataVersion,
+                    entries = new List<AccountSave.AccountDataEntry>(),
+                },
+            };
+
+            return save;
         }
 
-        private static byte[] HashPassword(byte[] salt, string password)
+        /// <summary>
+        /// Validates a password against the stored PBKDF2 hash using constant-time comparison.
+        /// </summary>
+        /// <param name="save">Account data loaded from disk.</param>
+        /// <param name="rawPassword">Password entered by the player.</param>
+        /// <returns>True when the password matches the stored hash.</returns>
+        public static bool VerifyPassword(AccountSave save, string rawPassword)
         {
-            if (salt == null)
-                throw new ArgumentNullException(nameof(salt));
-            if (password == null)
-                throw new ArgumentNullException(nameof(password));
+            if (save == null)
+                throw new ArgumentNullException(nameof(save));
+            if (rawPassword == null)
+                throw new ArgumentNullException(nameof(rawPassword));
 
-            var passwordBytes = Encoding.UTF8.GetBytes(password);
-            var buffer = new byte[salt.Length + passwordBytes.Length];
-            Buffer.BlockCopy(salt, 0, buffer, 0, salt.Length);
-            Buffer.BlockCopy(passwordBytes, 0, buffer, salt.Length, passwordBytes.Length);
+            if (string.IsNullOrEmpty(save.passwordSalt) || string.IsNullOrEmpty(save.passwordHash))
+                return false;
 
-            using var sha = SHA256.Create();
-            return sha.ComputeHash(buffer);
+            try
+            {
+                byte[] salt = Convert.FromBase64String(save.passwordSalt);
+                byte[] storedHash = Convert.FromBase64String(save.passwordHash);
+                byte[] computed = HashPassword(rawPassword, salt);
+                return ConstantTimeEquals(storedHash, computed);
+            }
+            catch (FormatException)
+            {
+                Debug.LogError($"AccountManager: Stored credentials for '{save.usernameSlug}' are corrupted.");
+                return false;
+            }
         }
 
-        private static bool ConstantTimeEquals(byte[] a, byte[] b)
+        /// <summary>
+        /// Saves the supplied account to disk using atomic file replacement.
+        /// </summary>
+        /// <param name="save">Account that should be persisted.</param>
+        public static async Task SaveAsync(AccountSave save)
         {
-            if (a == null || b == null || a.Length != b.Length)
+            if (save == null)
+                throw new ArgumentNullException(nameof(save));
+
+            EnsureBaseDirectory();
+            EnsureDefaults(save, save.usernameSlug, save.username);
+
+            save.lastLoginUtc = DateTime.UtcNow.ToString("O");
+
+            string path = GetAccountPath(save.usernameSlug);
+            string tempPath = path + ".tmp";
+            string json = JsonSerializer.Serialize(save, SerializerOptions);
+
+            try
+            {
+                await Task.Run(() =>
+                {
+                    File.WriteAllText(tempPath, json, Encoding.UTF8);
+                    if (File.Exists(path))
+                    {
+                        File.Replace(tempPath, path, null);
+                    }
+                    else
+                    {
+#if NETSTANDARD2_1 || NETCOREAPP
+                        File.Move(tempPath, path, overwrite: true);
+#else
+                        if (File.Exists(path))
+                            File.Delete(path);
+                        File.Move(tempPath, path);
+#endif
+                    }
+                }).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"AccountManager: Failed to persist account '{save.usernameSlug}': {ex}");
+                throw;
+            }
+            finally
+            {
+                try
+                {
+                    if (File.Exists(tempPath))
+                        File.Delete(tempPath);
+                }
+                catch
+                {
+                    // Ignored; temp cleanup best-effort.
+                }
+            }
+        }
+
+        /// <summary>
+        /// Provides the filesystem directory used for per-account saves so other systems can
+        /// reference it when needed (e.g., global data migration helpers).
+        /// </summary>
+        internal static string BaseDirectory => BaseSavePath;
+
+        private static void EnsureDefaults(AccountSave save, string slug, string username)
+        {
+            if (save == null)
+                return;
+
+            if (save.schemaVersion <= 0)
+                save.schemaVersion = 1;
+
+            if (string.IsNullOrEmpty(save.usernameSlug))
+                save.usernameSlug = SanitizeUsername(slug);
+
+            if (string.IsNullOrEmpty(save.username) && !string.IsNullOrWhiteSpace(username))
+                save.username = username.Trim();
+
+            if (save.data == null)
+            {
+                save.data = new AccountSave.AccountData
+                {
+                    version = SaveManager.SaveDataVersion,
+                    entries = new List<AccountSave.AccountDataEntry>(),
+                };
+            }
+            else
+            {
+                if (save.data.entries == null)
+                    save.data.entries = new List<AccountSave.AccountDataEntry>();
+                if (save.data.version != SaveManager.SaveDataVersion)
+                    save.data.version = SaveManager.SaveDataVersion;
+            }
+
+            if (string.IsNullOrEmpty(save.savedSceneName))
+                save.savedSceneName = DefaultSceneName;
+        }
+
+        private static byte[] HashPassword(string password, byte[] salt)
+        {
+            using var pbkdf2 = new Rfc2898DeriveBytes(password, salt, Pbkdf2Iterations, HashAlgorithmName.SHA256);
+            return pbkdf2.GetBytes(Pbkdf2KeySizeBytes);
+        }
+
+        private static bool ConstantTimeEquals(IReadOnlyList<byte> left, IReadOnlyList<byte> right)
+        {
+            if (left == null || right == null || left.Count != right.Count)
                 return false;
 
             int diff = 0;
-            for (int i = 0; i < a.Length; i++)
-                diff |= a[i] ^ b[i];
-
+            for (int i = 0; i < left.Count; i++)
+                diff |= left[i] ^ right[i];
             return diff == 0;
         }
 
-        private static AccountCollection EnsureCollection()
+        private static void EnsureBaseDirectory()
         {
-            if (cache != null)
-                return cache;
-
-            cache = SaveManager.LoadGlobal<AccountCollection>(AccountsKey);
-            if (cache == null)
-                cache = new AccountCollection();
-
-            return cache;
-        }
-
-        private static void SaveCollection()
-        {
-            if (cache == null)
-                return;
-
-            SaveManager.SaveGlobal(AccountsKey, cache);
-        }
-    }
-
-    /// <summary>
-    /// Serializable container stored in the global save file that tracks every known account
-    /// as well as the last-used identifier.
-    /// </summary>
-    [Serializable]
-    public sealed class AccountCollection
-    {
-        [SerializeField]
-        private List<AccountEntry> accounts = new List<AccountEntry>();
-
-        [SerializeField]
-        private string lastUsedProfileId = string.Empty;
-
-        /// <summary>
-        /// Read-only view of the stored accounts.
-        /// </summary>
-        public IReadOnlyList<AccountEntry> Accounts => accounts;
-
-        /// <summary>
-        /// Identifier of the most recently authenticated account.
-        /// </summary>
-        public string LastUsedProfileId
-        {
-            get => lastUsedProfileId;
-            set => lastUsedProfileId = value;
-        }
-
-        /// <summary>
-        /// Adds a new account entry to the collection.
-        /// </summary>
-        public void Add(AccountEntry entry)
-        {
-            if (entry == null)
-                throw new ArgumentNullException(nameof(entry));
-            accounts.Add(entry);
-        }
-
-        /// <summary>
-        /// Finds the stored account that matches the provided profile identifier.
-        /// </summary>
-        public AccountEntry FindByProfileId(string profileId)
-        {
-            if (string.IsNullOrEmpty(profileId))
-                return null;
-
-            for (int i = 0; i < accounts.Count; i++)
+            try
             {
-                var candidate = accounts[i];
-                if (candidate == null)
-                    continue;
-                if (string.Equals(candidate.ProfileId, profileId, StringComparison.Ordinal))
-                    return candidate;
+                Directory.CreateDirectory(BaseSavePath);
             }
-
-            return null;
+            catch (Exception ex)
+            {
+                Debug.LogError($"AccountManager: Failed to create save directory at '{BaseSavePath}': {ex}");
+            }
         }
     }
 
     /// <summary>
-    /// Serialized representation of an account, including the display name shown to the player
-    /// and the salted password hash used to validate credentials.
+    /// Serializable DTO that represents a single account, including credentials and gameplay state.
     /// </summary>
     [Serializable]
-    public sealed class AccountEntry
+    public sealed class AccountSave
     {
-        [SerializeField]
-        private string displayName;
+        public int schemaVersion;
+        public string username;
+        public string usernameSlug;
+        public string passwordHash;
+        public string passwordSalt;
+        public string savedSceneName;
+        public float savedX;
+        public float savedY;
+        public string createdAtUtc;
+        public string lastLoginUtc;
+        public AccountData data = new AccountData();
 
-        [SerializeField]
-        private string profileId;
-
-        [SerializeField]
-        private string salt;
-
-        [SerializeField]
-        private string passwordHash;
-
-        /// <summary>
-        /// Parameterless constructor required for serialization.
-        /// </summary>
-        public AccountEntry()
+        [Serializable]
+        public sealed class AccountData
         {
+            public int version = SaveManager.SaveDataVersion;
+            public List<AccountDataEntry> entries = new List<AccountDataEntry>();
         }
 
-        public AccountEntry(string displayName, string profileId, string salt, string passwordHash)
+        [Serializable]
+        public sealed class AccountDataEntry
         {
-            this.displayName = displayName;
-            this.profileId = profileId;
-            this.salt = salt;
-            this.passwordHash = passwordHash;
-        }
-
-        /// <summary>
-        /// Name presented to the player inside menus.
-        /// </summary>
-        public string DisplayName => displayName;
-
-        /// <summary>
-        /// Normalised identifier used to select save data.
-        /// </summary>
-        public string ProfileId => profileId;
-
-        /// <summary>
-        /// Base64 encoded salt used when hashing the password.
-        /// </summary>
-        public string Salt => salt;
-
-        /// <summary>
-        /// Base64 encoded salted password hash.
-        /// </summary>
-        public string PasswordHash => passwordHash;
-
-        /// <summary>
-        /// Updates the display name without altering the stored credentials.
-        /// </summary>
-        public void RefreshDisplayName(string value)
-        {
-            if (!string.IsNullOrWhiteSpace(value))
-                displayName = value.Trim();
+            public string key;
+            public string value;
         }
     }
 }

--- a/Assets/Scripts/Core/Save/SaveManager.cs
+++ b/Assets/Scripts/Core/Save/SaveManager.cs
@@ -1,3 +1,4 @@
+// Refactor: OSRS-style login with per-account saves; removed Overworld hop; atomic file IO; PBKDF2.
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -7,34 +8,37 @@ using UnityEngine;
 namespace Core.Save
 {
     /// <summary>
-    /// Simple JSON based save manager with versioning and a file backend
-    /// stored under a project-root folder for debugging.
-    /// Consider Application.persistentDataPath for builds.
+    /// Simple JSON based save manager that now persists per-account data managed by <see cref="AccountManager"/>.
+    /// The manager still coordinates registered saveables but writes through to the active account file.
     /// </summary>
     public static class SaveManager
     {
-        private const int Version = 1;
-        // Editor/debug path; consider Application.persistentDataPath for builds.
-        private static readonly string FilePath = Path.Combine(Application.dataPath, "../PlayerSave/save_data.json");
+        public const int SaveDataVersion = 1;
 
-        // Registered saveable objects
         private static readonly List<ISaveable> saveables = new List<ISaveable>();
+        private static readonly string GlobalFilePath = Path.Combine(AccountManager.BaseDirectory, "global_state.json");
 
-        /// <summary>
-        /// Identifier for the profile whose data should be loaded and saved. When empty the
-        /// manager behaves like the legacy single-profile implementation.
-        /// </summary>
         public static string ActiveProfileId { get; private set; } = string.Empty;
+
+        private static AccountSave boundAccount;
+        private static AccountSave.AccountData cache;
+        private static bool cacheDirty;
+
+        private static GlobalData globalCache;
 
         static SaveManager()
         {
-            // Ensure all data is persisted when the application quits
-            Application.quitting += SaveAll;
+            Application.quitting += HandleApplicationQuitting;
+        }
+
+        private static void HandleApplicationQuitting()
+        {
+            SaveAll();
         }
 
         /// <summary>
-        /// Register a saveable object with the manager. The object will immediately
-        /// load its state and will be included in future SaveAll calls.
+        /// Register a saveable object with the manager. The object will immediately load its state
+        /// and will be included in future SaveAll calls.
         /// </summary>
         public static void Register(ISaveable saveable)
         {
@@ -55,12 +59,14 @@ namespace Core.Save
         }
 
         /// <summary>
-        /// Invoke Save on all registered saveable objects.
+        /// Invoke Save on all registered saveable objects and flush the active account to disk.
         /// </summary>
         public static void SaveAll()
         {
             foreach (var s in saveables)
                 s.Save();
+
+            FlushActiveAccount();
         }
 
         /// <summary>
@@ -73,98 +79,35 @@ namespace Core.Save
         }
 
         /// <summary>
-        /// Normalises and activates a profile for subsequent save and load operations. The
-        /// previous profile is saved before switching and the new profile can be reloaded so
-        /// gameplay systems pick up their persisted state immediately.
+        /// Binds the manager to a specific account so Save/Load operations map into that account's data store.
         /// </summary>
-        /// <param name="profileId">Raw profile identifier supplied by the caller.</param>
-        /// <param name="reload">When true the manager invokes <see cref="LoadAll"/> after
-        /// switching so registered systems refresh their state.</param>
-        public static void SetActiveProfile(string profileId, bool reload = true)
+        /// <param name="account">Account save that should become active.</param>
+        /// <param name="reload">When true, triggers <see cref="LoadAll"/> after switching accounts.</param>
+        internal static void BindAccount(AccountSave account, bool reload = true)
         {
-            string normalized = NormalizeProfileId(profileId);
+            boundAccount = account;
+            cache = null;
+            cacheDirty = false;
+            ActiveProfileId = account != null ? account.usernameSlug : string.Empty;
 
-            if (string.Equals(normalized, ActiveProfileId, StringComparison.Ordinal))
+            if (boundAccount != null)
             {
-                if (reload)
-                    LoadAll();
-                return;
+                if (string.IsNullOrEmpty(boundAccount.usernameSlug))
+                    boundAccount.usernameSlug = AccountManager.SanitizeUsername(boundAccount.username);
+
+                if (boundAccount.data == null)
+                    boundAccount.data = new AccountSave.AccountData { version = SaveDataVersion, entries = new List<AccountSave.AccountDataEntry>() };
+                else
+                {
+                    if (boundAccount.data.entries == null)
+                        boundAccount.data.entries = new List<AccountSave.AccountDataEntry>();
+                    if (boundAccount.data.version != SaveDataVersion)
+                        boundAccount.data.version = SaveDataVersion;
+                }
             }
-
-            if (!string.IsNullOrEmpty(ActiveProfileId))
-                SaveAll();
-
-            ActiveProfileId = normalized;
 
             if (reload)
                 LoadAll();
-        }
-
-        [Serializable]
-        private class Entry
-        {
-            public string key;
-            public string value;
-        }
-
-        [Serializable]
-        private class SaveData
-        {
-            public int version;
-            public List<Entry> entries = new List<Entry>();
-        }
-
-        [Serializable]
-        private class Wrapper<T>
-        {
-            public T value;
-        }
-
-        private static SaveData cache;
-
-        private static SaveData LoadFile()
-        {
-            if (cache != null)
-                return cache;
-
-            if (File.Exists(FilePath))
-            {
-                try
-                {
-                    string json = File.ReadAllText(FilePath);
-                    cache = JsonUtility.FromJson<SaveData>(json);
-                }
-                catch (Exception e)
-                {
-                    Debug.LogError($"Failed to read save file: {e}");
-                }
-            }
-
-            if (cache == null || cache.version != Version || cache.entries == null)
-            {
-                cache = new SaveData { version = Version, entries = new List<Entry>() };
-            }
-
-            return cache;
-        }
-
-        private static void SaveFile()
-        {
-            try
-            {
-                Directory.CreateDirectory(Path.GetDirectoryName(FilePath));
-                string json = JsonUtility.ToJson(cache);
-                File.WriteAllText(FilePath, json);
-            }
-            catch (Exception e)
-            {
-                Debug.LogError($"Failed to write save file: {e}");
-            }
-        }
-
-        public static void Save<T>(string key, T data)
-        {
-            SaveInternal(ComposeKey(key), data);
         }
 
         /// <summary>
@@ -173,40 +116,24 @@ namespace Core.Save
         /// </summary>
         public static void SaveGlobal<T>(string key, T data)
         {
-            SaveInternal(key, data);
-        }
-
-        private static void SaveInternal<T>(string key, T data)
-        {
-            var all = LoadFile();
+            var store = LoadGlobalStore();
             string json = JsonUtility.ToJson(new Wrapper<T> { value = data });
-            var entry = all.entries.Find(e => e.key == key);
+            var entry = store.entries.Find(e => e.key == key);
             if (entry != null)
                 entry.value = json;
             else
-                all.entries.Add(new Entry { key = key, value = json });
+                store.entries.Add(new GlobalEntry { key = key, value = json });
 
-            SaveFile();
-        }
-
-        public static T Load<T>(string key)
-        {
-            return LoadInternal<T>(ComposeKey(key));
+            SaveGlobalStore();
         }
 
         /// <summary>
-        /// Loads a value stored without a profile prefix. Use this for global data such as the
-        /// account catalogue maintained by <see cref="AccountProfileService"/>.
+        /// Loads a value stored without a profile prefix.
         /// </summary>
         public static T LoadGlobal<T>(string key)
         {
-            return LoadInternal<T>(key);
-        }
-
-        private static T LoadInternal<T>(string key)
-        {
-            var all = LoadFile();
-            var entry = all.entries.Find(e => e.key == key);
+            var store = LoadGlobalStore();
+            var entry = store.entries.Find(e => e.key == key);
             if (entry == null || string.IsNullOrEmpty(entry.value))
                 return default;
 
@@ -221,24 +148,127 @@ namespace Core.Save
             }
         }
 
+        /// <summary>
+        /// Removes a value stored without a profile prefix.
+        /// </summary>
+        public static void DeleteGlobal(string key)
+        {
+            var store = LoadGlobalStore();
+            if (store.entries.RemoveAll(e => e.key == key) > 0)
+                SaveGlobalStore();
+        }
+
+        public static void Save<T>(string key, T data)
+        {
+            SaveInternal(ComposeKey(key), data);
+        }
+
+        public static T Load<T>(string key)
+        {
+            return LoadInternal<T>(ComposeKey(key));
+        }
+
         public static void Delete(string key)
         {
             DeleteInternal(ComposeKey(key));
         }
 
         /// <summary>
-        /// Removes a value stored without a profile prefix.
+        /// Normalises and activates a profile for subsequent save and load operations. Provided for
+        /// backwards compatibility; prefer <see cref="BindAccount"/> when authenticating users.
         /// </summary>
-        public static void DeleteGlobal(string key)
+        public static void SetActiveProfile(string profileId, bool reload = true)
         {
-            DeleteInternal(key);
+            ActiveProfileId = NormalizeProfileId(profileId);
+            cache = null;
+            cacheDirty = false;
+
+            if (reload)
+                LoadAll();
+        }
+
+        private static void SaveInternal<T>(string key, T data)
+        {
+            var store = EnsureDataStore();
+            string json = JsonUtility.ToJson(new Wrapper<T> { value = data });
+            var entry = store.entries.Find(e => e.key == key);
+            if (entry != null)
+                entry.value = json;
+            else
+                store.entries.Add(new AccountSave.AccountDataEntry { key = key, value = json });
+
+            cacheDirty = true;
+            FlushActiveAccount();
+        }
+
+        private static T LoadInternal<T>(string key)
+        {
+            var store = EnsureDataStore();
+            var entry = store.entries.Find(e => e.key == key);
+            if (entry == null || string.IsNullOrEmpty(entry.value))
+                return default;
+
+            try
+            {
+                var wrapper = JsonUtility.FromJson<Wrapper<T>>(entry.value);
+                return wrapper != null ? wrapper.value : default;
+            }
+            catch
+            {
+                return default;
+            }
         }
 
         private static void DeleteInternal(string key)
         {
-            var all = LoadFile();
-            all.entries.RemoveAll(e => e.key == key);
-            SaveFile();
+            var store = EnsureDataStore();
+            if (store.entries.RemoveAll(e => e.key == key) > 0)
+            {
+                cacheDirty = true;
+                FlushActiveAccount();
+            }
+        }
+
+        private static AccountSave.AccountData EnsureDataStore()
+        {
+            if (cache != null)
+                return cache;
+
+            if (boundAccount != null)
+            {
+                cache = boundAccount.data ?? new AccountSave.AccountData();
+                if (cache.entries == null)
+                    cache.entries = new List<AccountSave.AccountDataEntry>();
+                if (cache.version != SaveDataVersion)
+                    cache.version = SaveDataVersion;
+                boundAccount.data = cache;
+            }
+            else
+            {
+                cache = new AccountSave.AccountData
+                {
+                    version = SaveDataVersion,
+                    entries = new List<AccountSave.AccountDataEntry>(),
+                };
+            }
+
+            return cache;
+        }
+
+        private static void FlushActiveAccount()
+        {
+            if (!cacheDirty || boundAccount == null)
+                return;
+
+            try
+            {
+                AccountManager.SaveAsync(boundAccount).GetAwaiter().GetResult();
+                cacheDirty = false;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"SaveManager: Failed to persist account '{boundAccount.usernameSlug}': {ex}");
+            }
         }
 
         private static string ComposeKey(string key)
@@ -251,22 +281,96 @@ namespace Core.Save
 
         private static string NormalizeProfileId(string profileId)
         {
-            if (string.IsNullOrWhiteSpace(profileId))
-                return string.Empty;
+            return AccountManager.SanitizeUsername(profileId);
+        }
 
-            string trimmed = profileId.Trim();
-            var builder = new StringBuilder(trimmed.Length);
-            for (int i = 0; i < trimmed.Length; i++)
+        [Serializable]
+        private sealed class Wrapper<T>
+        {
+            public T value;
+        }
+
+        [Serializable]
+        private sealed class GlobalEntry
+        {
+            public string key;
+            public string value;
+        }
+
+        [Serializable]
+        private sealed class GlobalData
+        {
+            public List<GlobalEntry> entries = new List<GlobalEntry>();
+        }
+
+        private static GlobalData LoadGlobalStore()
+        {
+            if (globalCache != null)
+                return globalCache;
+
+            try
             {
-                char c = char.ToLowerInvariant(trimmed[i]);
-                if (char.IsWhiteSpace(c))
-                    continue;
-                if (c == ':')
-                    c = '_';
-                builder.Append(c);
+                Directory.CreateDirectory(AccountManager.BaseDirectory);
+                if (File.Exists(GlobalFilePath))
+                {
+                    string json = File.ReadAllText(GlobalFilePath, Encoding.UTF8);
+                    globalCache = JsonUtility.FromJson<GlobalData>(json);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"SaveManager: Failed to read global save file: {ex}");
             }
 
-            return builder.Length > 0 ? builder.ToString() : string.Empty;
+            if (globalCache == null || globalCache.entries == null)
+                globalCache = new GlobalData { entries = new List<GlobalEntry>() };
+
+            return globalCache;
+        }
+
+        private static void SaveGlobalStore()
+        {
+            if (globalCache == null)
+                return;
+
+            string tempPath = GlobalFilePath + ".tmp";
+
+            try
+            {
+                Directory.CreateDirectory(AccountManager.BaseDirectory);
+                string json = JsonUtility.ToJson(globalCache);
+                File.WriteAllText(tempPath, json, Encoding.UTF8);
+                if (File.Exists(GlobalFilePath))
+                {
+                    File.Replace(tempPath, GlobalFilePath, null);
+                }
+                else
+                {
+#if NETSTANDARD2_1 || NETCOREAPP
+                    File.Move(tempPath, GlobalFilePath, overwrite: true);
+#else
+                    if (File.Exists(GlobalFilePath))
+                        File.Delete(GlobalFilePath);
+                    File.Move(tempPath, GlobalFilePath);
+#endif
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"SaveManager: Failed to write global save file: {ex}");
+            }
+            finally
+            {
+                try
+                {
+                    if (File.Exists(tempPath))
+                        File.Delete(tempPath);
+                }
+                catch
+                {
+                    // Ignore temp cleanup failure.
+                }
+            }
         }
     }
 }

--- a/Assets/Scripts/Player/PlayerLocator.cs
+++ b/Assets/Scripts/Player/PlayerLocator.cs
@@ -1,8 +1,6 @@
-// ------------------------------------------------------------------------------
-// CHANGES: Introduced a shared helper for resolving the active Player instance
-// after a scene load so login resume and other systems can safely locate the
-// in-scene prefab without instantiating duplicates.
-// ------------------------------------------------------------------------------
+// Refactor: OSRS-style login with per-account saves; removed Overworld hop; atomic file IO; PBKDF2.
+using System;
+using System.Reflection;
 using UnityEngine;
 
 namespace Player
@@ -19,26 +17,118 @@ namespace Player
         /// <returns>True when a player object could be resolved.</returns>
         public static bool TryFindPlayer(out GameObject player)
         {
-            player = GameObject.FindWithTag("Player");
+            player = TryFindByTag();
             if (player != null)
                 return true;
 
-            var mover = Object.FindObjectOfType<PlayerMover>(true);
-            if (mover != null)
-            {
-                player = mover.gameObject;
+            player = TryFindByController();
+            if (player != null)
                 return true;
-            }
 
-            var hitpoints = Object.FindObjectOfType<PlayerHitpoints>(true);
-            if (hitpoints != null)
-            {
-                player = hitpoints.gameObject;
+            player = TryFindByComponent<PlayerMover>();
+            if (player != null)
                 return true;
-            }
+
+            player = TryFindByComponent<PlayerHitpoints>();
+            if (player != null)
+                return true;
 
             player = null;
             return false;
+        }
+
+        private static GameObject TryFindByTag()
+        {
+            try
+            {
+                return GameObject.FindWithTag("Player");
+            }
+            catch (UnityException)
+            {
+                return null;
+            }
+        }
+
+        private static GameObject TryFindByController()
+        {
+            var controller = ResolveComponentByType("Player.PlayerController, Assembly-CSharp")
+                ?? ResolveComponentByType("PlayerController, Assembly-CSharp");
+            return controller != null ? controller.gameObject : null;
+        }
+
+        private static GameObject TryFindByComponent<T>() where T : Component
+        {
+            var component = UnityEngine.Object.FindFirstObjectByType<T>(FindObjectsInactive.Include);
+            return component != null ? component.gameObject : null;
+        }
+
+        private static Component ResolveComponentByType(string typeName)
+        {
+            var type = Type.GetType(typeName);
+            if (type == null)
+                return null;
+
+            var instance = InvokeFindFirstObjectByType(type);
+            if (instance is Component component && component != null)
+                return component;
+            if (instance is GameObject obj)
+                return obj.GetComponent(type);
+
+            var all = Resources.FindObjectsOfTypeAll(type);
+            for (int i = 0; i < all.Length; i++)
+            {
+                switch (all[i])
+                {
+                    case Component comp when comp.gameObject.scene.IsValid():
+                        return comp;
+                    case GameObject go when go.scene.IsValid():
+                        var resolved = go.GetComponent(type);
+                        if (resolved != null)
+                            return resolved;
+                        break;
+                }
+            }
+
+            return null;
+        }
+
+        private static object InvokeFindFirstObjectByType(Type type)
+        {
+            try
+            {
+                var methods = typeof(UnityEngine.Object).GetMethods(BindingFlags.Public | BindingFlags.Static);
+                for (int i = 0; i < methods.Length; i++)
+                {
+                    var candidate = methods[i];
+                    if (!candidate.IsGenericMethodDefinition || candidate.Name != "FindFirstObjectByType")
+                        continue;
+
+                    var parameters = candidate.GetParameters();
+                    object[] args;
+                    if (parameters.Length == 0)
+                    {
+                        args = Array.Empty<object>();
+                    }
+                    else if (parameters.Length == 1 && parameters[0].ParameterType.FullName == "UnityEngine.FindObjectsInactive")
+                    {
+                        var includeValue = Enum.ToObject(parameters[0].ParameterType, 1);
+                        args = new[] { includeValue };
+                    }
+                    else
+                    {
+                        continue;
+                    }
+
+                    var generic = candidate.MakeGenericMethod(type);
+                    return generic.Invoke(null, args);
+                }
+            }
+            catch
+            {
+                // Reflection fallback failures can be ignored.
+            }
+
+            return null;
         }
     }
 }

--- a/Assets/Scripts/UI/Login/LoginFlowController.cs
+++ b/Assets/Scripts/UI/Login/LoginFlowController.cs
@@ -1,10 +1,6 @@
-// ------------------------------------------------------------------------------
-// CHANGES: Added a dedicated login flow controller that loads the saved scene
-// directly, positions the existing Player prefab, and handles fallbacks when the
-// saved data is invalid.
-// ------------------------------------------------------------------------------
+// Refactor: OSRS-style login with per-account saves; removed Overworld hop; atomic file IO; PBKDF2.
 using System;
-using System.Collections;
+using System.Threading.Tasks;
 using Core.Save;
 using Player;
 using UnityEngine;
@@ -19,47 +15,16 @@ namespace UI.Login
     [DisallowMultipleComponent]
     public sealed class LoginFlowController : MonoBehaviour
     {
-        private const string PlayerPositionKey = "PlayerPosition";
-
-        [Header("Fallback Settings")]
-        [SerializeField, Tooltip("Scene to load when the saved scene is unavailable or missing.")]
+        [SerializeField]
         private string fallbackSceneName = "OverWorld";
 
-        [SerializeField, Tooltip("Spawn coordinates used when no saved position exists.")]
+        [SerializeField]
         private Vector2 fallbackSpawnPosition = Vector2.zero;
 
-        [SerializeField, Tooltip("Seconds spent searching for the player after a scene load before declaring failure.")]
+        [SerializeField]
         private float playerSearchTimeout = 5f;
 
         private LoginScreenController loginScreen;
-        private Coroutine loginRoutine;
-
-        [Serializable]
-        private sealed class PlayerPositionRecord
-        {
-            public float x;
-            public float y;
-            public float z;
-            public string scene;
-        }
-
-        private readonly struct TargetLocation
-        {
-            public TargetLocation(string sceneName, Vector2 position, bool applyPosition, string statusMessage, string diagnosticMessage)
-            {
-                SceneName = sceneName;
-                Position = position;
-                ApplyPosition = applyPosition;
-                StatusMessage = statusMessage;
-                DiagnosticMessage = diagnosticMessage;
-            }
-
-            public string SceneName { get; }
-            public Vector2 Position { get; }
-            public bool ApplyPosition { get; }
-            public string StatusMessage { get; }
-            public string DiagnosticMessage { get; }
-        }
 
         private void Awake()
         {
@@ -78,187 +43,116 @@ namespace UI.Login
         /// <summary>
         /// Initiates the scene-loading routine once authentication has completed.
         /// </summary>
-        public void BeginLoginFlow(bool accountCreated)
+        public async Task BeginLoginFlowAsync(AccountSave save)
         {
             if (!isActiveAndEnabled)
                 return;
 
-            if (loginRoutine != null)
-                StopCoroutine(loginRoutine);
+            if (save == null)
+            {
+                ReportError("Save data is missing. Cannot continue into gameplay.");
+                return;
+            }
 
-            loginRoutine = StartCoroutine(BeginLoginFlowRoutine(accountCreated));
-        }
+            string targetScene = string.IsNullOrWhiteSpace(save.savedSceneName) ? fallbackSceneName : save.savedSceneName;
+            Vector2 targetPosition = new Vector2(save.savedX, save.savedY);
 
-        private IEnumerator BeginLoginFlowRoutine(bool accountCreated)
-        {
-            var target = ResolveTargetLocation(accountCreated);
-            if (!string.IsNullOrEmpty(target.DiagnosticMessage))
-                Debug.LogWarning($"LoginFlowController: {target.DiagnosticMessage}", this);
+            if (!CanLoadScene(targetScene))
+            {
+                NotifyFallback($"Saved scene '{targetScene}' is unavailable. Loading fallback scene '{fallbackSceneName}'.");
+                targetScene = fallbackSceneName;
+                targetPosition = fallbackSpawnPosition;
+            }
 
             if (loginScreen != null)
-                loginScreen.SetStatus(target.StatusMessage, loginScreen.InfoColour);
+                loginScreen.SetStatus($"Loading {targetScene}…", loginScreen.InfoColour);
 
-            yield return ResumeFromLocation(target, allowFallback: true);
-
-            loginRoutine = null;
-        }
-
-        private TargetLocation ResolveTargetLocation(bool accountCreated)
-        {
-            var data = SaveManager.Load<PlayerPositionRecord>(PlayerPositionKey);
-            if (data != null && !string.IsNullOrWhiteSpace(data.scene))
+            bool loaded = await TryLoadSceneAsync(targetScene);
+            if (!loaded)
             {
-                if (Application.CanStreamedLevelBeLoaded(data.scene))
+                if (!IsFallbackScene(targetScene))
                 {
-                    return new TargetLocation(
-                        data.scene,
-                        new Vector2(data.x, data.y),
-                        applyPosition: true,
-                        statusMessage: "Restoring last location…",
-                        diagnosticMessage: string.Empty);
+                    NotifyFallback($"Failed to load scene '{targetScene}'. Loading fallback scene '{fallbackSceneName}'.");
+                    targetScene = fallbackSceneName;
+                    targetPosition = fallbackSpawnPosition;
+                    loaded = await TryLoadSceneAsync(targetScene);
                 }
 
-                string diagnostic = $"Saved scene '{data.scene}' is not available. Defaulting to '{fallbackSceneName}'.";
-                return new TargetLocation(
-                    fallbackSceneName,
-                    fallbackSpawnPosition,
-                    applyPosition: true,
-                    statusMessage: "Preparing the overworld…",
-                    diagnosticMessage: diagnostic);
+                if (!loaded)
+                {
+                    ReportError($"Unable to load scene '{targetScene}'.");
+                    return;
+                }
             }
 
-            string status = accountCreated
-                ? "Preparing the overworld…"
-                : "Previous session did not record a location. Preparing the overworld…";
+            await Task.Yield();
 
-            string diagnosticFallback = accountCreated
-                ? string.Empty
-                : "No saved position was found for this profile. Falling back to the overworld.";
-
-            return new TargetLocation(
-                fallbackSceneName,
-                fallbackSpawnPosition,
-                applyPosition: true,
-                statusMessage: status,
-                diagnosticMessage: diagnosticFallback);
-        }
-
-        private IEnumerator ResumeFromLocation(TargetLocation target, bool allowFallback)
-        {
-            DestroyLingeringPlayers();
-
-            bool loadSucceeded = false;
-            string failure = string.Empty;
-
-            yield return LoadSceneRoutine(target.SceneName, () => loadSucceeded = true, message => failure = message);
-
-            if (!loadSucceeded)
-            {
-                string reason = string.IsNullOrEmpty(failure) ? "Unknown failure." : failure;
-                Debug.LogError($"LoginFlowController: Failed to load scene '{target.SceneName}': {reason}", this);
-
-                if (allowFallback && !IsFallbackScene(target.SceneName))
-                {
-                    if (loginScreen != null)
-                        loginScreen.SetStatus("Failed to restore last location. Loading overworld fallback…", loginScreen.ErrorColour);
-
-                    var fallback = CreateFallbackTarget();
-                    if (loginScreen != null)
-                        loginScreen.SetStatus(fallback.StatusMessage, loginScreen.InfoColour);
-
-                    yield return ResumeFromLocation(fallback, false);
-                }
-                else if (loginScreen != null)
-                {
-                    loginScreen.SetStatus($"Failed to load scene '{target.SceneName}'.", loginScreen.ErrorColour);
-                    loginScreen.SetLoginButtonInteractable(true);
-                }
-
-                yield break;
-            }
-
-            yield return null;
-
-            GameObject player = null;
-            yield return AcquirePlayerCoroutine(found => player = found);
-
+            GameObject player = await LocatePlayerAsync();
             if (player == null)
             {
-                Debug.LogError($"LoginFlowController: No Player object was found after loading scene '{target.SceneName}'.", this);
-
-                if (allowFallback && !IsFallbackScene(target.SceneName))
-                {
-                    if (loginScreen != null)
-                        loginScreen.SetStatus("Failed to locate player in saved scene. Loading overworld fallback…", loginScreen.ErrorColour);
-
-                    var fallback = CreateFallbackTarget();
-                    if (loginScreen != null)
-                        loginScreen.SetStatus(fallback.StatusMessage, loginScreen.InfoColour);
-
-                    yield return ResumeFromLocation(fallback, false);
-                }
-                else if (loginScreen != null)
-                {
-                    loginScreen.SetStatus("Unable to locate the player after scene load.", loginScreen.ErrorColour);
-                    loginScreen.SetLoginButtonInteractable(true);
-                }
-
-                yield break;
+                ReportError($"No Player object was found after loading '{targetScene}'.");
+                return;
             }
 
-            CullDuplicatePlayers(player);
-
-            if (target.ApplyPosition)
-            {
-                Vector3 current = player.transform.position;
-                player.transform.position = new Vector3(target.Position.x, target.Position.y, current.z);
-            }
+            Vector3 current = player.transform.position;
+            player.transform.position = new Vector3(targetPosition.x, targetPosition.y, current.z);
 
             EnsureCameraFollow(player);
+
+            if (loginScreen != null)
+                loginScreen.SetStatus("Entering the world…", loginScreen.SuccessColour);
         }
 
-        private IEnumerator LoadSceneRoutine(string sceneName, Action onSuccess, Action<string> onFailure)
+        private bool CanLoadScene(string sceneName)
         {
-            AsyncOperation operation = null;
+            if (string.IsNullOrWhiteSpace(sceneName))
+                return false;
 
+            return Application.CanStreamedLevelBeLoaded(sceneName);
+        }
+
+        private async Task<bool> TryLoadSceneAsync(string sceneName)
+        {
+            if (string.IsNullOrWhiteSpace(sceneName))
+                return false;
+
+            AsyncOperation operation;
             try
             {
                 operation = SceneManager.LoadSceneAsync(sceneName, LoadSceneMode.Single);
             }
             catch (Exception ex)
             {
-                onFailure?.Invoke(ex.Message);
-                yield break;
+                Debug.LogError($"LoginFlowController: Exception while loading scene '{sceneName}': {ex}", this);
+                return false;
             }
 
             if (operation == null)
-            {
-                onFailure?.Invoke("LoadSceneAsync returned null.");
-                yield break;
-            }
+                return false;
 
             while (!operation.isDone)
-                yield return null;
+                await Task.Yield();
 
-            onSuccess?.Invoke();
+            return true;
         }
 
-        private IEnumerator AcquirePlayerCoroutine(Action<GameObject> callback)
+        private async Task<GameObject> LocatePlayerAsync()
         {
-            GameObject player = null;
             float elapsed = 0f;
 
             while (elapsed < playerSearchTimeout)
             {
-                if (PlayerLocator.TryFindPlayer(out player) && player != null)
-                    break;
+                if (PlayerLocator.TryFindPlayer(out GameObject player) && player != null)
+                    return player;
 
-                player = null;
+                await Task.Yield();
                 elapsed += Time.unscaledDeltaTime;
-                yield return null;
             }
 
-            callback?.Invoke(player);
+            if (PlayerLocator.TryFindPlayer(out GameObject fallback) && fallback != null)
+                return fallback;
+
+            return null;
         }
 
         private void EnsureCameraFollow(GameObject player)
@@ -283,61 +177,21 @@ namespace UI.Login
                 followProperty.SetValue(vcams[i], player.transform, null);
         }
 
-        private static void DestroyLingeringPlayers()
+        private void NotifyFallback(string message)
         {
-            GameObject[] players;
-
-            try
-            {
-                players = GameObject.FindGameObjectsWithTag("Player");
-            }
-            catch (UnityException)
-            {
-                return;
-            }
-
-            for (int i = 0; i < players.Length; i++)
-            {
-                var candidate = players[i];
-                if (candidate != null && candidate.scene.name == "DontDestroyOnLoad")
-                    UnityEngine.Object.Destroy(candidate);
-            }
+            Debug.LogWarning($"LoginFlowController: {message}", this);
+            if (loginScreen != null)
+                loginScreen.SetStatus(message, loginScreen.ErrorColour);
         }
 
-        private static void CullDuplicatePlayers(GameObject keep)
+        private void ReportError(string message)
         {
-            if (keep == null)
-                return;
-
-            GameObject[] players;
-
-            try
+            Debug.LogError($"LoginFlowController: {message}", this);
+            if (loginScreen != null)
             {
-                players = GameObject.FindGameObjectsWithTag("Player");
+                loginScreen.SetStatus(message, loginScreen.ErrorColour);
+                loginScreen.SetLoginButtonInteractable(true);
             }
-            catch (UnityException)
-            {
-                return;
-            }
-
-            for (int i = 0; i < players.Length; i++)
-            {
-                var candidate = players[i];
-                if (candidate == null || candidate == keep)
-                    continue;
-
-                UnityEngine.Object.Destroy(candidate);
-            }
-        }
-
-        private TargetLocation CreateFallbackTarget()
-        {
-            return new TargetLocation(
-                fallbackSceneName,
-                fallbackSpawnPosition,
-                applyPosition: true,
-                statusMessage: "Preparing the overworld…",
-                diagnosticMessage: string.Empty);
         }
 
         private bool IsFallbackScene(string sceneName)

--- a/Assets/Scripts/UI/Login/LoginScreenController.cs
+++ b/Assets/Scripts/UI/Login/LoginScreenController.cs
@@ -1,8 +1,6 @@
-// ------------------------------------------------------------------------------
-// CHANGES: Implemented direct scene resume on login by delegating world loading
-// to LoginFlowController. Exposed status helpers/colours for the new flow and
-// removed the legacy Overworld-first coroutine.
-// ------------------------------------------------------------------------------
+// Refactor: OSRS-style login with per-account saves; removed Overworld hop; atomic file IO; PBKDF2.
+using System;
+using System.Threading.Tasks;
 using Core.Save;
 using UnityEngine;
 using UnityEngine.EventSystems;
@@ -17,7 +15,7 @@ namespace UI.Login
     /// <summary>
     /// Coordinates the login panel so users can authenticate before gameplay loads. The
     /// controller validates input, forwards credential checks to
-    /// <see cref="AccountProfileService"/>, and hands off to <see cref="LoginFlowController"/>
+    /// <see cref="AccountManager"/>, and hands off to <see cref="LoginFlowController"/>
     /// to resume the saved scene after a successful login.
     /// </summary>
     [DisallowMultipleComponent]
@@ -46,6 +44,7 @@ namespace UI.Login
         private string backgroundSpritePath = "Sprites/LoginScreen/Background";
 
         private const string LoginPanelSpritePath = "Sprites/LoginScreen/LoginBox";
+        private const string LastUsedUsernameKey = "AccountManager.LastUsername";
 
         [SerializeField, Tooltip("Resources path for the login button sprite.")]
         private string loginButtonSpritePath = "Sprites/LoginScreen/LoginButton";
@@ -161,7 +160,7 @@ namespace UI.Login
             if (usernameField == null)
                 return;
 
-            string lastUsed = AccountProfileService.GetLastUsedDisplayName();
+            string lastUsed = PlayerPrefs.GetString(LastUsedUsernameKey, string.Empty);
             if (!string.IsNullOrEmpty(lastUsed))
             {
                 usernameField.text = lastUsed;
@@ -180,7 +179,7 @@ namespace UI.Login
             loginButton.interactable = valid;
         }
 
-        private void HandleLoginClicked()
+        private async void HandleLoginClicked()
         {
             if (loginButton != null)
                 loginButton.interactable = false;
@@ -191,33 +190,53 @@ namespace UI.Login
             string username = usernameField != null ? usernameField.text : string.Empty;
             string password = passwordField != null ? passwordField.text : string.Empty;
 
-            bool created;
-            bool success = AccountProfileService.TryAuthenticate(username, password, out created, out AccountEntry entry, out string message);
-
-            if (!success)
+            try
             {
-                SetStatus(message, errorColour);
-                if (loginButton != null)
-                    loginButton.interactable = true;
-                return;
+                bool accountExists = AccountManager.TryLoadAccount(username, out AccountSave save);
+
+                if (accountExists)
+                {
+                    if (!AccountManager.VerifyPassword(save, password))
+                    {
+                        SetStatus("Invalid credentials.", errorColour);
+                        SetLoginButtonInteractable(true);
+                        return;
+                    }
+
+                    SetStatus($"Welcome back, {save.username}.", successColour);
+                }
+                else
+                {
+                    save = AccountManager.CreateNewAccount(username, password);
+                    SetStatus($"Created new account for {save.username}.", successColour);
+                }
+
+                SaveManager.BindAccount(save, reload: true);
+                await AccountManager.SaveAsync(save);
+                CacheLastUsedAccount(save.username);
+
+                if (loginFlowController != null)
+                {
+                    await loginFlowController.BeginLoginFlowAsync(save);
+                }
+                else
+                {
+                    Debug.LogError("LoginScreenController: LoginFlowController reference is missing. Cannot continue into gameplay.", this);
+                    SetStatus("Login succeeded but the gameplay flow is misconfigured.", errorColour);
+                    SetLoginButtonInteractable(true);
+                }
             }
-
-            SetStatus(message, successColour);
-
-            string activationMessage = AccountProfileService.ActivateAccount(entry);
-            SetStatus(activationMessage, successColour);
-            SaveManager.LoadAll();
-
-            if (loginFlowController != null)
+            catch (ArgumentException ex)
             {
-                loginFlowController.BeginLoginFlow(created);
+                Debug.LogWarning($"LoginScreenController: {ex.Message}", this);
+                SetStatus(ex.Message, errorColour);
+                SetLoginButtonInteractable(true);
             }
-            else
+            catch (Exception ex)
             {
-                Debug.LogError("LoginScreenController: LoginFlowController reference is missing. Cannot continue into gameplay.");
-                SetStatus("Login succeeded but the gameplay flow is misconfigured.", errorColour);
-                if (loginButton != null)
-                    loginButton.interactable = true;
+                Debug.LogError($"LoginScreenController: Failed to process login: {ex}", this);
+                SetStatus("Unexpected error while logging in.", errorColour);
+                SetLoginButtonInteractable(true);
             }
         }
 
@@ -454,6 +473,15 @@ namespace UI.Login
         {
             if (loginButton != null)
                 loginButton.interactable = interactable;
+        }
+
+        private static void CacheLastUsedAccount(string username)
+        {
+            if (string.IsNullOrWhiteSpace(username))
+                return;
+
+            PlayerPrefs.SetString(LastUsedUsernameKey, username);
+            PlayerPrefs.Save();
         }
 
         private RectTransform CreateRectTransform(string name, RectTransform parent, Vector2 anchorMin, Vector2 anchorMax, Vector2 pivot, Vector2 anchoredPosition, Vector2 sizeDelta)


### PR DESCRIPTION
## Summary
- implement AccountManager to manage per-account PBKDF2 credentials and JSON saves at the specified PlayerSave path
- rework SaveManager to operate on AccountSave payloads, flush through AccountManager, and maintain global metadata
- update the login UI/flow to use the new account system, async scene loading, and PlayerLocator-based player hand-off

## Testing
- not run (Unity automated tests not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d1312efc38832ea97872e213006a2d