### PR TITLE
Add Firemaking skill implementation

### DIFF
--- a/Assets/Scripts/Inventory/ItemData.cs
+++ b/Assets/Scripts/Inventory/ItemData.cs
@@ -117,6 +117,10 @@ namespace Inventory
         [Tooltip("Additional cooking XP multiplier (0.025 = +2.5% XP).")]
         public float cookingXpBonusMultiplier = 0f;
 
+        [Header("Firemaking Bonuses")]
+        [Tooltip("Additional firemaking XP multiplier (0.025 = +2.5% XP).")]
+        public float firemakingXpBonusMultiplier = 0f;
+
         [Header("Requirements")]
         public SkillRequirement[] skillRequirements;
 

--- a/Assets/Scripts/Skills/AdminF2Menu.cs
+++ b/Assets/Scripts/Skills/AdminF2Menu.cs
@@ -10,6 +10,7 @@ using Skills.Fishing;
 using Skills.Mining;
 using Skills.Outfits;
 using Skills.Woodcutting;
+using Skills.Firemaking;
 using Status;
 using Status.Antifire;
 using Status.Poison;
@@ -55,6 +56,7 @@ namespace Skills
         private string magicLevel = "";
         private string miningLevel = "";
         private string woodcuttingLevel = "";
+        private string firemakingLevel = "";
         private string fishingLevel = "";
         private string cookingLevel = "";
         private string beastmasterLevel = "";
@@ -64,6 +66,7 @@ namespace Skills
 
         private MiningSkill miningSkillBehaviour;
         private WoodcuttingSkill woodcuttingSkillBehaviour;
+        private FiremakingSkill firemakingSkillBehaviour;
         private FishingSkill fishingSkillBehaviour;
         private CookingSkill cookingSkillBehaviour;
 
@@ -236,6 +239,8 @@ namespace Skills
                 miningSkillBehaviour = FindObjectOfType<MiningSkill>();
             if (woodcuttingSkillBehaviour == null)
                 woodcuttingSkillBehaviour = FindObjectOfType<WoodcuttingSkill>();
+            if (firemakingSkillBehaviour == null)
+                firemakingSkillBehaviour = FindObjectOfType<FiremakingSkill>();
             if (fishingSkillBehaviour == null)
                 fishingSkillBehaviour = FindObjectOfType<FishingSkill>();
             if (cookingSkillBehaviour == null)
@@ -261,6 +266,7 @@ namespace Skills
 
             miningSkillBehaviour = FindObjectOfType<MiningSkill>();
             woodcuttingSkillBehaviour = FindObjectOfType<WoodcuttingSkill>();
+            firemakingSkillBehaviour = FindObjectOfType<FiremakingSkill>();
             fishingSkillBehaviour = FindObjectOfType<FishingSkill>();
             cookingSkillBehaviour = FindObjectOfType<CookingSkill>();
 
@@ -271,6 +277,7 @@ namespace Skills
             magicLevel = skillManager != null ? skillManager.GetLevel(SkillType.Magic).ToString() : "";
             miningLevel = skillManager != null ? skillManager.GetLevel(SkillType.Mining).ToString() : "";
             woodcuttingLevel = skillManager != null ? skillManager.GetLevel(SkillType.Woodcutting).ToString() : "";
+            firemakingLevel = skillManager != null ? skillManager.GetLevel(SkillType.Firemaking).ToString() : "";
             fishingLevel = skillManager != null ? skillManager.GetLevel(SkillType.Fishing).ToString() : "";
             cookingLevel = skillManager != null ? skillManager.GetLevel(SkillType.Cooking).ToString() : "";
             beastmasterLevel = skillManager != null ? skillManager.GetLevel(SkillType.Beastmaster).ToString() : "";
@@ -282,7 +289,7 @@ namespace Skills
                 return;
 
             const float width = 220f;
-            const float height = 220f;
+            const float height = 240f;
             Rect area = new Rect(10f, 10f, width, height);
             GUILayout.BeginArea(area, GUI.skin.box);
 
@@ -307,14 +314,17 @@ namespace Skills
             GUILayout.Label("Mining Level");
             miningLevel = GUILayout.TextField(miningLevel);
 
-            GUILayout.Label("Woodcutting Level");
-            woodcuttingLevel = GUILayout.TextField(woodcuttingLevel);
-
             GUILayout.Label("Fishing Level");
             fishingLevel = GUILayout.TextField(fishingLevel);
 
             GUILayout.Label("Cooking Level");
             cookingLevel = GUILayout.TextField(cookingLevel);
+
+            GUILayout.Label("Firemaking Level");
+            firemakingLevel = GUILayout.TextField(firemakingLevel);
+
+            GUILayout.Label("Woodcutting Level");
+            woodcuttingLevel = GUILayout.TextField(woodcuttingLevel);
 
             GUILayout.Label("Beastmaster Level");
             beastmasterLevel = GUILayout.TextField(beastmasterLevel);
@@ -351,6 +361,11 @@ namespace Skills
                 () => cookingSkillBehaviour != null,
                 () => cookingSkillBehaviour.EnableDebugLogging,
                 value => cookingSkillBehaviour.EnableDebugLogging = value);
+            DrawSkillDebugToggle(
+                "Firemaking Debug Logging",
+                () => firemakingSkillBehaviour != null,
+                () => firemakingSkillBehaviour.EnableDebugLogging,
+                value => firemakingSkillBehaviour.EnableDebugLogging = value);
 
             if (GUILayout.Button("Apply"))
             {
@@ -370,12 +385,14 @@ namespace Skills
                     skillManager.DebugSetLevel(SkillType.Magic, mag);
                 if (skillManager != null && int.TryParse(miningLevel, out var mine))
                     skillManager.DebugSetLevel(SkillType.Mining, mine);
-                if (skillManager != null && int.TryParse(woodcuttingLevel, out var wood))
-                    skillManager.DebugSetLevel(SkillType.Woodcutting, wood);
                 if (skillManager != null && int.TryParse(fishingLevel, out var fish))
                     skillManager.DebugSetLevel(SkillType.Fishing, fish);
                 if (skillManager != null && int.TryParse(cookingLevel, out var cook))
                     skillManager.DebugSetLevel(SkillType.Cooking, cook);
+                if (skillManager != null && int.TryParse(firemakingLevel, out var fire))
+                    skillManager.DebugSetLevel(SkillType.Firemaking, fire);
+                if (skillManager != null && int.TryParse(woodcuttingLevel, out var wood))
+                    skillManager.DebugSetLevel(SkillType.Woodcutting, wood);
                 if (skillManager != null && int.TryParse(beastmasterLevel, out var bm))
                 {
                     skillManager.DebugSetLevel(SkillType.Beastmaster, bm);

--- a/Assets/Scripts/Skills/Firemaking/Core/FiremakingFire.cs
+++ b/Assets/Scripts/Skills/Firemaking/Core/FiremakingFire.cs
@@ -1,0 +1,208 @@
+using System;
+using Inventory;
+using MyGame.Drops;
+using Skills.Common;
+using UnityEngine;
+
+namespace Skills.Firemaking
+{
+    /// <summary>
+    ///     Runtime component spawned for each active fire. The fire counts down via the global ticker
+    ///     and notifies listeners when it expires so ashes can be spawned and UI updated.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public sealed class FiremakingFire : TickedSkillBehaviour
+    {
+        [SerializeField] private Collider2D blockingCollider;
+        [SerializeField] private Animator animator;
+        [SerializeField] private SpriteRenderer spriteRenderer;
+        [SerializeField] private AudioSource loopedAudio;
+
+        private int ticksRemaining;
+        private int lifetimeCap;
+        private ItemData ashesItem;
+        private GroundItemSpawner groundItemSpawner;
+        private AudioClip igniteClip;
+        private AudioClip extinguishClip;
+        private FiremakingSkill ownerSkill;
+
+        /// <summary>
+        ///     Tracks whether the fire has already been extinguished so additional fuel is ignored.
+        /// </summary>
+        public bool IsExtinguished { get; private set; }
+
+        /// <summary>
+        ///     Definition that produced this fire. Useful for UI when showing remaining lifetime.
+        /// </summary>
+        public FiremakingLogDefinition SourceLog { get; private set; }
+
+        /// <summary>
+        ///     Raised when the fire burns out and the component is about to be destroyed.
+        /// </summary>
+        public event Action<FiremakingFire> Extinguished;
+
+        /// <summary>
+        ///     Provides read-only access to the skill that spawned this fire for debugging and cleanup.
+        /// </summary>
+        public FiremakingSkill OwnerSkill => ownerSkill;
+
+        /// <summary>
+        ///     Configures the fire with the lifetime, loot and audio data for the originating log.
+        /// </summary>
+        /// <param name="definition">Definition describing the log that ignited.</param>
+        /// <param name="initialTicks">Initial lifetime contribution from the log.</param>
+        /// <param name="maxTicks">Lifetime cap for stacking additional logs.</param>
+        /// <param name="ashesItem">Ashes item to spawn once the fire dies.</param>
+        /// <param name="spawner">World drop spawner used for ashes.</param>
+        /// <param name="igniteSound">Optional sound played when the fire starts.</param>
+        /// <param name="extinguishSound">Optional sound played when the fire ends.</param>
+        public void Initialise(
+            FiremakingLogDefinition definition,
+            int initialTicks,
+            int maxTicks,
+            ItemData ashesItem,
+            GroundItemSpawner spawner,
+            AudioClip igniteSound,
+            AudioClip extinguishSound)
+        {
+            // Cache everything so subsequent fuel additions share the same configuration.
+            SourceLog = definition;
+            this.ashesItem = ashesItem;
+            groundItemSpawner = spawner;
+            igniteClip = igniteSound;
+            extinguishClip = extinguishSound;
+
+            // Convert the configured maximum into an easy-to-use cap. <=0 means unlimited stacking.
+            lifetimeCap = maxTicks > 0 ? Mathf.Max(1, maxTicks) : int.MaxValue;
+            ticksRemaining = Mathf.Clamp(initialTicks, 1, lifetimeCap);
+            IsExtinguished = false;
+
+            // Kick the ambient loop if one is configured on the prefab.
+            if (loopedAudio != null && !loopedAudio.isPlaying)
+                loopedAudio.Play();
+
+            // Play a one-shot ignition sound immediately so the action feels responsive.
+            if (igniteClip != null)
+            {
+                if (loopedAudio != null)
+                    loopedAudio.PlayOneShot(igniteClip);
+                else
+                    AudioSource.PlayClipAtPoint(igniteClip, transform.position);
+            }
+
+            // Ensure we are subscribed in case the object was instantiated while disabled.
+            TrySubscribeToTicker();
+        }
+
+        /// <summary>
+        ///     Stores a reference to the owning skill so it can detach event listeners safely.
+        /// </summary>
+        /// <param name="owner">Skill responsible for managing this fire.</param>
+        public void SetOwner(FiremakingSkill owner)
+        {
+            ownerSkill = owner;
+        }
+
+        /// <summary>
+        ///     Adds additional lifetime to the fire. Requests after the fire has gone out are ignored.
+        /// </summary>
+        /// <param name="ticks">Lifetime contribution from the newly added log.</param>
+        /// <param name="maxTicksOverride">Optional cap to enforce when different log types are added.</param>
+        /// <param name="igniteClipOverride">Sound clip to play when the log successfully catches.</param>
+        public void AddFuel(int ticks, int maxTicksOverride, AudioClip igniteClipOverride = null)
+        {
+            if (IsExtinguished)
+                return;
+
+            if (ticks <= 0)
+                return;
+
+            // Update the lifetime cap when the caller provides a stricter value.
+            if (maxTicksOverride > 0)
+            {
+                int normalized = Mathf.Max(1, maxTicksOverride);
+                lifetimeCap = lifetimeCap == int.MaxValue
+                    ? normalized
+                    : Mathf.Max(lifetimeCap, normalized);
+            }
+
+            int cap = lifetimeCap > 0 ? lifetimeCap : int.MaxValue;
+            ticksRemaining = Mathf.Clamp(ticksRemaining + ticks, 1, cap);
+
+            // Play any provided sound effect so fuelling feels reactive.
+            var clip = igniteClipOverride ?? igniteClip;
+            if (clip != null)
+            {
+                if (loopedAudio != null)
+                    loopedAudio.PlayOneShot(clip);
+                else
+                    AudioSource.PlayClipAtPoint(clip, transform.position);
+            }
+
+            // Make sure the fire is ticking in case it was paused after running out of fuel previously.
+            TrySubscribeToTicker();
+        }
+
+        /// <summary>
+        ///     Fires do not log ticker subscriptions by default unless explicitly enabled.
+        /// </summary>
+        protected override bool LogTickerSubscription => false;
+
+        /// <summary>
+        ///     Counts down the remaining lifetime and triggers extinction once the timer hits zero.
+        /// </summary>
+        protected override void HandleTick()
+        {
+            if (IsExtinguished)
+                return;
+
+            if (ticksRemaining > 0)
+                ticksRemaining--;
+
+            if (ticksRemaining > 0)
+                return;
+
+            Extinguish();
+        }
+
+        /// <summary>
+        ///     Handles the teardown workflow when the fire has burned out.
+        /// </summary>
+        private void Extinguish()
+        {
+            if (IsExtinguished)
+                return;
+
+            IsExtinguished = true;
+
+            // Stop receiving tick events immediately so we do not run this twice.
+            CancelTickerSubscription();
+
+            // Release any collision the fire was providing so the tile becomes walkable again.
+            if (blockingCollider != null)
+                blockingCollider.enabled = false;
+
+            // Stop looping audio and play the final extinguish sound if provided.
+            if (loopedAudio != null)
+                loopedAudio.Stop();
+
+            if (extinguishClip != null)
+            {
+                if (loopedAudio != null)
+                    loopedAudio.PlayOneShot(extinguishClip);
+                else
+                    AudioSource.PlayClipAtPoint(extinguishClip, transform.position);
+            }
+
+            // Spawn ashes when an item definition was supplied.
+            if (groundItemSpawner != null && ashesItem != null)
+                groundItemSpawner.Spawn(ashesItem, 1, transform.position);
+
+            // Notify listeners before the GameObject is destroyed.
+            Extinguished?.Invoke(this);
+
+            // Destroy the visual so the world is cleared once the fire expires.
+            Destroy(gameObject);
+        }
+    }
+}

--- a/Assets/Scripts/Skills/Firemaking/Core/FiremakingGroundTarget.cs
+++ b/Assets/Scripts/Skills/Firemaking/Core/FiremakingGroundTarget.cs
@@ -1,0 +1,98 @@
+using Inventory;
+using UI;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace Skills.Firemaking
+{
+    /// <summary>
+    ///     Handles ground clicks for Firemaking. Translates pointer input into ignition attempts on the active skill.
+    /// </summary>
+    [RequireComponent(typeof(Collider2D))]
+    public sealed class FiremakingGroundTarget : MonoBehaviour, IPointerClickHandler
+    {
+        [SerializeField] private FiremakingSkill skill;
+        [SerializeField] private Inventory.Inventory inventory;
+        [SerializeField] private Camera worldCamera;
+        [SerializeField] private LayerMask fireSearchLayers;
+
+        /// <summary>
+        ///     Locates the Firemaking skill, player inventory, and ensures the camera has a Physics2D raycaster for UI clicks.
+        /// </summary>
+        private void Awake()
+        {
+            if (skill == null)
+                skill = FindObjectOfType<FiremakingSkill>();
+            if (inventory == null && skill != null)
+                inventory = skill.GetComponent<Inventory.Inventory>();
+            if (worldCamera == null)
+                worldCamera = Camera.main;
+
+            if (worldCamera != null && worldCamera.GetComponent<Physics2DRaycaster>() == null)
+                worldCamera.gameObject.AddComponent<Physics2DRaycaster>();
+        }
+
+        /// <summary>
+        ///     Responds to left clicks by validating the selected logs and delegating to <see cref="FiremakingSkill"/>.
+        /// </summary>
+        /// <param name="eventData">Pointer payload provided by Unity's event system.</param>
+        public void OnPointerClick(PointerEventData eventData)
+        {
+            if (eventData == null || eventData.button != PointerEventData.InputButton.Left)
+                return;
+
+            if (skill == null || inventory == null)
+                return;
+
+            if (inventory.selectedIndex < 0)
+                return;
+
+            var entry = inventory.GetSlot(inventory.selectedIndex);
+            if (entry.item == null)
+                return;
+
+            var definition = skill.GetDefinitionForItem(entry.item.id);
+            if (definition == null)
+                return;
+
+            Vector3 rawWorld = eventData.pointerCurrentRaycast.worldPosition;
+            if (worldCamera != null && (rawWorld == Vector3.zero || float.IsNaN(rawWorld.x)))
+            {
+                // Fall back to a manual ray conversion when the event system does not provide a world position.
+                Vector3 screenPoint = eventData.position;
+                rawWorld = worldCamera.ScreenToWorldPoint(new Vector3(screenPoint.x, screenPoint.y, worldCamera.nearClipPlane));
+            }
+            rawWorld.z = 0f;
+
+            Vector3 snapped = SnapToWorld(rawWorld);
+
+            FiremakingFire targetFire = null;
+            if (fireSearchLayers.value != 0)
+            {
+                // Probe the configured fire layers so feeding an existing bonfire picks the correct component.
+                Collider2D hit = Physics2D.OverlapPoint(snapped, fireSearchLayers);
+                if (hit != null)
+                    targetFire = hit.GetComponentInParent<FiremakingFire>() ?? hit.GetComponent<FiremakingFire>();
+            }
+
+            if (!skill.TryBeginLighting(inventory.selectedIndex, snapped, targetFire, out var failureReason))
+            {
+                if (!string.IsNullOrEmpty(failureReason))
+                    FloatingText.Show(failureReason, snapped);
+            }
+        }
+
+        /// <summary>
+        ///     Snaps the incoming pointer position to the Firemaking grid rules so placement is consistent.
+        /// </summary>
+        /// <param name="rawWorld">Unsnapped pointer position.</param>
+        /// <returns>Grid aligned position used for the ignition attempt.</returns>
+        private Vector3 SnapToWorld(Vector3 rawWorld)
+        {
+            // Delegate to the skill whenever possible so snapping stays in sync with configuration toggles.
+            return skill != null
+                ? skill.SnapToIgnitionPoint(rawWorld)
+                : new Vector3(Mathf.Round(rawWorld.x), Mathf.Round(rawWorld.y), 0f);
+        }
+    }
+}

--- a/Assets/Scripts/Skills/Firemaking/Core/FiremakingSkill.cs
+++ b/Assets/Scripts/Skills/Firemaking/Core/FiremakingSkill.cs
@@ -1,0 +1,649 @@
+using System;
+using System.Collections.Generic;
+using BankSystem;
+using Core.Save;
+using Inventory;
+using MyGame.Drops;
+using Player;
+using Skills.Common;
+using Skills.Outfits;
+using UI;
+using UnityEngine;
+using Util;
+using Random = UnityEngine.Random;
+
+namespace Skills.Firemaking
+{
+    /// <summary>
+    ///     Implements the Firemaking skill by handling ignition attempts, tracking active bonfires,
+    ///     and awarding XP through the shared gathering reward processors.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public sealed class FiremakingSkill : TickedSkillBehaviour
+    {
+        [SerializeField] private Inventory.Inventory inventory;
+        [SerializeField] private Equipment equipment;
+        [SerializeField] private Transform floatingTextAnchor;
+        [SerializeField] private PlayerMover playerMover;
+        [SerializeField] private LayerMask fireBlockingLayers;
+        [SerializeField] private LayerMask existingFireLayers;
+        [SerializeField] private GameObject defaultFirePrefab;
+        [SerializeField] private GroundItemSpawner groundItemSpawner;
+        [SerializeField] private string tinderboxItemId = "Tinderbox";
+        [SerializeField] private float maxIgniteDistance = 1.6f;
+        [SerializeField, Tooltip("Enables verbose logging while diagnosing Firemaking behaviour.")]
+        private bool enableDebugLogging;
+        [SerializeField] private bool allowTileSnapping = true;
+        [SerializeField] private Vector2 tileSnapSize = Vector2.one;
+
+        private SkillManager skills;
+        private Dictionary<string, FiremakingLogDefinition> logLookup;
+        private Dictionary<string, ItemData> itemCache;
+        private FiremakingAttempt currentAttempt;
+        private readonly List<FiremakingFire> activeFires = new();
+        private SkillingOutfitProgress firemakingOutfit;
+        private int attemptTicksElapsed;
+
+        private struct FiremakingAttempt
+        {
+            public FiremakingLogDefinition definition;
+            public Vector3 worldPosition;
+            public FiremakingFire targetFire;
+            public int inventorySlot;
+            public int ticksRequired;
+            public bool feedingExistingFire;
+        }
+
+        /// <summary>
+        ///     True whenever the player is mid-ignition attempt.
+        /// </summary>
+        public bool IsLighting => currentAttempt.definition != null;
+
+        /// <summary>
+        ///     Normalised 0..1 representation of the current ignition progress.
+        /// </summary>
+        public float IgnitionProgressNormalized
+        {
+            get
+            {
+                if (!IsLighting || currentAttempt.ticksRequired <= 0)
+                    return 0f;
+                return Mathf.Clamp01((float)attemptTicksElapsed / currentAttempt.ticksRequired);
+            }
+        }
+
+        /// <summary>
+        ///     World position where the current ignition attempt is centred.
+        /// </summary>
+        public Vector3 CurrentAttemptPosition => currentAttempt.definition != null ? currentAttempt.worldPosition : transform.position;
+
+        /// <summary>
+        ///     Definition describing the logs currently being ignited.
+        /// </summary>
+        public FiremakingLogDefinition CurrentDefinition => currentAttempt.definition;
+
+        /// <summary>
+        ///     Runtime flag used by the admin menu to toggle verbose debug logging.
+        /// </summary>
+        public bool EnableDebugLogging
+        {
+            get => enableDebugLogging;
+            set => enableDebugLogging = value;
+        }
+
+        /// <summary>
+        ///     Invoked when an ignition attempt starts so HUDs can attach to the action.
+        /// </summary>
+        public event Action<FiremakingLogDefinition, Vector3> IgnitionStarted;
+
+        /// <summary>
+        ///     Invoked when an ignition attempt ends for any reason.
+        /// </summary>
+        public event Action IgnitionStopped;
+
+        /// <summary>
+        ///     Raised whenever a bonfire gains fuel (either from a fresh log or by feeding an existing fire).
+        /// </summary>
+        public event Action<FiremakingFire> FireIgnited;
+
+        /// <summary>
+        ///     Raised when a tracked fire expires and burns to ashes.
+        /// </summary>
+        public event Action<FiremakingFire> FireExtinguished;
+
+        /// <summary>
+        ///     Raised when the player levels the Firemaking skill so other systems can react.
+        /// </summary>
+        public event Action<int> OnLevelUp;
+
+        /// <summary>
+        ///     Exposes the configured snapping logic so click handlers can mirror the placement rules.
+        /// </summary>
+        /// <param name="rawWorldPosition">Position gathered from player input.</param>
+        /// <returns>Snapped world position that honours the skill configuration.</returns>
+        public Vector3 SnapToIgnitionPoint(Vector3 rawWorldPosition)
+        {
+            if (!allowTileSnapping)
+                return new Vector3(rawWorldPosition.x, rawWorldPosition.y, 0f);
+
+            float cellX = Mathf.Approximately(tileSnapSize.x, 0f) ? 1f : tileSnapSize.x;
+            float cellY = Mathf.Approximately(tileSnapSize.y, 0f) ? 1f : tileSnapSize.y;
+            float snappedX = Mathf.Round(rawWorldPosition.x / cellX) * cellX;
+            float snappedY = Mathf.Round(rawWorldPosition.y / cellY) * cellY;
+            return new Vector3(snappedX, snappedY, 0f);
+        }
+
+        /// <summary>
+        ///     Automatically fetches references and loads log definitions so ignition lookups are ready immediately.
+        /// </summary>
+        private void Awake()
+        {
+            if (inventory == null)
+                inventory = GetComponent<Inventory.Inventory>();
+            if (equipment == null)
+                equipment = GetComponent<Equipment>();
+            if (playerMover == null)
+                playerMover = GetComponent<PlayerMover>();
+            if (groundItemSpawner == null)
+                groundItemSpawner = FindObjectOfType<GroundItemSpawner>();
+            if (floatingTextAnchor == null)
+                floatingTextAnchor = transform;
+
+            skills = GetComponent<SkillManager>();
+            logLookup = new Dictionary<string, FiremakingLogDefinition>(StringComparer.Ordinal);
+            itemCache = null;
+
+            LoadLogDefinitions();
+
+            firemakingOutfit = new SkillingOutfitProgress(new[]
+            {
+                "Pyromancer Hood",
+                "Pyromancer Garb",
+                "Pyromancer Robes",
+                "Pyromancer Boots"
+            }, "FiremakingOutfitOwned");
+        }
+
+        /// <summary>
+        ///     Ensures outfit progress is unregistered and fire listeners are torn down when the skill is destroyed.
+        /// </summary>
+        private void OnDestroy()
+        {
+            SaveManager.Unregister(firemakingOutfit);
+            ClearActiveFires();
+        }
+
+        /// <summary>
+        ///     Routes ticker subscription logging through the runtime toggle.
+        /// </summary>
+        protected override bool LogTickerSubscription => enableDebugLogging;
+
+        /// <summary>
+        ///     Cleans up attempts and listeners when the component is disabled (e.g. on scene changes).
+        /// </summary>
+        protected override void OnDisable()
+        {
+            base.OnDisable();
+            CancelAttempt(true);
+            ClearActiveFires();
+        }
+
+        /// <summary>
+        ///     Retrieves the log definition associated with the supplied item identifier.
+        /// </summary>
+        /// <param name="itemId">Inventory item identifier to look up.</param>
+        /// <returns>Matching <see cref="FiremakingLogDefinition"/> or <c>null</c> if not registered.</returns>
+        public FiremakingLogDefinition GetDefinitionForItem(string itemId)
+        {
+            if (string.IsNullOrEmpty(itemId))
+                return null;
+
+            return logLookup != null && logLookup.TryGetValue(itemId, out var definition) ? definition : null;
+        }
+
+        /// <summary>
+        ///     Validates and begins a new ignition attempt using the specified inventory slot and world position.
+        /// </summary>
+        /// <param name="inventorySlot">Slot index containing the selected logs.</param>
+        /// <param name="worldPosition">Target position where the fire should be created.</param>
+        /// <param name="existingFire">Optional fire to feed instead of creating a new one.</param>
+        /// <param name="failureReason">Outputs a player-facing reason when the attempt cannot start.</param>
+        /// <returns><c>true</c> when the attempt was started, otherwise <c>false</c>.</returns>
+        public bool TryBeginLighting(int inventorySlot, Vector3 worldPosition, FiremakingFire existingFire, out string failureReason)
+        {
+            failureReason = string.Empty;
+
+            if (IsLighting)
+            {
+                failureReason = "You are already trying to light a fire.";
+                return false;
+            }
+
+            if (inventory == null)
+            {
+                failureReason = "You need an inventory to light fires.";
+                return false;
+            }
+
+            var entry = inventory.GetSlot(inventorySlot);
+            if (entry.item == null)
+            {
+                failureReason = "You need logs to light a fire.";
+                return false;
+            }
+
+            var definition = GetDefinitionForItem(entry.item.id);
+            if (definition == null)
+            {
+                failureReason = "You can't light those logs.";
+                return false;
+            }
+
+            if (!string.Equals(entry.item.id, definition.logItemId, StringComparison.Ordinal))
+            {
+                failureReason = "You need to select the correct logs.";
+                return false;
+            }
+
+            int level = skills != null ? skills.GetLevel(SkillType.Firemaking) : 1;
+            if (level < definition.requiredLevel)
+            {
+                failureReason = $"You need Firemaking level {definition.requiredLevel}.";
+                return false;
+            }
+
+            if (!inventory.HasItem(tinderboxItemId))
+            {
+                failureReason = "You need a tinderbox.";
+                return false;
+            }
+
+            Vector3 snappedPosition = SnapToIgnitionPoint(worldPosition);
+            bool feedingExisting = existingFire != null;
+
+            if (feedingExisting)
+            {
+                if (existingFire.IsExtinguished)
+                {
+                    failureReason = "That fire has already burned out.";
+                    return false;
+                }
+
+                Vector3 firePosition = existingFire.transform.position;
+                if (Vector3.Distance(transform.position, firePosition) > maxIgniteDistance)
+                {
+                    failureReason = "You are too far away.";
+                    return false;
+                }
+
+                snappedPosition = firePosition;
+            }
+            else
+            {
+                if (Vector3.Distance(transform.position, snappedPosition) > maxIgniteDistance)
+                {
+                    failureReason = "You are too far away.";
+                    return false;
+                }
+
+                Vector2 checkSize = ResolveCollisionCheckSize();
+                if (Physics2D.OverlapBox(snappedPosition, checkSize, 0f, fireBlockingLayers))
+                {
+                    failureReason = "You can't light a fire there.";
+                    return false;
+                }
+
+                if (Physics2D.OverlapBox(snappedPosition, checkSize * 0.9f, 0f, existingFireLayers))
+                {
+                    failureReason = "There is already a fire here.";
+                    return false;
+                }
+            }
+
+            EnsureFireTracked(existingFire);
+
+            currentAttempt = new FiremakingAttempt
+            {
+                definition = definition,
+                worldPosition = snappedPosition,
+                targetFire = existingFire,
+                inventorySlot = inventorySlot,
+                ticksRequired = Mathf.Max(1, definition.GetIgnitionTicks(level)),
+                feedingExistingFire = feedingExisting
+            };
+            attemptTicksElapsed = 0;
+
+            IgnitionStarted?.Invoke(definition, snappedPosition);
+            LogDebug($"Started lighting {definition.displayName} at {snappedPosition} (feeding existing: {feedingExisting}).");
+            return true;
+        }
+
+        /// <summary>
+        ///     Cancels the active attempt, optionally informing the player via floating text.
+        /// </summary>
+        /// <param name="showMessage">True to display the default cancellation feedback message.</param>
+        public void CancelAttempt(bool showMessage)
+        {
+            CancelAttemptInternal(showMessage, showMessage ? "You stop trying to light the logs." : null);
+        }
+
+        /// <summary>
+        ///     Runs each tick of the ignition attempt, checking for cancellation conditions and resolving success rolls.
+        /// </summary>
+        protected override void HandleTick()
+        {
+            if (!IsLighting)
+                return;
+
+            var definition = currentAttempt.definition;
+            if (definition == null)
+            {
+                CancelAttemptInternal(false, null);
+                return;
+            }
+
+            var entry = inventory.GetSlot(currentAttempt.inventorySlot);
+            if (entry.item == null || entry.item.id != definition.logItemId)
+            {
+                CancelAttemptInternal(true, "You ran out of logs.");
+                return;
+            }
+
+            if (currentAttempt.feedingExistingFire)
+            {
+                if (currentAttempt.targetFire == null || currentAttempt.targetFire.IsExtinguished)
+                {
+                    CancelAttemptInternal(true, "The fire has already burned out.");
+                    return;
+                }
+            }
+
+            if (playerMover != null && playerMover.IsMoving)
+            {
+                CancelAttemptInternal(true, "You stop trying to light the logs.");
+                return;
+            }
+
+            Vector3 anchor = currentAttempt.feedingExistingFire && currentAttempt.targetFire != null
+                ? currentAttempt.targetFire.transform.position
+                : currentAttempt.worldPosition;
+            if (Vector3.Distance(transform.position, anchor) > maxIgniteDistance)
+            {
+                CancelAttemptInternal(true, "You are too far away.");
+                return;
+            }
+
+            attemptTicksElapsed++;
+            LogDebug($"Firemaking tick {attemptTicksElapsed}/{currentAttempt.ticksRequired}.");
+
+            if (attemptTicksElapsed < currentAttempt.ticksRequired)
+                return;
+
+            attemptTicksElapsed = 0;
+            int level = skills != null ? skills.GetLevel(SkillType.Firemaking) : 1;
+            float chance = definition.GetSuccessChance(level, currentAttempt.feedingExistingFire);
+            bool success = Random.value <= chance;
+
+            if (success)
+            {
+                CompleteAttempt();
+            }
+            else
+            {
+                ShowFeedback("The logs fail to catch fire.", anchor);
+                LogDebug($"Failed to light {definition.displayName} (chance {chance:P2}).");
+            }
+        }
+
+        /// <summary>
+        ///     Handles the success workflow after an ignition attempt finishes, including XP awards and fire creation.
+        /// </summary>
+        private void CompleteAttempt()
+        {
+            var definition = currentAttempt.definition;
+            if (definition == null)
+            {
+                CancelAttemptInternal(false, null);
+                return;
+            }
+
+            if (inventory == null || !inventory.RemoveItem(definition.logItemId))
+            {
+                CancelAttemptInternal(true, "You ran out of logs.");
+                return;
+            }
+
+            int lifetime = definition.GetLifetimeContribution(currentAttempt.feedingExistingFire);
+            var ashesItem = GatheringInventoryHelper.GetItemData(definition.ashesItemId, ref itemCache);
+
+            FiremakingFire fire = currentAttempt.targetFire;
+            bool createdNewFire = fire == null;
+
+            if (createdNewFire)
+            {
+                GameObject prefab = definition.firePrefab != null ? definition.firePrefab : defaultFirePrefab;
+                GameObject instance;
+                if (prefab != null)
+                {
+                    instance = Instantiate(prefab, currentAttempt.worldPosition, Quaternion.identity);
+                }
+                else
+                {
+                    instance = new GameObject("FiremakingFire");
+                    instance.transform.position = currentAttempt.worldPosition;
+                }
+
+                fire = instance.GetComponent<FiremakingFire>();
+                if (fire == null)
+                    fire = instance.AddComponent<FiremakingFire>();
+
+                fire.SetOwner(this);
+                fire.Initialise(definition, lifetime, definition.maxLifetimeTicks, ashesItem, groundItemSpawner, definition.igniteSound, definition.extinguishSound);
+                EnsureFireTracked(fire);
+            }
+            else
+            {
+                fire.AddFuel(lifetime, definition.maxLifetimeTicks, definition.igniteSound);
+            }
+
+            FireIgnited?.Invoke(fire);
+
+            string successMessage = currentAttempt.feedingExistingFire
+                ? "You add a log to the fire."
+                : "The fire catches alight.";
+            ShowFeedback(successMessage, currentAttempt.worldPosition);
+
+            var context = GatheringRewardContextBuilder.BuildContext(new GatheringRewardContextBuilder.ContextArgs
+            {
+                Runner = this,
+                Skills = skills,
+                SkillType = SkillType.Firemaking,
+                Inventory = inventory,
+                Item = null,
+                RewardDisplayName = definition.displayName,
+                Quantity = 1,
+                XpPerItem = definition.xp,
+                PetAssistExtraQuantity = 0,
+                FloatingTextAnchor = floatingTextAnchor,
+                FallbackAnchor = transform,
+                Equipment = equipment,
+                EquipmentXpBonusEvaluator = data => data != null ? data.firemakingXpBonusMultiplier : 0f,
+                CustomAddItemHandler = _ => true,
+                ShowItemFloatingText = false,
+                OnSuccess = _ =>
+                {
+                    if (definition.phoenixPetRoll > 0 && fire != null)
+                        SkillingPetRewarder.TryRollPet("firemaking", skills, fire.transform, definition.phoenixPetRoll);
+                    TryAwardFiremakingOutfitPiece();
+                },
+                LevelUpFloatingTextFormatter = result => $"Firemaking level {result.NewLevel}",
+                OnLevelUp = level => OnLevelUp?.Invoke(level)
+            });
+
+            GatheringRewardProcessor.Process(context);
+
+            LogDebug($"Successfully lit {definition.displayName} at {currentAttempt.worldPosition}.");
+            FinishAttempt();
+        }
+
+        /// <summary>
+        ///     Handles cleanup when a tracked fire expires and burns to ashes.
+        /// </summary>
+        /// <param name="fire">Fire instance that triggered the event.</param>
+        private void HandleFireExtinguished(FiremakingFire fire)
+        {
+            if (fire == null)
+                return;
+
+            fire.Extinguished -= HandleFireExtinguished;
+            activeFires.Remove(fire);
+            FireExtinguished?.Invoke(fire);
+            LogDebug($"Fire at {fire.transform.position} burned to ashes.");
+            ShowFeedback("Your fire burns to ashes.", fire.transform.position);
+        }
+
+        /// <summary>
+        ///     Loads all Firemaking log definitions from Resources and builds the lookup dictionary.
+        /// </summary>
+        private void LoadLogDefinitions()
+        {
+            logLookup.Clear();
+            var definitions = Resources.LoadAll<FiremakingLogDefinition>("Firemaking/Logs");
+            if (definitions == null || definitions.Length == 0)
+            {
+                Debug.LogWarning("[FiremakingSkill] No Firemaking log definitions were found in Resources/Firemaking/Logs.");
+                return;
+            }
+
+            foreach (var definition in definitions)
+            {
+                if (definition == null)
+                    continue;
+
+                if (string.IsNullOrEmpty(definition.logItemId))
+                {
+                    Debug.LogWarning($"[FiremakingSkill] Log definition '{definition.name}' is missing a log item id.");
+                    continue;
+                }
+
+                if (logLookup.ContainsKey(definition.logItemId))
+                    Debug.LogWarning($"[FiremakingSkill] Duplicate log item id '{definition.logItemId}' detected. Overwriting previous entry.");
+
+                logLookup[definition.logItemId] = definition;
+            }
+        }
+
+        /// <summary>
+        ///     Helper used by other systems to attempt a pyromancer outfit roll.
+        /// </summary>
+        /// <returns>True when an outfit piece was awarded.</returns>
+        private bool TryAwardFiremakingOutfitPiece()
+        {
+            return SkillingOutfitRewarder.TryAwardPiece(
+                firemakingOutfit,
+                inventory,
+                BankUI.Instance,
+                Random.Range,
+                "Firemaking",
+                "You receive a piece of the pyromancer outfit.",
+                "A pyromancer outfit piece has been sent to your bank.");
+        }
+
+        /// <summary>
+        ///     Displays floating text feedback at the supplied position.
+        /// </summary>
+        /// <param name="message">Text to show.</param>
+        /// <param name="position">World position where the text should appear.</param>
+        private void ShowFeedback(string message, Vector3 position)
+        {
+            if (string.IsNullOrEmpty(message))
+                return;
+
+            FloatingText.Show(message, position);
+        }
+
+        /// <summary>
+        ///     Cancels the current attempt with a custom message, used internally by validation checks.
+        /// </summary>
+        /// <param name="showMessage">Whether to display floating text.</param>
+        /// <param name="message">Optional message to show.</param>
+        private void CancelAttemptInternal(bool showMessage, string message)
+        {
+            if (!IsLighting)
+                return;
+
+            if (showMessage && !string.IsNullOrEmpty(message))
+                ShowFeedback(message, CurrentAttemptPosition);
+
+            LogDebug(message != null ? $"Cancelled firemaking attempt: {message}" : "Cancelled firemaking attempt.");
+            FinishAttempt();
+        }
+
+        /// <summary>
+        ///     Resets attempt state and notifies listeners that Firemaking has stopped.
+        /// </summary>
+        private void FinishAttempt()
+        {
+            currentAttempt = default;
+            attemptTicksElapsed = 0;
+            IgnitionStopped?.Invoke();
+        }
+
+        /// <summary>
+        ///     Computes the overlap size used to check for blocking colliders at the target location.
+        /// </summary>
+        /// <returns>Size vector appropriate for the configured grid.</returns>
+        private Vector2 ResolveCollisionCheckSize()
+        {
+            if (!allowTileSnapping)
+                return new Vector2(0.9f, 0.9f);
+
+            float width = Mathf.Approximately(tileSnapSize.x, 0f) ? 1f : tileSnapSize.x;
+            float height = Mathf.Approximately(tileSnapSize.y, 0f) ? 1f : tileSnapSize.y;
+            return new Vector2(Mathf.Abs(width), Mathf.Abs(height));
+        }
+
+        /// <summary>
+        ///     Ensures the supplied fire is tracked so extinction events can be handled consistently.
+        /// </summary>
+        /// <param name="fire">Fire instance to track.</param>
+        private void EnsureFireTracked(FiremakingFire fire)
+        {
+            if (fire == null)
+                return;
+
+            if (!activeFires.Contains(fire))
+            {
+                fire.Extinguished += HandleFireExtinguished;
+                fire.SetOwner(this);
+                activeFires.Add(fire);
+            }
+        }
+
+        /// <summary>
+        ///     Removes event listeners from every tracked fire. Invoked when the skill is disabled or destroyed.
+        /// </summary>
+        private void ClearActiveFires()
+        {
+            foreach (var fire in activeFires)
+            {
+                if (fire != null)
+                    fire.Extinguished -= HandleFireExtinguished;
+            }
+
+            activeFires.Clear();
+        }
+
+        /// <summary>
+        ///     Emits a formatted debug message when verbose logging is enabled.
+        /// </summary>
+        /// <param name="message">Message to output to the Unity console.</param>
+        private void LogDebug(string message)
+        {
+            if (!enableDebugLogging)
+                return;
+
+            Debug.Log($"[FiremakingSkill] {message}");
+        }
+    }
+}

--- a/Assets/Scripts/Skills/Firemaking/Data/FiremakingLogDefinition.cs
+++ b/Assets/Scripts/Skills/Firemaking/Data/FiremakingLogDefinition.cs
@@ -1,0 +1,88 @@
+using UnityEngine;
+
+namespace Skills.Firemaking
+{
+    [CreateAssetMenu(menuName = "Skills/Firemaking/Log Definition", fileName = "NewFiremakingLog")]
+    public sealed class FiremakingLogDefinition : ScriptableObject
+    {
+        [Header("Inventory")]
+        [Tooltip("Item id of the log that this definition represents.")]
+        public string logItemId;
+        [Tooltip("Human-readable name shown in floating text.")]
+        public string displayName;
+
+        [Header("Requirements & Rewards")]
+        [Tooltip("Firemaking level required to attempt lighting this log.")]
+        public int requiredLevel = 1;
+        [Tooltip("XP granted when the log successfully burns.")]
+        public float xp = 0f;
+        [Tooltip("Default 1-in-N pet roll used when this log lights. Leave <= 0 to skip the roll.")]
+        public int phoenixPetRoll = 5000;
+
+        [Header("Ignition Behaviour")]
+        [Tooltip("Number of OSRS ticks required for one lighting attempt at the required level.")]
+        public int baseIgnitionTicks = 4;
+        [Tooltip("How many ticks are removed per level above the requirement. Clamped so at least one tick remains.")]
+        public float ignitionTickReductionPerLevel = 0.1f;
+        [Range(0f, 1f)]
+        [Tooltip("Chance to succeed at the minimum required level.")]
+        public float baseIgnitionChance = 0.35f;
+        [Tooltip("Additional success chance per Firemaking level above the requirement.")]
+        public float ignitionChancePerLevel = 0.01f;
+        [Range(0f, 1f)]
+        [Tooltip("Flat success chance bonus when adding the log to an existing bonfire.")]
+        public float bonfireIgnitionBonus = 0.15f;
+
+        [Header("Fire Lifetime")]
+        [Tooltip("Lifetime in ticks when this log is the first fuel in the fire.")]
+        public int baseFireLifetimeTicks = 50;
+        [Tooltip("Extra ticks granted when feeding an existing fire.")]
+        public int bonusLifetimeWhenAdding = 25;
+        [Tooltip("Hard cap for a fire's lifetime when repeatedly fed. Set to <= 0 to allow unlimited stacking.")]
+        public int maxLifetimeTicks = 150;
+
+        [Header("Loot & Effects")]
+        [Tooltip("Optional item id to drop as ashes when the fire expires.")]
+        public string ashesItemId;
+        [Tooltip("Prefab spawned when this log creates a new fire. Falls back to the skill's default prefab when null.")]
+        public GameObject firePrefab;
+        [Tooltip("Sound played at the fire location when the log lights.")]
+        public AudioClip igniteSound;
+        [Tooltip("Sound played when the fire dies out.")]
+        public AudioClip extinguishSound;
+
+        /// <summary>
+        /// Calculates the ignition duration in ticks after accounting for the player's level.
+        /// </summary>
+        public int GetIgnitionTicks(int playerLevel)
+        {
+            if (playerLevel <= requiredLevel)
+                return Mathf.Max(1, baseIgnitionTicks);
+            float reduction = (playerLevel - requiredLevel) * ignitionTickReductionPerLevel;
+            return Mathf.Max(1, Mathf.RoundToInt(baseIgnitionTicks - reduction));
+        }
+
+        /// <summary>
+        /// Returns the chance (0..1) that the current attempt succeeds.
+        /// </summary>
+        public float GetSuccessChance(int playerLevel, bool addingToExistingFire)
+        {
+            float chance = baseIgnitionChance;
+            if (playerLevel > requiredLevel)
+                chance += (playerLevel - requiredLevel) * ignitionChancePerLevel;
+            if (addingToExistingFire)
+                chance += bonfireIgnitionBonus;
+            return Mathf.Clamp01(chance);
+        }
+
+        /// <summary>
+        /// Calculates how many ticks the fire should gain if this log succeeds.
+        /// </summary>
+        public int GetLifetimeContribution(bool addingToExistingFire)
+        {
+            return addingToExistingFire
+                ? Mathf.Max(0, bonusLifetimeWhenAdding)
+                : Mathf.Max(0, baseFireLifetimeTicks);
+        }
+    }
+}

--- a/Assets/Scripts/Skills/Firemaking/UI/FiremakingHUD.cs
+++ b/Assets/Scripts/Skills/Firemaking/UI/FiremakingHUD.cs
@@ -1,0 +1,400 @@
+using Skills.Common.UI;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.UI;
+using Util;
+using World;
+using Skills;
+
+namespace Skills.Firemaking
+{
+    /// <summary>
+    ///     Displays Firemaking progress above the current ignition point using a world space progress bar.
+    /// </summary>
+    public sealed class FiremakingHUD : GatheringSkillHudBase<FiremakingSkill>, ITickable
+    {
+        private static FiremakingHUD instance;
+        private static bool waitingForAllowedScene;
+        private static bool applicationIsQuitting;
+
+        private const string HudName = nameof(FiremakingHUD);
+
+        public static FiremakingHUD Instance => instance;
+
+        private bool sceneGateSubscribed;
+        private bool sceneLoadedSubscribed;
+        private bool tickerSubscribed;
+
+        private GameObject progressRoot;
+        private Canvas progressCanvas;
+        private Image progressFill;
+        private readonly Vector3 offset = new Vector3(0f, 0.8f, 0f);
+
+        private bool hasTarget;
+        private Vector3 targetPosition;
+        private float currentFill;
+        private float nextFill;
+        private float tickTimer;
+        private float segmentDuration = Ticker.TickDuration;
+        private float progressStep = 1f;
+        private SkillManager skillManager;
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        private static void Bootstrap()
+        {
+            var activeScene = SceneManager.GetActiveScene();
+            if (!activeScene.IsValid() || !PersistentSceneGate.ShouldSpawnInScene(activeScene))
+            {
+                BeginWaitingForAllowedScene();
+                return;
+            }
+
+            CreateOrAdoptInstance();
+        }
+
+        private static void CreateOrAdoptInstance()
+        {
+            if (instance != null)
+                return;
+
+            StopWaitingForAllowedScene();
+
+            var existing = FindExistingInstance();
+            if (existing != null)
+            {
+                instance = existing;
+                if (existing.gameObject.scene.name != "DontDestroyOnLoad")
+                    Object.DontDestroyOnLoad(existing.gameObject);
+                existing.EnsureSceneGateSubscription();
+                existing.EnsureSceneLoadedSubscription();
+                existing.EnsureProgressObjects();
+                existing.RefreshSkillSubscription();
+                return;
+            }
+
+            var go = new GameObject(HudName);
+            Object.DontDestroyOnLoad(go);
+            go.AddComponent<FiremakingHUD>();
+        }
+
+        private static FiremakingHUD FindExistingInstance()
+        {
+#if UNITY_2023_1_OR_NEWER
+            return Object.FindFirstObjectByType<FiremakingHUD>();
+#else
+            return Object.FindObjectOfType<FiremakingHUD>();
+#endif
+        }
+
+        private static void BeginWaitingForAllowedScene()
+        {
+            if (waitingForAllowedScene)
+                return;
+
+            waitingForAllowedScene = true;
+            PersistentSceneGate.SceneEvaluationChanged += HandleSceneEvaluationForBootstrap;
+        }
+
+        private static void StopWaitingForAllowedScene()
+        {
+            if (!waitingForAllowedScene)
+                return;
+
+            PersistentSceneGate.SceneEvaluationChanged -= HandleSceneEvaluationForBootstrap;
+            waitingForAllowedScene = false;
+        }
+
+        private static void HandleSceneEvaluationForBootstrap(Scene scene, bool allowed)
+        {
+            if (!allowed)
+                return;
+
+            if (scene != SceneManager.GetActiveScene())
+                return;
+
+            CreateOrAdoptInstance();
+        }
+
+        private void Awake()
+        {
+            if (instance != null && instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            instance = this;
+            DontDestroyOnLoad(gameObject);
+
+            StopWaitingForAllowedScene();
+            EnsureSceneGateSubscription();
+            EnsureSceneLoadedSubscription();
+            EnsureProgressObjects();
+            RefreshSkillSubscription();
+        }
+
+        private void OnEnable()
+        {
+            EnsureSceneLoadedSubscription();
+            RefreshSkillSubscription();
+        }
+
+        private void OnDisable()
+        {
+            if (sceneLoadedSubscribed)
+            {
+                SceneManager.sceneLoaded -= HandleSceneLoaded;
+                sceneLoadedSubscribed = false;
+            }
+
+            HandleStop();
+            DetachFromSkill();
+            CancelSkillRefreshRoutine();
+            UnsubscribeFromTicker();
+        }
+
+        private void OnApplicationQuit()
+        {
+            applicationIsQuitting = true;
+        }
+
+        private void OnDestroy()
+        {
+            if (instance == this)
+            {
+                if (sceneGateSubscribed)
+                {
+                    PersistentSceneGate.SceneEvaluationChanged -= HandleSceneGateEvaluation;
+                    sceneGateSubscribed = false;
+                }
+
+                if (sceneLoadedSubscribed)
+                {
+                    SceneManager.sceneLoaded -= HandleSceneLoaded;
+                    sceneLoadedSubscribed = false;
+                }
+
+                HandleStop();
+                DetachFromSkill();
+                CancelSkillRefreshRoutine();
+                UnsubscribeFromTicker();
+
+                if (!applicationIsQuitting)
+                    BeginWaitingForAllowedScene();
+
+                instance = null;
+            }
+        }
+
+        protected override void OnSkillLocated(FiremakingSkill located)
+        {
+            EnsureProgressObjects();
+            skillManager = located.GetComponent<SkillManager>();
+            located.IgnitionStarted += HandleIgnitionStarted;
+            located.IgnitionStopped += HandleIgnitionStopped;
+        }
+
+        protected override void OnSkillDetached(FiremakingSkill previous)
+        {
+            previous.IgnitionStarted -= HandleIgnitionStarted;
+            previous.IgnitionStopped -= HandleIgnitionStopped;
+            skillManager = null;
+            HandleStop();
+        }
+
+        private void HandleIgnitionStarted(FiremakingLogDefinition definition, Vector3 position)
+        {
+            EnsureProgressObjects();
+            hasTarget = true;
+            targetPosition = position;
+            UpdateSegmentSettings();
+            currentFill = 0f;
+            nextFill = progressStep;
+            tickTimer = 0f;
+            if (progressFill != null)
+                progressFill.fillAmount = 0f;
+            if (progressRoot != null)
+            {
+                progressRoot.SetActive(true);
+                progressRoot.transform.position = position + offset;
+            }
+
+            SubscribeToTicker();
+        }
+
+        private void HandleIgnitionStopped()
+        {
+            HandleStop();
+        }
+
+        private void HandleSceneLoaded(Scene scene, LoadSceneMode mode)
+        {
+            EnsureProgressObjects();
+            RefreshSkillSubscription();
+        }
+
+        private void LateUpdate()
+        {
+            if (!hasTarget || progressRoot == null || progressFill == null)
+                return;
+
+            // Keep the HUD hovering just above the ignition target.
+            if (skill != null && skill.IsLighting)
+                targetPosition = skill.CurrentAttemptPosition;
+
+            progressRoot.transform.position = targetPosition + offset;
+
+            tickTimer += Time.deltaTime;
+            if (segmentDuration <= 0f)
+            {
+                progressFill.fillAmount = nextFill;
+                return;
+            }
+
+            float t = Mathf.Clamp01(tickTimer / segmentDuration);
+            progressFill.fillAmount = Mathf.Lerp(currentFill, nextFill, t);
+        }
+
+        public void OnTick()
+        {
+            if (!hasTarget || skill == null || !skill.IsLighting)
+            {
+                HandleStop();
+                return;
+            }
+
+            tickTimer = 0f;
+            UpdateSegmentSettings();
+            currentFill = progressFill != null ? progressFill.fillAmount : currentFill;
+            float normalized = Mathf.Clamp01(skill.IgnitionProgressNormalized);
+            // Ensure the bar always advances even if the skill reports stale progress (e.g. after a failure retry).
+            float targetFill = Mathf.Clamp01(currentFill + progressStep);
+            nextFill = Mathf.Max(normalized, targetFill);
+        }
+
+        private void EnsureProgressObjects()
+        {
+            if (progressRoot != null)
+                return;
+
+            progressRoot = new GameObject("FiremakingProgress");
+            progressRoot.transform.SetParent(transform, false);
+
+            progressCanvas = progressRoot.AddComponent<Canvas>();
+            progressCanvas.renderMode = RenderMode.WorldSpace;
+            progressCanvas.overrideSorting = true;
+            progressRoot.AddComponent<CanvasScaler>();
+            progressRoot.AddComponent<GraphicRaycaster>();
+            progressRoot.transform.localScale = Vector3.one * 0.01f;
+
+            var bg = new GameObject("Background");
+            bg.transform.SetParent(progressRoot.transform, false);
+            var bgImage = bg.AddComponent<Image>();
+            bgImage.color = new Color(0f, 0f, 0f, 0.6f);
+            var bgSprite = Sprite.Create(Texture2D.whiteTexture, new Rect(0f, 0f, 1f, 1f), new Vector2(0.5f, 0.5f));
+            bgImage.sprite = bgSprite;
+            var bgRect = bgImage.rectTransform;
+            bgRect.sizeDelta = new Vector2(120f, 24f);
+
+            var fill = new GameObject("Fill");
+            fill.transform.SetParent(bg.transform, false);
+            progressFill = fill.AddComponent<Image>();
+            progressFill.color = Color.green;
+            progressFill.sprite = bgSprite;
+            progressFill.type = Image.Type.Filled;
+            progressFill.fillMethod = Image.FillMethod.Horizontal;
+            progressFill.fillOrigin = (int)Image.OriginHorizontal.Left;
+            progressFill.fillAmount = 0f;
+            var fillRect = progressFill.rectTransform;
+            fillRect.anchorMin = Vector2.zero;
+            fillRect.anchorMax = Vector2.one;
+            fillRect.offsetMin = Vector2.zero;
+            fillRect.offsetMax = Vector2.zero;
+
+            progressRoot.SetActive(false);
+        }
+
+        private void HandleStop()
+        {
+            hasTarget = false;
+            currentFill = 0f;
+            nextFill = 0f;
+            tickTimer = 0f;
+            segmentDuration = Ticker.TickDuration;
+            if (progressRoot != null)
+                progressRoot.SetActive(false);
+            UnsubscribeFromTicker();
+        }
+
+        private void EnsureSceneGateSubscription()
+        {
+            if (sceneGateSubscribed)
+                return;
+
+            PersistentSceneGate.SceneEvaluationChanged += HandleSceneGateEvaluation;
+            sceneGateSubscribed = true;
+        }
+
+        private void HandleSceneGateEvaluation(Scene scene, bool allowed)
+        {
+            if (instance != this)
+                return;
+
+            if (scene != SceneManager.GetActiveScene())
+                return;
+
+            if (allowed)
+                return;
+
+            PersistentSceneGate.SceneEvaluationChanged -= HandleSceneGateEvaluation;
+            sceneGateSubscribed = false;
+            Destroy(gameObject);
+        }
+
+        private void EnsureSceneLoadedSubscription()
+        {
+            if (sceneLoadedSubscribed)
+                return;
+
+            SceneManager.sceneLoaded += HandleSceneLoaded;
+            sceneLoadedSubscribed = true;
+        }
+
+        private void SubscribeToTicker()
+        {
+            if (tickerSubscribed)
+                return;
+
+            if (Ticker.Instance == null)
+                return;
+
+            Ticker.Instance.Subscribe(this);
+            tickerSubscribed = true;
+        }
+
+        private void UnsubscribeFromTicker()
+        {
+            if (!tickerSubscribed)
+                return;
+
+            if (Ticker.Instance != null)
+                Ticker.Instance.Unsubscribe(this);
+            tickerSubscribed = false;
+        }
+
+        private void UpdateSegmentSettings()
+        {
+            if (skill == null || skill.CurrentDefinition == null)
+            {
+                progressStep = 1f;
+                segmentDuration = Ticker.TickDuration;
+                return;
+            }
+
+            int level = skillManager != null ? skillManager.GetLevel(SkillType.Firemaking) : 1;
+            int ticksRequired = Mathf.Max(1, skill.CurrentDefinition.GetIgnitionTicks(level));
+            progressStep = 1f / ticksRequired;
+            segmentDuration = Ticker.TickDuration;
+        }
+    }
+}

--- a/Assets/Scripts/Skills/SkillType.cs
+++ b/Assets/Scripts/Skills/SkillType.cs
@@ -9,6 +9,8 @@ namespace Skills
     public enum SkillType
     {
         Mining,
+        Cooking,
+        Firemaking,
         Woodcutting,
         Beastmaster,
         Hitpoints,
@@ -16,7 +18,6 @@ namespace Skills
         Strength,
         Defence,
         Magic,
-        Fishing,
-        Cooking
+        Fishing
     }
 }

--- a/Assets/Scripts/Skills/SkillsUI.cs
+++ b/Assets/Scripts/Skills/SkillsUI.cs
@@ -37,6 +37,7 @@ namespace Skills
             SkillType.Beastmaster,
             SkillType.Fishing,
             SkillType.Cooking,
+            SkillType.Firemaking,
             SkillType.Woodcutting,
             SkillType.Mining
         };


### PR DESCRIPTION
## Summary
- add Firemaking skill behaviour, bonfire controller, ground targeting, and dedicated HUD
- create ScriptableObject definitions for firemaking logs and hook XP bonuses into ItemData
- register Firemaking across SkillType, skill UI, and admin debug tooling

## Testing
- not run (Unity editor validations only)

------
https://chatgpt.com/codex/tasks/task_e_68d1815b2814832eb5f580f31cbe5efc