### PR TITLE
Persist account spawn location on save

### DIFF
--- a/Assets/Scripts/Core/Save/SaveManager.cs
+++ b/Assets/Scripts/Core/Save/SaveManager.cs
@@ -174,6 +174,45 @@ namespace Core.Save
         }
 
         /// <summary>
+        /// Updates the bound account with the latest scene and position metadata so the login flow
+        /// can restore the player to the correct location on the next session.
+        /// </summary>
+        /// <param name="scene">Scene name that should be persisted for the active account.</param>
+        /// <param name="position">World position that should be recorded.</param>
+        internal static void UpdateLastKnownLocation(string scene, Vector3 position)
+        {
+            if (boundAccount == null)
+                return;
+
+            string resolvedScene = scene ?? string.Empty;
+            bool changed = false;
+
+            if (!string.Equals(boundAccount.savedSceneName, resolvedScene, StringComparison.Ordinal))
+            {
+                boundAccount.savedSceneName = resolvedScene;
+                changed = true;
+            }
+
+            if (!Mathf.Approximately(boundAccount.savedX, position.x))
+            {
+                boundAccount.savedX = position.x;
+                changed = true;
+            }
+
+            if (!Mathf.Approximately(boundAccount.savedY, position.y))
+            {
+                boundAccount.savedY = position.y;
+                changed = true;
+            }
+
+            if (!changed)
+                return;
+
+            cacheDirty = true;
+            FlushActiveAccount();
+        }
+
+        /// <summary>
         /// Normalises and activates a profile for subsequent save and load operations. Provided for
         /// backwards compatibility; prefer <see cref="BindAccount"/> when authenticating users.
         /// </summary>

--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -523,6 +523,7 @@ namespace Player
                 scene = SceneManager.GetActiveScene().name
             };
             SaveManager.Save(PositionKey, data);
+            SaveManager.UpdateLastKnownLocation(data.scene, pos);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- add a SaveManager helper that syncs the bound account's last scene and coordinates
- update PlayerMover.SavePosition to push the scene/position metadata into the bound account after each autosave

## Testing
- not run (Unity editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d296fe8de8832ea450fe4cff94e60d