### PR TITLE
Enable tinderbox firemaking from inventory

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -9,6 +9,7 @@ using UnityEngine.InputSystem.UI;
 using ShopSystem;
 using Player;
 using Skills;
+using Skills.Firemaking;
 using Pets;
 using Quests;
 using UI;
@@ -133,6 +134,7 @@ namespace Inventory
 
         private PlayerMover playerMover;
         private Equipment equipment;
+        private FiremakingSkill firemakingSkill;
 
         // UI
         private GameObject uiRoot; // Canvas root
@@ -960,16 +962,21 @@ namespace Inventory
             return false;
         }
 
-        public bool CombineItems(int srcIndex, int dstIndex)
+        public bool CombineItems(int srcIndex, int dstIndex, out bool keepSelection)
         {
-            if (combinationDatabase == null)
-                return false;
+            keepSelection = false;
             if (srcIndex < 0 || dstIndex < 0 || srcIndex >= items.Length || dstIndex >= items.Length)
                 return false;
 
             var srcItem = items[srcIndex].item;
             var dstItem = items[dstIndex].item;
             if (srcItem == null || dstItem == null)
+                return false;
+
+            if (TryHandleFiremakingCombination(srcIndex, dstIndex, srcItem, dstItem, out keepSelection))
+                return true;
+
+            if (combinationDatabase == null)
                 return false;
 
             var result = combinationDatabase.GetResult(srcItem, dstItem);
@@ -991,6 +998,51 @@ namespace Inventory
                 NotifyInventoryChanged(false);
             else
                 NotifyInventoryChanged();
+            return true;
+        }
+
+        private FiremakingSkill GetFiremakingSkill()
+        {
+            if (firemakingSkill == null)
+                firemakingSkill = GetComponent<FiremakingSkill>();
+            return firemakingSkill;
+        }
+
+        private bool TryHandleFiremakingCombination(int srcIndex, int dstIndex, ItemData srcItem, ItemData dstItem, out bool keepSelection)
+        {
+            keepSelection = false;
+
+            var firemaking = GetFiremakingSkill();
+            if (firemaking == null)
+                return false;
+
+            string tinderboxId = firemaking.TinderboxItemId;
+            if (string.IsNullOrEmpty(tinderboxId))
+                return false;
+
+            bool srcIsTinderbox = string.Equals(srcItem.id, tinderboxId, StringComparison.Ordinal);
+            bool dstIsTinderbox = string.Equals(dstItem.id, tinderboxId, StringComparison.Ordinal);
+            if (!srcIsTinderbox && !dstIsTinderbox)
+                return false;
+
+            int logSlot = srcIsTinderbox ? dstIndex : srcIndex;
+            ItemData logItem = srcIsTinderbox ? dstItem : srcItem;
+            if (logItem == null)
+                return false;
+
+            if (firemaking.GetDefinitionForItem(logItem.id) == null)
+                return false;
+
+            keepSelection = true;
+            selectedIndex = logSlot;
+
+            if (!firemaking.BeginLightingFromInventory(logSlot, out var failureReason) && !string.IsNullOrEmpty(failureReason))
+            {
+                Vector3 feedbackPosition = transform != null ? transform.position : Vector3.zero;
+                feedbackPosition = firemaking.SnapToIgnitionPoint(feedbackPosition);
+                FloatingText.Show(failureReason, feedbackPosition);
+            }
+
             return true;
         }
 

--- a/Assets/Scripts/Inventory/InventorySlot.cs
+++ b/Assets/Scripts/Inventory/InventorySlot.cs
@@ -105,11 +105,19 @@ namespace Inventory
                 }
                 else
                 {
-                    inventory.CombineItems(inventory.selectedIndex, index);
-                    int prev = inventory.selectedIndex;
-                    inventory.ClearSelection();
-                    inventory.UpdateSlotVisual(prev);
+                    int previouslySelected = inventory.selectedIndex;
+                    bool keepSelection;
+                    inventory.CombineItems(previouslySelected, index, out keepSelection);
+                    int newSelection = inventory.selectedIndex;
+
+                    if (!keepSelection)
+                        inventory.ClearSelection();
+
+                    inventory.UpdateSlotVisual(previouslySelected);
                     inventory.UpdateSlotVisual(index);
+
+                    if (keepSelection && newSelection != previouslySelected && newSelection != index)
+                        inventory.UpdateSlotVisual(newSelection);
                 }
                 return;
             }

--- a/Assets/Scripts/Skills/Firemaking/Core/FiremakingGroundTarget.cs
+++ b/Assets/Scripts/Skills/Firemaking/Core/FiremakingGroundTarget.cs
@@ -15,6 +15,9 @@ namespace Skills.Firemaking
         [SerializeField] private Inventory.Inventory inventory;
         [SerializeField] private Camera worldCamera;
         [SerializeField] private LayerMask fireSearchLayers;
+        [SerializeField] private bool allowManualIgnitionPlacement;
+        [SerializeField, Tooltip("Feedback shown when manual placement is disabled and the helper is invoked instead.")]
+        private string manualPlacementDisabledMessage = "Use a tinderbox on the logs to light a fire.";
 
         /// <summary>
         ///     Locates the Firemaking skill, player inventory, and ensures the camera has a Physics2D raycaster for UI clicks.
@@ -73,6 +76,24 @@ namespace Skills.Firemaking
                 Collider2D hit = Physics2D.OverlapPoint(snapped, fireSearchLayers);
                 if (hit != null)
                     targetFire = hit.GetComponentInParent<FiremakingFire>() ?? hit.GetComponent<FiremakingFire>();
+            }
+
+            if (targetFire == null && !allowManualIgnitionPlacement)
+            {
+                if (skill != null && inventory != null && inventory.selectedIndex >= 0)
+                {
+                    if (!skill.BeginLightingFromInventory(inventory.selectedIndex, out var helperFailure) &&
+                        !string.IsNullOrEmpty(helperFailure))
+                    {
+                        FloatingText.Show(helperFailure, snapped);
+                    }
+                }
+                else if (!string.IsNullOrEmpty(manualPlacementDisabledMessage))
+                {
+                    FloatingText.Show(manualPlacementDisabledMessage, snapped);
+                }
+
+                return;
             }
 
             if (!skill.TryBeginLighting(inventory.selectedIndex, snapped, targetFire, out var failureReason))

--- a/Assets/Scripts/Skills/Firemaking/Core/FiremakingSkill.cs
+++ b/Assets/Scripts/Skills/Firemaking/Core/FiremakingSkill.cs
@@ -83,6 +83,11 @@ namespace Skills.Firemaking
         public FiremakingLogDefinition CurrentDefinition => currentAttempt.definition;
 
         /// <summary>
+        ///     Identifier of the tinderbox item required to ignite logs.
+        /// </summary>
+        public string TinderboxItemId => tinderboxItemId;
+
+        /// <summary>
         ///     Runtime flag used by the admin menu to toggle verbose debug logging.
         /// </summary>
         public bool EnableDebugLogging
@@ -316,6 +321,31 @@ namespace Skills.Firemaking
             IgnitionStarted?.Invoke(definition, snappedPosition);
             LogDebug($"Started lighting {definition.displayName} at {snappedPosition} (feeding existing: {feedingExisting}).");
             return true;
+        }
+
+        /// <summary>
+        ///     Attempts to light the selected logs at the player's current tile without requiring a ground target component.
+        /// </summary>
+        /// <param name="logSlot">Inventory slot that contains the logs to ignite.</param>
+        /// <param name="failureReason">Outputs a player-facing message when the attempt cannot start.</param>
+        /// <returns><c>true</c> when the ignition attempt was started, otherwise <c>false</c>.</returns>
+        public bool BeginLightingFromInventory(int logSlot, out string failureReason)
+        {
+            failureReason = string.Empty;
+            Vector3 anchorPosition = transform != null ? transform.position : Vector3.zero;
+            anchorPosition.z = 0f;
+            Vector3 snapped = SnapToIgnitionPoint(anchorPosition);
+
+            FiremakingFire targetFire = null;
+            if (existingFireLayers.value != 0)
+            {
+                Vector2 checkSize = ResolveCollisionCheckSize();
+                Collider2D fireCollider = Physics2D.OverlapBox(snapped, checkSize * 0.9f, 0f, existingFireLayers);
+                if (fireCollider != null)
+                    targetFire = fireCollider.GetComponentInParent<FiremakingFire>() ?? fireCollider.GetComponent<FiremakingFire>();
+            }
+
+            return TryBeginLighting(logSlot, snapped, targetFire, out failureReason);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- short-circuit inventory combinations so tinderbox on logs starts the Firemaking ignition flow and keeps the log slot selected
- expose a FiremakingSkill helper that lights logs from the player tile and reuse it from the ground target when manual placement is disabled
- add an optional flag on FiremakingGroundTarget to reserve it for bonfire feeding while still surfacing failure feedback

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68d19e5adec8832e9c0e9d81fa49d2ee