### PR TITLE
Align bonfire interactions with existing interactable layer

### DIFF
--- a/Assets/Prefabs/MainScriptObjects/Player.prefab
+++ b/Assets/Prefabs/MainScriptObjects/Player.prefab
@@ -79,6 +79,7 @@ GameObject:
   - component: {fileID: -8837884572014598511}
   - component: {fileID: -2219103460593389809}
   - component: {fileID: 4293722103470127009}
+  - component: {fileID: 1218445456886628537}
   m_Layer: 8
   m_Name: Player
   m_TagString: Player
@@ -949,3 +950,32 @@ MonoBehaviour:
   enableDebugLogging: 0
   allowTileSnapping: 1
   tileSnapSize: {x: 1, y: 1}
+--- !u!114 &1218445456886628537
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4297641342699346684}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 716da45a93c34af5b5b06ff231a5d6fd, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  defaultInteractRange: 1.5
+  defaultCancelDistance: 3
+  interactionCooldownSeconds: 0.2
+  prospectCooldownSeconds: 3
+  autoMoveIntoRange: 1
+  autoMoveStopBuffer: 0.1
+  playerInput: {fileID: 0}
+  interactActionReference: {fileID: 0}
+  prospectActionReference: {fileID: 0}
+  cancelActionReference: {fileID: 0}
+  skill: {fileID: 4293722103470127009}
+  playerMover: {fileID: 5825080390935697164}
+  worldCamera: {fileID: 0}
+  bonfireMask:
+    serializedVersion: 2
+    m_Bits: 128
+  inventory: {fileID: 491447706204386932}

--- a/Assets/Scripts/Skills/Firemaking/Core/FiremakingBonfireController.cs
+++ b/Assets/Scripts/Skills/Firemaking/Core/FiremakingBonfireController.cs
@@ -1,0 +1,146 @@
+using Inventory;
+using Skills.Common;
+using UnityEngine;
+
+namespace Skills.Firemaking
+{
+    /// <summary>
+    ///     Handles player interaction with permanent bonfires by delegating shared behaviour to
+    ///     <see cref="GatheringController{TSkill,TNode}"/>. Reads the highlighted log from the
+    ///     inventory, validates range, and passes the request to <see cref="FiremakingSkill"/> so
+    ///     the existing tick-driven fueling loop remains authoritative.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public sealed class FiremakingBonfireController : GatheringController<FiremakingSkill, FiremakingBonfireObject>
+    {
+        private const string InteractableLayerName = "Interactable";
+
+        [Header("Bonfire Search")]
+        [SerializeField]
+        [Tooltip("Physics layers that contain bonfires the player can fuel.")]
+        private LayerMask bonfireMask = LayerMask.GetMask(InteractableLayerName);
+
+        [Header("Inventory")]
+        [SerializeField]
+        [Tooltip("Inventory providing the highlighted log selection for bonfire fueling.")]
+        private Inventory.Inventory inventory;
+
+        /// <summary>
+        ///     Cache optional references on Awake while still letting the base controller wire the
+        ///     shared gathering dependencies.
+        /// </summary>
+        protected override void Awake()
+        {
+            base.Awake();
+
+            if (bonfireMask == 0)
+                bonfireMask = ResolveDefaultMask();
+
+            if (inventory == null)
+                inventory = GetComponent<Inventory.Inventory>();
+        }
+
+        /// <summary>
+        ///     Bonfires should continue to accept clicks even if the pointer is hovering UI, matching
+        ///     the fishing controller behaviour so banking or chat overlays do not block fueling.
+        /// </summary>
+        protected override bool BlockMouseWhilePointerOverUI => false;
+
+        /// <inheritdoc />
+        protected override bool IsPerformingAction => Skill != null && Skill.IsFeedingBonfire;
+
+        /// <inheritdoc />
+        protected override FiremakingBonfireObject CurrentNode => Skill != null ? Skill.ActiveBonfire : null;
+
+        /// <inheritdoc />
+        protected override void StopAction()
+        {
+            Skill?.StopBonfireFeeding(false, null);
+        }
+
+        /// <inheritdoc />
+        protected override FiremakingBonfireObject FindNodeAtWorldPosition(Vector2 worldPosition)
+        {
+            var colliders = Physics2D.OverlapPointAll(worldPosition, bonfireMask);
+            foreach (var collider in colliders)
+            {
+                if (collider == null)
+                    continue;
+
+                var bonfire = collider.GetComponentInParent<FiremakingBonfireObject>();
+                if (bonfire == null)
+                    bonfire = collider.GetComponent<FiremakingBonfireObject>();
+                if (bonfire != null)
+                    return bonfire;
+            }
+
+            return null;
+        }
+
+        /// <inheritdoc />
+        protected override bool HasInventorySpace(FiremakingBonfireObject node, out string failureMessage)
+        {
+            failureMessage = string.Empty;
+            return true;
+        }
+
+        /// <inheritdoc />
+        protected override float GetInteractionRange(FiremakingBonfireObject node)
+        {
+            return node != null ? Mathf.Max(0f, node.CancelDistance) : base.GetInteractionRange(node);
+        }
+
+        /// <inheritdoc />
+        protected override float GetCancelDistance(FiremakingBonfireObject node)
+        {
+            return node != null ? Mathf.Max(0f, node.CancelDistance) : base.GetCancelDistance(node);
+        }
+
+        /// <inheritdoc />
+        protected override bool TryStartAction(FiremakingBonfireObject node, out string failureMessage)
+        {
+            failureMessage = string.Empty;
+
+            if (Skill == null || node == null)
+            {
+                failureMessage = "That bonfire is no longer available.";
+                return false;
+            }
+
+            if (inventory == null)
+                inventory = GetComponent<Inventory.Inventory>();
+
+            if (inventory == null)
+            {
+                failureMessage = "You need an inventory to add logs.";
+                return false;
+            }
+
+            int selectedIndex = inventory.selectedIndex;
+            if (selectedIndex < 0)
+            {
+                failureMessage = "Select a log to feed the bonfire.";
+                return false;
+            }
+
+            if (!Skill.TryStartBonfireFeeding(node, selectedIndex, out failureMessage))
+                return false;
+
+            inventory.ClearSelection();
+            return true;
+        }
+
+        /// <summary>
+        ///     Attempts to build a sensible default mask when the inspector value is cleared or when
+        ///     the target layer is missing from the project.
+        /// </summary>
+        private static LayerMask ResolveDefaultMask()
+        {
+            int interactableLayer = LayerMask.NameToLayer(InteractableLayerName);
+            if (interactableLayer >= 0)
+                return 1 << interactableLayer;
+
+            return Physics2D.AllLayers;
+        }
+    }
+}

--- a/Assets/Scripts/Skills/Firemaking/Core/FiremakingBonfireController.cs.meta
+++ b/Assets/Scripts/Skills/Firemaking/Core/FiremakingBonfireController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 716da45a93c34af5b5b06ff231a5d6fd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Skills/Firemaking/Core/FiremakingBonfireObject.cs
+++ b/Assets/Scripts/Skills/Firemaking/Core/FiremakingBonfireObject.cs
@@ -1,176 +1,48 @@
-using Inventory;
-using Player;
-using UI;
 using UnityEngine;
-using UnityEngine.EventSystems;
 
 namespace Skills.Firemaking
 {
     /// <summary>
-    ///     Permanent bonfire world object. Players can click it while having a log
-    ///     selected to begin the automated fuel workflow handled by <see cref="FiremakingSkill"/>.
-    ///     The component resolves the player references on awake and forwards pointer
-    ///     clicks to the skill so the shared tick loop can process each 4-tick fuel
-    ///     cycle.
+    ///     Permanent bonfire world object used by <see cref="FiremakingSkill"/>. The component now
+    ///     simply exposes the cancel distance and notifies the skill if the bonfire becomes
+    ///     unavailable so active fueling sessions end immediately.
     /// </summary>
     [RequireComponent(typeof(Collider2D))]
     [DisallowMultipleComponent]
-    public sealed class FiremakingBonfireObject : MonoBehaviour, IPointerClickHandler
+    public sealed class FiremakingBonfireObject : MonoBehaviour
     {
         [SerializeField]
         [Tooltip("Maximum distance the player can move away before fueling cancels.")]
         private float cancelDistance = 3f;
 
-        private Inventory.Inventory inventory;
-        private FiremakingSkill firemakingSkill;
-        private PlayerMover playerMover;
-        private Transform playerTransform;
+        private FiremakingSkill cachedSkill;
 
         /// <summary>
-        ///     Distance threshold used when checking whether the player has stepped
-        ///     too far away from the bonfire during fueling.
+        ///     Distance threshold used when checking whether the player has stepped too far away from
+        ///     the bonfire during fueling.
         /// </summary>
         public float CancelDistance => cancelDistance;
 
         /// <summary>
-        ///     Caches the player components and ensures the active camera can raycast
-        ///     into 2D physics so pointer clicks reach this object.
+        ///     Cache the Firemaking skill reference so the component can request cancellation without
+        ///     performing repeated scene lookups.
         /// </summary>
         private void Awake()
         {
-            EnsurePlayerReferences();
-            EnsureCameraRaycaster();
+            cachedSkill = FindObjectOfType<FiremakingSkill>();
         }
 
         /// <summary>
-        ///     Ensures the bonfire is still tracking the active player after
-        ///     disable/enable cycles so runtime-spawned characters can interact
-        ///     without requiring a scene reload.
-        /// </summary>
-        private void OnEnable()
-        {
-            EnsurePlayerReferences();
-            EnsureCameraRaycaster();
-        }
-
-        /// <summary>
-        ///     Attempts to locate the player object via tag lookups and caches
-        ///     the components the bonfire relies on for interaction. When the
-        ///     search fails a floating text toast informs the player so clicks
-        ///     do not silently do nothing.
-        /// </summary>
-        /// <param name="showFailureMessage">
-        ///     When true, a floating text message is displayed if the player
-        ///     cannot be located.
-        /// </param>
-        /// <returns>
-        ///     True when the required references (inventory, firemaking skill
-        ///     and player transform) were located; otherwise false.
-        /// </returns>
-        private bool EnsurePlayerReferences(bool showFailureMessage = false)
-        {
-            bool needsRefresh = inventory == null || firemakingSkill == null ||
-                                playerMover == null || playerTransform == null;
-            if (!needsRefresh)
-                return true;
-
-            var playerObject = GameObject.FindGameObjectWithTag("Player");
-            if (playerObject != null)
-            {
-                inventory ??= playerObject.GetComponent<Inventory.Inventory>();
-                firemakingSkill ??= playerObject.GetComponent<FiremakingSkill>();
-                playerMover ??= playerObject.GetComponent<PlayerMover>();
-                playerTransform = playerObject.transform;
-            }
-
-            bool hasEssentials = inventory != null && firemakingSkill != null && playerTransform != null;
-            if (!hasEssentials && showFailureMessage)
-                FloatingText.Show("You need your adventurer to use the bonfire.", transform.position);
-
-            return hasEssentials;
-        }
-
-        /// <summary>
-        ///     Responds to player clicks by asking the Firemaking skill to begin a
-        ///     bonfire fueling session. Validation (selected logs, level checks, etc.)
-        ///     happens inside the skill so the feedback stays centralised.
-        /// </summary>
-        /// <param name="eventData">Pointer payload provided by Unity's event system.</param>
-        public void OnPointerClick(PointerEventData eventData)
-        {
-            if (eventData == null || eventData.button != PointerEventData.InputButton.Left)
-                return;
-
-            if (!EnsureCameraRaycaster())
-                return;
-
-            if (!EnsurePlayerReferences(true))
-                return;
-
-            int selectedIndex = inventory.selectedIndex;
-            if (selectedIndex < 0)
-                return;
-
-            var entry = inventory.GetSlot(selectedIndex);
-            if (entry.item == null)
-                return;
-
-            if (playerMover != null && playerMover.IsMoving)
-            {
-                // Prompt the player to stand still before attempting to feed the bonfire.
-                FloatingText.Show("You need to stop moving first.", transform.position);
-                return;
-            }
-
-            if (playerTransform != null && cancelDistance > 0f &&
-                Vector3.Distance(playerTransform.position, transform.position) > cancelDistance)
-            {
-                FloatingText.Show("You are too far away from the bonfire.", transform.position);
-                return;
-            }
-
-            if (!firemakingSkill.TryStartBonfireFeeding(this, selectedIndex, out var failureReason))
-            {
-                if (!string.IsNullOrEmpty(failureReason))
-                    FloatingText.Show(failureReason, transform.position);
-                return;
-            }
-
-            // Clear the inventory highlight so repeated clicks continue to use the same log stack.
-            inventory.ClearSelection();
-        }
-
-        /// <summary>
-        ///     Makes sure the active main camera can emit 2D physics raycasts so UI
-        ///     clicks reach the bonfire collider. When a camera is present but already
-        ///     configured with a <see cref="Physics2DRaycaster"/> the helper exits
-        ///     without creating duplicates. Returns false if no main camera is currently
-        ///     available so the caller can retry on future frames.
-        /// </summary>
-        /// <returns>
-        ///     True when a raycaster is guaranteed to exist; otherwise false.
-        /// </returns>
-        private bool EnsureCameraRaycaster()
-        {
-            var mainCamera = Camera.main;
-            if (mainCamera == null)
-                return false;
-
-            if (mainCamera.TryGetComponent<Physics2DRaycaster>(out var existingRaycaster) && existingRaycaster != null)
-                return true;
-
-            mainCamera.gameObject.AddComponent<Physics2DRaycaster>();
-            return true;
-        }
-
-        /// <summary>
-        ///     When the bonfire is disabled while fueling is active we notify the
-        ///     skill so the player receives the appropriate cancellation feedback.
+        ///     When the bonfire is disabled while fueling is active we notify the skill so the player
+        ///     receives the appropriate cancellation feedback.
         /// </summary>
         private void OnDisable()
         {
-            if (firemakingSkill != null && firemakingSkill.IsFeedingBonfire && firemakingSkill.ActiveBonfire == this)
-                firemakingSkill.StopBonfireFeeding(true, "The bonfire is no longer available.");
+            if (cachedSkill == null)
+                cachedSkill = FindObjectOfType<FiremakingSkill>();
+
+            if (cachedSkill != null && cachedSkill.IsFeedingBonfire && cachedSkill.ActiveBonfire == this)
+                cachedSkill.StopBonfireFeeding(true, "The bonfire is no longer available.");
         }
     }
 }

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -16,8 +16,7 @@ TagManager:
   - Interactable
   - Player
   - Pets
-  - 
-  - 
+  -
   - 
   - 
   - 


### PR DESCRIPTION
## Summary
- default the bonfire controller's mask to the shared Interactable layer and fall back gracefully if it is missing
- move the bonfire and player prefab configuration back to layer 7 so fueling searches match other gathering objects
- remove the dedicated Bonfire physics layer from project settings to keep the shared interactable setup

## Testing
- not run (Unity editor only)


------
https://chatgpt.com/codex/tasks/task_e_68d279880798832eab22b89928248e2e