### PR TITLE
Allow minimap drag with middle mouse button

### DIFF
--- a/Assets/Scripts/World/Minimap.cs
+++ b/Assets/Scripts/World/Minimap.cs
@@ -425,7 +425,7 @@ namespace World
 
             if (mapCamera != null)
             {
-                if (IsExpanded && expandedMapRect != null && Input.GetMouseButton(1))
+                if (IsExpanded && expandedMapRect != null && (Input.GetMouseButton(1) || Input.GetMouseButton(2)))
                 {
                     float worldPerPixel = (mapCamera.orthographicSize * 2f) / expandedMapRect.rect.height;
                     dragOffset += new Vector3(-Input.GetAxis("Mouse X"), -Input.GetAxis("Mouse Y"), 0f) * worldPerPixel * 10f;


### PR DESCRIPTION
## Summary
- allow the expanded minimap to treat either the right or middle mouse buttons as valid drag inputs so players can pan while holding the scroll wheel

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2bf05181c832eb053a25d12daa6fb