### PR TITLE
Ensure bonfire reacquires player references at runtime

### DIFF
--- a/Assets/Scripts/Skills/Firemaking/Core/FiremakingBonfireObject.cs
+++ b/Assets/Scripts/Skills/Firemaking/Core/FiremakingBonfireObject.cs
@@ -38,18 +38,58 @@ namespace Skills.Firemaking
         /// </summary>
         private void Awake()
         {
-            var playerObject = GameObject.FindGameObjectWithTag("Player");
-            if (playerObject != null)
-            {
-                inventory = playerObject.GetComponent<Inventory.Inventory>();
-                firemakingSkill = playerObject.GetComponent<FiremakingSkill>();
-                playerMover = playerObject.GetComponent<PlayerMover>();
-                playerTransform = playerObject.transform;
-            }
+            EnsurePlayerReferences();
 
             var mainCamera = Camera.main;
             if (mainCamera != null && mainCamera.GetComponent<Physics2DRaycaster>() == null)
                 mainCamera.gameObject.AddComponent<Physics2DRaycaster>();
+        }
+
+        /// <summary>
+        ///     Ensures the bonfire is still tracking the active player after
+        ///     disable/enable cycles so runtime-spawned characters can interact
+        ///     without requiring a scene reload.
+        /// </summary>
+        private void OnEnable()
+        {
+            EnsurePlayerReferences();
+        }
+
+        /// <summary>
+        ///     Attempts to locate the player object via tag lookups and caches
+        ///     the components the bonfire relies on for interaction. When the
+        ///     search fails a floating text toast informs the player so clicks
+        ///     do not silently do nothing.
+        /// </summary>
+        /// <param name="showFailureMessage">
+        ///     When true, a floating text message is displayed if the player
+        ///     cannot be located.
+        /// </param>
+        /// <returns>
+        ///     True when the required references (inventory, firemaking skill
+        ///     and player transform) were located; otherwise false.
+        /// </returns>
+        private bool EnsurePlayerReferences(bool showFailureMessage = false)
+        {
+            bool needsRefresh = inventory == null || firemakingSkill == null ||
+                                playerMover == null || playerTransform == null;
+            if (!needsRefresh)
+                return true;
+
+            var playerObject = GameObject.FindGameObjectWithTag("Player");
+            if (playerObject != null)
+            {
+                inventory ??= playerObject.GetComponent<Inventory.Inventory>();
+                firemakingSkill ??= playerObject.GetComponent<FiremakingSkill>();
+                playerMover ??= playerObject.GetComponent<PlayerMover>();
+                playerTransform = playerObject.transform;
+            }
+
+            bool hasEssentials = inventory != null && firemakingSkill != null && playerTransform != null;
+            if (!hasEssentials && showFailureMessage)
+                FloatingText.Show("You need your adventurer to use the bonfire.", transform.position);
+
+            return hasEssentials;
         }
 
         /// <summary>
@@ -63,7 +103,7 @@ namespace Skills.Firemaking
             if (eventData == null || eventData.button != PointerEventData.InputButton.Left)
                 return;
 
-            if (inventory == null || firemakingSkill == null)
+            if (!EnsurePlayerReferences(true))
                 return;
 
             int selectedIndex = inventory.selectedIndex;


### PR DESCRIPTION
## Summary
- add a helper on the bonfire object to reacquire player inventory, firemaking, mover, and transform references
- call the helper from lifecycle methods and pointer clicks so runtime-spawned players can fuel bonfires, surfacing a floating text error when unavailable

## Testing
- not run (Unity Editor play mode required)


------
https://chatgpt.com/codex/tasks/task_e_68d257005960832e94bcd2e1bb115417