### PR TITLE
Update login flow status message

### DIFF
--- a/Assets/Scripts/UI/Login/LoginFlowController.cs
+++ b/Assets/Scripts/UI/Login/LoginFlowController.cs
@@ -65,7 +65,11 @@ namespace UI.Login
             }
 
             if (loginScreen != null)
-                loginScreen.SetStatus($"Loading {targetScene}…", loginScreen.InfoColour);
+            {
+                // Always present a consistent login message that matches the requested
+                // branding instead of echoing the scene name.
+                loginScreen.SetStatus("Loading into VIosla 2D", loginScreen.InfoColour);
+            }
 
             bool loaded = await TryLoadSceneAsync(targetScene);
             if (!loaded)


### PR DESCRIPTION
## Summary
- ensure the login flow always shows the branded "Loading into VIosla 2D" message instead of echoing the destination scene name

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d14839e0bc832e97d4f3f56283fb5f