### PR TITLE
Refactor cooking interaction to use gathering controller

### DIFF
--- a/Assets/Scripts/Skills/Cooking/Core/CookingController.cs
+++ b/Assets/Scripts/Skills/Cooking/Core/CookingController.cs
@@ -1,0 +1,284 @@
+using System.Collections.Generic;
+using Inventory;
+using Skills.Common;
+using UnityEngine;
+
+namespace Skills.Cooking
+{
+    /// <summary>
+    ///     Handles player interaction with <see cref="CookingObject"/> instances by delegating shared
+    ///     behaviour to <see cref="GatheringController{TSkill, TNode}"/>. Validates selected ingredients,
+    ///     enforces Cooking level requirements, and instructs the skill component to begin cooking.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class CookingController : GatheringController<CookingSkill, CookingObject>
+    {
+        [SerializeField]
+        [Tooltip("Layer mask used when searching for cooking stations.")]
+        private LayerMask cookingStationMask = LayerMask.GetMask("Interactable");
+
+        private static readonly Dictionary<string, CookableRecipe> RecipeLookup = new();
+        private static bool recipesLoaded;
+
+        private Inventory.Inventory inventory;
+        private CookableRecipe cachedRecipe;
+        private ItemData cachedRawItem;
+        private CookingObject cachedStation;
+        private int cachedQuantity;
+        private string cachedFailureMessage;
+
+        private CookingSkill CookingSkill => Skill;
+
+        /// <summary>
+        ///     Resolve optional references and ensure the recipe dictionary is ready.
+        /// </summary>
+        protected override void Awake()
+        {
+            base.Awake();
+            if (inventory == null)
+                inventory = GetComponent<Inventory.Inventory>();
+            if (inventory == null && CookingSkill != null)
+                inventory = CookingSkill.GetComponent<Inventory.Inventory>();
+            EnsureRecipeLookup();
+            if (cookingStationMask == 0)
+                cookingStationMask = ~0;
+        }
+
+        /// <summary>
+        ///     Subscribe to skill events so cached state clears whenever cooking stops externally.
+        /// </summary>
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+            if (CookingSkill != null)
+                CookingSkill.OnStopCooking += HandleSkillStopped;
+        }
+
+        /// <summary>
+        ///     Unsubscribe from skill events when disabled and clear cached selections.
+        /// </summary>
+        protected override void OnDisable()
+        {
+            if (CookingSkill != null)
+                CookingSkill.OnStopCooking -= HandleSkillStopped;
+            base.OnDisable();
+            ClearCachedInteraction();
+        }
+
+        /// <inheritdoc />
+        protected override bool BlockMouseWhilePointerOverUI => false;
+
+        /// <inheritdoc />
+        protected override bool IsPerformingAction => CookingSkill != null && CookingSkill.IsCooking;
+
+        /// <inheritdoc />
+        protected override CookingObject CurrentNode => CookingSkill != null ? CookingSkill.ActiveCookingObject : null;
+
+        /// <inheritdoc />
+        protected override CookingObject FindNodeAtWorldPosition(Vector2 worldPosition)
+        {
+            var colliders = Physics2D.OverlapPointAll(worldPosition, cookingStationMask);
+            foreach (var collider in colliders)
+            {
+                var station = collider.GetComponentInParent<CookingObject>();
+                if (station != null)
+                    return station;
+            }
+            return null;
+        }
+
+        /// <inheritdoc />
+        protected override float GetInteractionRange(CookingObject node)
+        {
+            return node != null ? node.InteractionRange : base.GetInteractionRange(node);
+        }
+
+        /// <inheritdoc />
+        protected override float GetCancelDistance(CookingObject node)
+        {
+            return node != null ? node.CancelDistance : base.GetCancelDistance(node);
+        }
+
+        /// <summary>
+        ///     Use the optional approach anchor if one is supplied on the station.
+        /// </summary>
+        protected override Transform GetApproachTransform(CookingObject node)
+        {
+            return node != null ? node.ApproachAnchor : base.GetApproachTransform(node);
+        }
+
+        /// <inheritdoc />
+        protected override void StopAction()
+        {
+            CookingSkill?.StopCooking();
+            ClearCachedInteraction();
+        }
+
+        /// <inheritdoc />
+        protected override bool ValidateNode(CookingObject node, out string failureMessage)
+        {
+            failureMessage = string.Empty;
+            cachedFailureMessage = string.Empty;
+            cachedRecipe = null;
+            cachedRawItem = null;
+            cachedStation = null;
+            cachedQuantity = 0;
+
+            if (CookingSkill == null || inventory == null || node == null)
+            {
+                failureMessage = "You can't cook here";
+                cachedFailureMessage = failureMessage;
+                return false;
+            }
+
+            EnsureRecipeLookup();
+
+            if (RecipeLookup.Count == 0)
+            {
+                failureMessage = "No recipes available";
+                cachedFailureMessage = failureMessage;
+                return false;
+            }
+
+            // Resolve the currently highlighted item.
+            ItemData candidateItem = null;
+            CookableRecipe candidateRecipe = null;
+            int selectedIndex = inventory.selectedIndex;
+            if (selectedIndex >= 0)
+            {
+                var selectedEntry = inventory.GetSlot(selectedIndex);
+                candidateItem = selectedEntry.item;
+                if (candidateItem != null && !string.IsNullOrEmpty(candidateItem.id))
+                    RecipeLookup.TryGetValue(candidateItem.id, out candidateRecipe);
+            }
+
+            // Fallback to the first cookable item in the inventory if the highlighted slot is invalid.
+            if (candidateRecipe == null || candidateItem == null)
+            {
+                for (int i = 0; i < inventory.size; i++)
+                {
+                    var slot = inventory.GetSlot(i);
+                    var item = slot.item;
+                    if (item == null || string.IsNullOrEmpty(item.id))
+                        continue;
+
+                    if (!RecipeLookup.TryGetValue(item.id, out candidateRecipe))
+                        continue;
+
+                    candidateItem = item;
+                    break;
+                }
+            }
+
+            if (candidateRecipe == null || candidateItem == null)
+            {
+                failureMessage = "You need something raw to cook";
+                cachedFailureMessage = failureMessage;
+                return false;
+            }
+
+            if (CookingSkill.Level < candidateRecipe.requiredLevel)
+            {
+                failureMessage = $"You need Cooking level {candidateRecipe.requiredLevel}";
+                cachedFailureMessage = failureMessage;
+                return false;
+            }
+
+            int quantity = inventory.GetItemCount(candidateItem);
+            if (quantity <= 0)
+            {
+                failureMessage = "You need something raw to cook";
+                cachedFailureMessage = failureMessage;
+                return false;
+            }
+
+            cachedStation = node;
+            cachedRecipe = candidateRecipe;
+            cachedRawItem = candidateItem;
+            cachedQuantity = quantity;
+            return true;
+        }
+
+        /// <inheritdoc />
+        protected override bool HasInventorySpace(CookingObject node, out string failureMessage)
+        {
+            if (cachedRecipe == null || cachedRawItem == null || cachedQuantity <= 0 || cachedStation == null)
+            {
+                failureMessage = !string.IsNullOrEmpty(cachedFailureMessage)
+                    ? cachedFailureMessage
+                    : "You can't cook that";
+                return false;
+            }
+
+            failureMessage = string.Empty;
+            return true;
+        }
+
+        /// <inheritdoc />
+        protected override bool TryStartAction(CookingObject node, out string failureMessage)
+        {
+            failureMessage = string.Empty;
+
+            if (CookingSkill == null)
+            {
+                failureMessage = "You can't cook here";
+                ClearCachedInteraction();
+                return false;
+            }
+
+            if (cachedRecipe == null || cachedRawItem == null || cachedQuantity <= 0 || cachedStation != node)
+            {
+                failureMessage = !string.IsNullOrEmpty(cachedFailureMessage)
+                    ? cachedFailureMessage
+                    : "You can't cook that";
+                ClearCachedInteraction();
+                return false;
+            }
+
+            bool started = CookingSkill.TryStartCooking(node, cachedRecipe, cachedQuantity, out failureMessage);
+            if (started)
+            {
+                inventory?.ClearSelection();
+                ClearCachedInteraction();
+                return true;
+            }
+
+            if (string.IsNullOrEmpty(failureMessage))
+                failureMessage = "You can't cook here";
+
+            ClearCachedInteraction();
+            return false;
+        }
+
+        private static void EnsureRecipeLookup()
+        {
+            if (recipesLoaded)
+                return;
+
+            RecipeLookup.Clear();
+            var recipes = Resources.LoadAll<CookableRecipe>("CookingDatabase");
+            foreach (var recipe in recipes)
+            {
+                if (recipe == null || string.IsNullOrEmpty(recipe.rawItemId))
+                    continue;
+                RecipeLookup[recipe.rawItemId] = recipe;
+            }
+
+            recipesLoaded = true;
+        }
+
+        private void ClearCachedInteraction()
+        {
+            cachedRecipe = null;
+            cachedRawItem = null;
+            cachedStation = null;
+            cachedQuantity = 0;
+            cachedFailureMessage = string.Empty;
+        }
+
+        private void HandleSkillStopped()
+        {
+            ClearCachedInteraction();
+        }
+    }
+}

--- a/Assets/Scripts/Skills/Cooking/Core/CookingController.cs.meta
+++ b/Assets/Scripts/Skills/Cooking/Core/CookingController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: aec6d9c51adf420eadafdb4b18b62e97

--- a/Assets/Scripts/Skills/Cooking/Core/CookingObject.cs
+++ b/Assets/Scripts/Skills/Cooking/Core/CookingObject.cs
@@ -1,115 +1,65 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.EventSystems;
-using Inventory;
-using Player;
-using UI;
-using Pets;
 
 namespace Skills.Cooking
 {
     /// <summary>
-    /// World object that allows the player to cook items when used.
-    /// The player selects a cookable item in the inventory and then
-    /// clicks this object to begin cooking. Cooking stops if the
-    /// player moves or steps too far away.
+    ///     Passive world component representing a cooking station.
+    ///     The station only exposes distance settings so <see cref="CookingController"/>
+    ///     can handle all player interaction logic.
     /// </summary>
+    [DisallowMultipleComponent]
     [RequireComponent(typeof(Collider2D))]
-    public class CookingObject : MonoBehaviour, IPointerClickHandler
+    public class CookingObject : MonoBehaviour
     {
-        [SerializeField] private float cancelDistance = 3f;
+        [Header("Interaction")]
+        [SerializeField]
+        [Tooltip("Maximum distance the player can stand from this station to start cooking.")]
+        private float interactionRange = 1.5f;
 
-        private static Dictionary<string, CookableRecipe> recipeLookup;
+        [SerializeField]
+        [Tooltip("Distance at which active cooking automatically cancels.")]
+        private float cancelDistance = 3f;
 
-        private Inventory.Inventory inventory;
+        [SerializeField]
+        [Tooltip("Optional anchor transform used when auto-moving the player into position.")]
+        private Transform approachAnchor;
+
         private CookingSkill cookingSkill;
-        private PlayerMover playerMover;
-        private Transform playerTransform;
+
+        /// <summary>
+        ///     Range used when checking whether the player can interact with this station.
+        /// </summary>
+        public float InteractionRange => interactionRange;
+
+        /// <summary>
+        ///     Maximum distance allowed before an active cooking action is cancelled.
+        /// </summary>
+        public float CancelDistance => cancelDistance;
+
+        /// <summary>
+        ///     Optional transform for auto-move targeting. Falls back to <see cref="Component.transform"/> when null.
+        /// </summary>
+        public Transform ApproachAnchor => approachAnchor != null ? approachAnchor : transform;
 
         private void Awake()
         {
-            var playerObj = GameObject.FindGameObjectWithTag("Player");
-            if (playerObj != null)
-            {
-                inventory = playerObj.GetComponent<Inventory.Inventory>();
-                cookingSkill = playerObj.GetComponent<CookingSkill>();
-                playerMover = playerObj.GetComponent<PlayerMover>();
-                playerTransform = playerObj.transform;
-            }
-            EnsureRecipeLookup();
-            var mainCam = Camera.main;
-            if (mainCam != null && mainCam.GetComponent<Physics2DRaycaster>() == null)
-                mainCam.gameObject.AddComponent<Physics2DRaycaster>();
+            // Cache the player's cooking skill so we can cancel if the station disappears.
+            var player = GameObject.FindGameObjectWithTag("Player");
+            if (player != null)
+                cookingSkill = player.GetComponent<CookingSkill>();
         }
 
-        private void EnsureRecipeLookup()
+        private void OnDisable()
         {
-            if (recipeLookup != null)
-                return;
-            recipeLookup = new Dictionary<string, CookableRecipe>();
-            var recipes = Resources.LoadAll<CookableRecipe>("CookingDatabase");
-            foreach (var r in recipes)
-            {
-                if (r != null && !string.IsNullOrEmpty(r.rawItemId))
-                    recipeLookup[r.rawItemId] = r;
-            }
+            // If this station goes away while in use ensure the active session stops cleanly.
+            if (cookingSkill != null && cookingSkill.ActiveCookingObject == this)
+                cookingSkill.StopCooking();
         }
 
-        private void Update()
+        private void OnValidate()
         {
-            if (cookingSkill != null && cookingSkill.IsCooking)
-            {
-                if (playerMover != null && playerMover.IsMoving)
-                {
-                    cookingSkill.StopCooking();
-                    return;
-                }
-                if (playerTransform != null && Vector3.Distance(playerTransform.position, transform.position) > cancelDistance)
-                    cookingSkill.StopCooking();
-            }
-        }
-
-        public void OnPointerClick(PointerEventData eventData)
-        {
-            if (eventData.button == PointerEventData.InputButton.Left)
-            {
-                TryStartCooking();
-            }
-        }
-
-        private void TryStartCooking()
-        {
-            if (inventory == null || cookingSkill == null)
-                return;
-
-            int selected = inventory.selectedIndex;
-            if (selected < 0)
-                return;
-
-            var entry = inventory.GetSlot(selected);
-            if (entry.item == null)
-                return;
-
-            if (!recipeLookup.TryGetValue(entry.item.id, out var recipe))
-            {
-                FloatingText.Show("You can't cook that", transform.position);
-                return;
-            }
-
-            if (cookingSkill.Level < recipe.requiredLevel)
-            {
-                FloatingText.Show($"You need Cooking level {recipe.requiredLevel}", transform.position);
-                return;
-            }
-
-            int quantity = inventory.GetItemCount(entry.item);
-            if (quantity <= 0)
-                return;
-
-            cookingSkill.StartCooking(recipe, quantity);
-            inventory.ClearSelection();
+            interactionRange = Mathf.Max(0f, interactionRange);
+            cancelDistance = Mathf.Max(0f, cancelDistance);
         }
     }
 }
-

--- a/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
+++ b/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
@@ -39,7 +39,8 @@ namespace Skills.Cooking
 
         public int Level => skills != null ? skills.GetLevel(SkillType.Cooking) : 1;
         public float Xp => skills != null ? skills.GetXp(SkillType.Cooking) : 0f;
-        public bool IsCooking => currentRecipe != null && itemsRemaining > 0;
+        public CookingObject ActiveCookingObject { get; private set; }
+        public bool IsCooking => currentRecipe != null && itemsRemaining > 0 && ActiveCookingObject != null;
         public float CookProgressNormalized => CookIntervalTicks <= 1 ? 0f : (float)cookProgress / (CookIntervalTicks - 1);
 
         /// <summary>
@@ -73,26 +74,87 @@ namespace Skills.Cooking
             SaveManager.Unregister(cookingOutfit);
         }
 
-        public void StartCooking(CookableRecipe recipe, int quantity)
+        /// <summary>
+        ///     Attempts to begin a cooking session at the supplied station.
+        ///     Validates the player's level and ingredient availability before starting.
+        /// </summary>
+        /// <param name="station">World object representing the cooking station.</param>
+        /// <param name="recipe">Recipe to cook.</param>
+        /// <param name="quantity">Number of raw items to process.</param>
+        /// <param name="failureMessage">Feedback explaining why the action failed.</param>
+        /// <returns><c>true</c> if the session began successfully; otherwise <c>false</c>.</returns>
+        public bool TryStartCooking(CookingObject station, CookableRecipe recipe, int quantity, out string failureMessage)
         {
-            if (recipe == null || quantity <= 0)
-                return;
+            failureMessage = string.Empty;
+
+            if (station == null || recipe == null)
+            {
+                failureMessage = "You can't cook here";
+                return false;
+            }
+
+            if (quantity <= 0)
+            {
+                failureMessage = "You need something raw to cook";
+                return false;
+            }
+
             if (skills != null && skills.GetLevel(SkillType.Cooking) < recipe.requiredLevel)
-                return;
+            {
+                failureMessage = $"You need Cooking level {recipe.requiredLevel}";
+                return false;
+            }
+
+            if (inventory == null)
+            {
+                failureMessage = "You can't cook here";
+                return false;
+            }
+
+            var rawItem = ItemDatabase.GetItem(recipe.rawItemId);
+            if (rawItem == null)
+            {
+                failureMessage = "You can't cook that";
+                return false;
+            }
+
+            int available = inventory.GetItemCount(rawItem);
+            if (available <= 0)
+            {
+                failureMessage = "You need something raw to cook";
+                return false;
+            }
+
+            if (quantity > available)
+                quantity = available;
+
+            if (IsCooking)
+                StopCooking();
+
+            ActiveCookingObject = station;
             currentRecipe = recipe;
             itemsRemaining = quantity;
             cookProgress = 0;
             LogDebug($"Started cooking {recipe.cookedItemId} x{quantity}");
             OnStartCooking?.Invoke(recipe);
+            return true;
         }
 
+        /// <summary>
+        ///     Stops the current cooking session, clearing the active station and notifying listeners.
+        /// </summary>
         public void StopCooking()
         {
-            if (!IsCooking)
-                return;
+            bool hadActiveSession = IsCooking || ActiveCookingObject != null;
+
             currentRecipe = null;
             itemsRemaining = 0;
             cookProgress = 0;
+            ActiveCookingObject = null;
+
+            if (!hadActiveSession)
+                return;
+
             LogDebug("Stopped cooking");
             OnStopCooking?.Invoke();
         }


### PR DESCRIPTION
## Summary
- convert cooking stations into passive nodes that expose interaction and cancel distances
- add a dedicated CookingController that validates inventory selections, caches recipes, and drives CookingSkill
- update CookingSkill to track the active station and expose TryStartCooking with failure feedback

## Testing
- not run (Unity editor required)


------
https://chatgpt.com/codex/tasks/task_e_68d2ef4d5c08832e895c8f3fd99982b9