### PR TITLE
Ensure firemaking fires drop ashes via ground spawner

### DIFF
--- a/Assets/Scripts/Skills/Firemaking/Core/FiremakingFire.cs
+++ b/Assets/Scripts/Skills/Firemaking/Core/FiremakingFire.cs
@@ -61,14 +61,21 @@ namespace Skills.Firemaking
             int initialTicks,
             int maxTicks,
             ItemData ashesItem,
-            GroundItemSpawner spawner,
-            AudioClip igniteSound,
-            AudioClip extinguishSound)
+            GroundItemSpawner spawner = null,
+            AudioClip igniteSound = null,
+            AudioClip extinguishSound = null)
         {
             // Cache everything so subsequent fuel additions share the same configuration.
             SourceLog = definition;
             this.ashesItem = ashesItem;
-            groundItemSpawner = spawner;
+            if (spawner != null)
+            {
+                groundItemSpawner = spawner;
+            }
+            else if (groundItemSpawner == null)
+            {
+                groundItemSpawner = ResolveGroundItemSpawner();
+            }
             igniteClip = igniteSound;
             extinguishClip = extinguishSound;
 
@@ -194,15 +201,37 @@ namespace Skills.Firemaking
                     AudioSource.PlayClipAtPoint(extinguishClip, transform.position);
             }
 
-            // Spawn ashes when an item definition was supplied.
-            if (groundItemSpawner != null && ashesItem != null)
-                groundItemSpawner.Spawn(ashesItem, 1, transform.position);
+            if (ashesItem != null)
+            {
+                var spawner = ResolveGroundItemSpawner();
+                if (spawner != null)
+                {
+                    spawner.Spawn(ashesItem, 1, transform.position);
+                }
+                else
+                {
+                    Debug.LogWarning($"[FiremakingFire] Unable to spawn ashes at {transform.position} because no GroundItemSpawner was found.");
+                }
+            }
 
             // Notify listeners before the GameObject is destroyed.
             Extinguished?.Invoke(this);
 
             // Destroy the visual so the world is cleared once the fire expires.
             Destroy(gameObject);
+        }
+
+        /// <summary>
+        ///     Attempts to resolve the shared <see cref="GroundItemSpawner"/> so extinguished fires can drop ashes via the loot pipeline.
+        /// </summary>
+        /// <returns>Spawner instance when located; otherwise <c>null</c>.</returns>
+        private GroundItemSpawner ResolveGroundItemSpawner()
+        {
+            if (groundItemSpawner != null)
+                return groundItemSpawner;
+
+            groundItemSpawner = FindObjectOfType<GroundItemSpawner>(true);
+            return groundItemSpawner;
         }
     }
 }

--- a/Assets/Scripts/Skills/Firemaking/Core/FiremakingSkill.cs
+++ b/Assets/Scripts/Skills/Firemaking/Core/FiremakingSkill.cs
@@ -149,8 +149,7 @@ namespace Skills.Firemaking
                 equipment = GetComponent<Equipment>();
             if (playerMover == null)
                 playerMover = GetComponent<PlayerMover>();
-            if (groundItemSpawner == null)
-                groundItemSpawner = FindObjectOfType<GroundItemSpawner>();
+            ResolveGroundItemSpawner();
             if (floatingTextAnchor == null)
                 floatingTextAnchor = transform;
 
@@ -451,6 +450,7 @@ namespace Skills.Firemaking
 
             if (createdNewFire)
             {
+                GroundItemSpawner spawner = ResolveGroundItemSpawner();
                 GameObject prefab = definition.firePrefab != null ? definition.firePrefab : defaultFirePrefab;
                 GameObject instance;
                 if (prefab != null)
@@ -468,7 +468,27 @@ namespace Skills.Firemaking
                     fire = instance.AddComponent<FiremakingFire>();
 
                 fire.SetOwner(this);
-                fire.Initialise(definition, lifetime, definition.maxLifetimeTicks, ashesItem, groundItemSpawner, definition.igniteSound, definition.extinguishSound);
+                if (spawner != null)
+                {
+                    fire.Initialise(
+                        definition,
+                        lifetime,
+                        definition.maxLifetimeTicks,
+                        ashesItem,
+                        spawner,
+                        definition.igniteSound,
+                        definition.extinguishSound);
+                }
+                else
+                {
+                    fire.Initialise(
+                        definition,
+                        lifetime,
+                        definition.maxLifetimeTicks,
+                        ashesItem,
+                        igniteSound: definition.igniteSound,
+                        extinguishSound: definition.extinguishSound);
+                }
                 EnsureFireTracked(fire);
             }
             else
@@ -662,6 +682,29 @@ namespace Skills.Firemaking
             }
 
             activeFires.Clear();
+        }
+
+        /// <summary>
+        ///     Locates the shared <see cref="GroundItemSpawner"/> responsible for ground loot and caches it for future fires.
+        /// </summary>
+        /// <returns>Cached spawner reference when available; otherwise <c>null</c>.</returns>
+        private GroundItemSpawner ResolveGroundItemSpawner()
+        {
+            if (groundItemSpawner != null)
+                return groundItemSpawner;
+
+            var spawner = FindObjectOfType<GroundItemSpawner>(true);
+            if (spawner != null)
+            {
+                groundItemSpawner = spawner;
+                LogDebug($"Resolved GroundItemSpawner instance '{spawner.name}'.");
+            }
+            else
+            {
+                Debug.LogWarning("[FiremakingSkill] Unable to locate a GroundItemSpawner in the active scene. Ashes drops will be skipped until one is available.");
+            }
+
+            return groundItemSpawner;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- add a helper in FiremakingSkill to resolve and cache the scene GroundItemSpawner before spawning new fires, with debug logging and fallbacks
- update FiremakingFire to lazily resolve the GroundItemSpawner when extinguishing and use the shared drop spawner for ashes, warning if it is missing

## Testing
- not run (Unity editor required)

------
https://chatgpt.com/codex/tasks/task_e_68d1ae8d6e68832e8812513818504ad8