### PR TITLE
Integrate cooking priority when feeding bonfires

### DIFF
--- a/Assets/Scripts/Skills/Cooking/Core/CookingController.cs
+++ b/Assets/Scripts/Skills/Cooking/Core/CookingController.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Inventory;
 using Skills.Common;
 using UnityEngine;
@@ -17,9 +16,6 @@ namespace Skills.Cooking
         [Tooltip("Layer mask used when searching for cooking stations.")]
         private LayerMask cookingStationMask = LayerMask.GetMask("Interactable");
 
-        private static readonly Dictionary<string, CookableRecipe> RecipeLookup = new();
-        private static bool recipesLoaded;
-
         private Inventory.Inventory inventory;
         private CookableRecipe cachedRecipe;
         private ItemData cachedRawItem;
@@ -30,7 +26,7 @@ namespace Skills.Cooking
         private CookingSkill CookingSkill => Skill;
 
         /// <summary>
-        ///     Resolve optional references and ensure the recipe dictionary is ready.
+        ///     Resolve optional references and ensure default configuration values are populated.
         /// </summary>
         protected override void Awake()
         {
@@ -39,7 +35,6 @@ namespace Skills.Cooking
                 inventory = GetComponent<Inventory.Inventory>();
             if (inventory == null && CookingSkill != null)
                 inventory = CookingSkill.GetComponent<Inventory.Inventory>();
-            EnsureRecipeLookup();
             if (cookingStationMask == 0)
                 cookingStationMask = ~0;
         }
@@ -131,71 +126,39 @@ namespace Skills.Cooking
                 return false;
             }
 
-            EnsureRecipeLookup();
+            var searchResult = CookingInventoryHelper.FindCookableRecipe(inventory, CookingSkill, inventory.selectedIndex);
 
-            if (RecipeLookup.Count == 0)
+            if (!searchResult.HasRecipe)
             {
-                failureMessage = "No recipes available";
+                failureMessage = !string.IsNullOrEmpty(searchResult.FailureMessage)
+                    ? searchResult.FailureMessage
+                    : "You need something raw to cook";
                 cachedFailureMessage = failureMessage;
                 return false;
             }
 
-            // Resolve the currently highlighted item.
-            ItemData candidateItem = null;
-            CookableRecipe candidateRecipe = null;
-            int selectedIndex = inventory.selectedIndex;
-            if (selectedIndex >= 0)
+            if (!searchResult.HasRequiredQuantity)
             {
-                var selectedEntry = inventory.GetSlot(selectedIndex);
-                candidateItem = selectedEntry.item;
-                if (candidateItem != null && !string.IsNullOrEmpty(candidateItem.id))
-                    RecipeLookup.TryGetValue(candidateItem.id, out candidateRecipe);
-            }
-
-            // Fallback to the first cookable item in the inventory if the highlighted slot is invalid.
-            if (candidateRecipe == null || candidateItem == null)
-            {
-                for (int i = 0; i < inventory.size; i++)
-                {
-                    var slot = inventory.GetSlot(i);
-                    var item = slot.item;
-                    if (item == null || string.IsNullOrEmpty(item.id))
-                        continue;
-
-                    if (!RecipeLookup.TryGetValue(item.id, out candidateRecipe))
-                        continue;
-
-                    candidateItem = item;
-                    break;
-                }
-            }
-
-            if (candidateRecipe == null || candidateItem == null)
-            {
-                failureMessage = "You need something raw to cook";
+                failureMessage = !string.IsNullOrEmpty(searchResult.FailureMessage)
+                    ? searchResult.FailureMessage
+                    : "You need something raw to cook";
                 cachedFailureMessage = failureMessage;
                 return false;
             }
 
-            if (CookingSkill.Level < candidateRecipe.requiredLevel)
+            if (!searchResult.MeetsLevelRequirement)
             {
-                failureMessage = $"You need Cooking level {candidateRecipe.requiredLevel}";
-                cachedFailureMessage = failureMessage;
-                return false;
-            }
-
-            int quantity = inventory.GetItemCount(candidateItem);
-            if (quantity <= 0)
-            {
-                failureMessage = "You need something raw to cook";
+                failureMessage = !string.IsNullOrEmpty(searchResult.FailureMessage)
+                    ? searchResult.FailureMessage
+                    : $"You need Cooking level {searchResult.Recipe.requiredLevel}";
                 cachedFailureMessage = failureMessage;
                 return false;
             }
 
             cachedStation = node;
-            cachedRecipe = candidateRecipe;
-            cachedRawItem = candidateItem;
-            cachedQuantity = quantity;
+            cachedRecipe = searchResult.Recipe;
+            cachedRawItem = searchResult.RawItem;
+            cachedQuantity = searchResult.Quantity;
             return true;
         }
 
@@ -248,23 +211,6 @@ namespace Skills.Cooking
 
             ClearCachedInteraction();
             return false;
-        }
-
-        private static void EnsureRecipeLookup()
-        {
-            if (recipesLoaded)
-                return;
-
-            RecipeLookup.Clear();
-            var recipes = Resources.LoadAll<CookableRecipe>("CookingDatabase");
-            foreach (var recipe in recipes)
-            {
-                if (recipe == null || string.IsNullOrEmpty(recipe.rawItemId))
-                    continue;
-                RecipeLookup[recipe.rawItemId] = recipe;
-            }
-
-            recipesLoaded = true;
         }
 
         private void ClearCachedInteraction()

--- a/Assets/Scripts/Skills/Cooking/Core/CookingInventoryHelper.cs
+++ b/Assets/Scripts/Skills/Cooking/Core/CookingInventoryHelper.cs
@@ -1,0 +1,189 @@
+using System.Collections.Generic;
+using Inventory;
+using UnityEngine;
+
+namespace Skills.Cooking
+{
+    /// <summary>
+    ///     Shared helper that centralises cookable recipe lookups so multiple controllers can
+    ///     consistently determine whether the player can cook a raw item from their inventory.
+    /// </summary>
+    public static class CookingInventoryHelper
+    {
+        private static readonly Dictionary<string, CookableRecipe> RecipeLookup = new();
+        private static bool recipesLoaded;
+
+        /// <summary>
+        ///     Result data returned when probing the inventory for a cookable recipe.
+        /// </summary>
+        public struct CookableInventorySearchResult
+        {
+            /// <summary>
+            ///     Recipe resolved from the inventory search.
+            /// </summary>
+            public CookableRecipe Recipe;
+
+            /// <summary>
+            ///     Raw item instance associated with the recipe.
+            /// </summary>
+            public ItemData RawItem;
+
+            /// <summary>
+            ///     Inventory slot index containing the raw item.
+            /// </summary>
+            public int SlotIndex;
+
+            /// <summary>
+            ///     Total number of raw items currently owned.
+            /// </summary>
+            public int Quantity;
+
+            /// <summary>
+            ///     Indicates whether the player has at least one of the raw item.
+            /// </summary>
+            public bool HasRequiredQuantity;
+
+            /// <summary>
+            ///     Indicates whether the player meets the recipe's Cooking level requirement.
+            /// </summary>
+            public bool MeetsLevelRequirement;
+
+            /// <summary>
+            ///     When <c>true</c>, the preferred inventory slot supplied to the search resolved the recipe.
+            /// </summary>
+            public bool UsesPreferredSlot;
+
+            /// <summary>
+            ///     Failure message explaining why cooking cannot begin.
+            /// </summary>
+            public string FailureMessage;
+
+            /// <summary>
+            ///     <c>true</c> when a recipe and raw item were located.
+            /// </summary>
+            public bool HasRecipe => Recipe != null && RawItem != null;
+
+            /// <summary>
+            ///     <c>true</c> when all cooking requirements are satisfied.
+            /// </summary>
+            public bool CanCook => HasRecipe && HasRequiredQuantity && MeetsLevelRequirement;
+        }
+
+        /// <summary>
+        ///     Searches the player's inventory for a cookable recipe, preferring the highlighted slot when possible.
+        /// </summary>
+        /// <param name="inventory">Inventory to search.</param>
+        /// <param name="cookingSkill">Cooking skill used for level checks.</param>
+        /// <param name="preferredSlotIndex">Slot index to evaluate before scanning the rest of the inventory.</param>
+        /// <returns>Struct describing the located recipe and whether the player can cook it.</returns>
+        public static CookableInventorySearchResult FindCookableRecipe(Inventory.Inventory inventory, CookingSkill cookingSkill, int preferredSlotIndex = -1)
+        {
+            var result = new CookableInventorySearchResult
+            {
+                Recipe = null,
+                RawItem = null,
+                SlotIndex = -1,
+                Quantity = 0,
+                HasRequiredQuantity = false,
+                MeetsLevelRequirement = false,
+                UsesPreferredSlot = false,
+                FailureMessage = string.Empty
+            };
+
+            if (inventory == null)
+            {
+                result.FailureMessage = "You need something raw to cook";
+                return result;
+            }
+
+            EnsureRecipeLookup();
+
+            if (RecipeLookup.Count == 0)
+            {
+                result.FailureMessage = "No recipes available";
+                return result;
+            }
+
+            bool EvaluateSlot(int slotIndex, bool markPreferred)
+            {
+                if (slotIndex < 0 || slotIndex >= inventory.size)
+                    return false;
+
+                var entry = inventory.GetSlot(slotIndex);
+                var item = entry.item;
+                if (item == null || string.IsNullOrEmpty(item.id))
+                    return false;
+
+                if (!RecipeLookup.TryGetValue(item.id, out var recipe))
+                    return false;
+
+                result.Recipe = recipe;
+                result.RawItem = item;
+                result.SlotIndex = slotIndex;
+                result.UsesPreferredSlot = markPreferred;
+                return true;
+            }
+
+            if (preferredSlotIndex >= 0 && preferredSlotIndex < inventory.size)
+                EvaluateSlot(preferredSlotIndex, true);
+
+            if (result.Recipe == null)
+            {
+                for (int i = 0; i < inventory.size; i++)
+                {
+                    if (i == preferredSlotIndex)
+                        continue;
+
+                    if (EvaluateSlot(i, false))
+                        break;
+                }
+            }
+
+            if (!result.HasRecipe)
+            {
+                result.FailureMessage = "You need something raw to cook";
+                return result;
+            }
+
+            result.Quantity = inventory.GetItemCount(result.RawItem);
+            result.HasRequiredQuantity = result.Quantity > 0;
+            if (!result.HasRequiredQuantity)
+            {
+                result.FailureMessage = "You need something raw to cook";
+                return result;
+            }
+
+            int playerLevel = cookingSkill != null ? cookingSkill.Level : 1;
+            result.MeetsLevelRequirement = playerLevel >= result.Recipe.requiredLevel;
+            if (!result.MeetsLevelRequirement)
+            {
+                result.FailureMessage = $"You need Cooking level {result.Recipe.requiredLevel}";
+                return result;
+            }
+
+            result.FailureMessage = string.Empty;
+            return result;
+        }
+
+        /// <summary>
+        ///     Loads the cookable recipe database on demand and caches the mapping for quick lookups.
+        /// </summary>
+        private static void EnsureRecipeLookup()
+        {
+            if (recipesLoaded)
+                return;
+
+            RecipeLookup.Clear();
+            var recipes = Resources.LoadAll<CookableRecipe>("CookingDatabase");
+            foreach (var recipe in recipes)
+            {
+                if (recipe == null || string.IsNullOrEmpty(recipe.rawItemId))
+                    continue;
+
+                RecipeLookup[recipe.rawItemId] = recipe;
+            }
+
+            recipesLoaded = true;
+        }
+    }
+}

--- a/Assets/Scripts/Skills/Firemaking/Core/FiremakingBonfireController.cs
+++ b/Assets/Scripts/Skills/Firemaking/Core/FiremakingBonfireController.cs
@@ -1,5 +1,7 @@
 using Inventory;
 using Skills.Common;
+using Skills.Cooking;
+using UI;
 using UnityEngine;
 
 namespace Skills.Firemaking
@@ -25,6 +27,14 @@ namespace Skills.Firemaking
         [Tooltip("Inventory providing the highlighted log selection for bonfire fueling.")]
         private Inventory.Inventory inventory;
 
+        [Header("Cooking Integration")]
+        [SerializeField]
+        [Tooltip("Player cooking skill used to coordinate cookable interactions with bonfires.")]
+        private CookingSkill cookingSkill;
+
+        private FiremakingBonfireObject pendingBonfire;
+        private int pendingLogSlot = -1;
+
         /// <summary>
         ///     Cache optional references on Awake while still letting the base controller wire the
         ///     shared gathering dependencies.
@@ -38,6 +48,35 @@ namespace Skills.Firemaking
 
             if (inventory == null)
                 inventory = GetComponent<Inventory.Inventory>();
+
+            if (cookingSkill == null)
+                cookingSkill = GetComponent<CookingSkill>();
+        }
+
+        /// <summary>
+        ///     Subscribe to cooking stop events so queued log fueling can begin immediately after fish finish cooking.
+        /// </summary>
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+
+            if (cookingSkill == null)
+                cookingSkill = GetComponent<CookingSkill>();
+
+            if (cookingSkill != null)
+                cookingSkill.OnStopCooking += HandleCookingStopped;
+        }
+
+        /// <summary>
+        ///     Ensure queued state is cleared and cooking callbacks are released when the controller is disabled.
+        /// </summary>
+        protected override void OnDisable()
+        {
+            if (cookingSkill != null)
+                cookingSkill.OnStopCooking -= HandleCookingStopped;
+
+            ClearPendingBonfire();
+            base.OnDisable();
         }
 
 #if UNITY_EDITOR
@@ -129,6 +168,25 @@ namespace Skills.Firemaking
             }
 
             int selectedIndex = inventory.selectedIndex;
+
+            var cookableResult = CookingInventoryHelper.FindCookableRecipe(inventory, cookingSkill, selectedIndex);
+            bool selectedSlotCookable = cookableResult.HasRecipe && cookableResult.UsesPreferredSlot;
+
+            if (cookableResult.CanCook)
+            {
+                int logSlot = ResolvePendingLogSlot(selectedIndex);
+                QueuePendingBonfire(node, logSlot);
+                return false;
+            }
+
+            if (selectedSlotCookable)
+            {
+                ClearPendingBonfire();
+                return false;
+            }
+
+            ClearPendingBonfire();
+
             if (selectedIndex < 0)
             {
                 failureMessage = "Select a log to feed the bonfire.";
@@ -138,6 +196,7 @@ namespace Skills.Firemaking
             if (!Skill.TryStartBonfireFeeding(node, selectedIndex, out failureMessage))
                 return false;
 
+            ClearPendingBonfire();
             inventory.ClearSelection();
             return true;
         }
@@ -153,6 +212,86 @@ namespace Skills.Firemaking
                 return 1 << interactableLayer;
 
             return Physics2D.AllLayers;
+        }
+
+        /// <summary>
+        ///     Resolves the inventory slot that should be used for bonfire fueling once cooking has completed.
+        /// </summary>
+        private int ResolvePendingLogSlot(int preferredSlot)
+        {
+            if (inventory == null || Skill == null)
+                return -1;
+
+            if (preferredSlot >= 0)
+            {
+                var selectedEntry = inventory.GetSlot(preferredSlot);
+                if (selectedEntry.item != null && Skill.GetDefinitionForItem(selectedEntry.item.id) != null)
+                    return preferredSlot;
+            }
+
+            for (int i = 0; i < inventory.size; i++)
+            {
+                var slot = inventory.GetSlot(i);
+                if (slot.item == null)
+                    continue;
+
+                if (Skill.GetDefinitionForItem(slot.item.id) != null)
+                    return i;
+            }
+
+            return -1;
+        }
+
+        /// <summary>
+        ///     Stores the bonfire/log slot pair to process once the cooking controller finishes.
+        /// </summary>
+        private void QueuePendingBonfire(FiremakingBonfireObject bonfire, int logSlot)
+        {
+            if (bonfire == null || logSlot < 0)
+            {
+                ClearPendingBonfire();
+                return;
+            }
+
+            pendingBonfire = bonfire;
+            pendingLogSlot = logSlot;
+        }
+
+        /// <summary>
+        ///     Clears any queued bonfire fueling request.
+        /// </summary>
+        private void ClearPendingBonfire()
+        {
+            pendingBonfire = null;
+            pendingLogSlot = -1;
+        }
+
+        /// <summary>
+        ///     Attempts to fuel the queued bonfire immediately after cooking stops.
+        /// </summary>
+        private void HandleCookingStopped()
+        {
+            if (pendingBonfire == null || pendingLogSlot < 0)
+            {
+                ClearPendingBonfire();
+                return;
+            }
+
+            var bonfire = pendingBonfire;
+            int logSlot = pendingLogSlot;
+            ClearPendingBonfire();
+
+            if (Skill == null)
+                return;
+
+            if (Skill.TryStartBonfireFeeding(bonfire, logSlot, out string failure))
+            {
+                inventory?.ClearSelection();
+                return;
+            }
+
+            if (!string.IsNullOrWhiteSpace(failure))
+                FloatingText.Show(failure, bonfire.transform.position);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a shared CookingInventoryHelper so controllers can find cookable recipes and requirement failures from the player's inventory
- update CookingController to use the shared helper when validating cooking interactions
- enhance FiremakingBonfireController to queue bonfire fueling after cooking, subscribing to CookingSkill stop events and deferring log prompts when raw food is available

## Testing
- Not run (Unity editor required)


------
https://chatgpt.com/codex/tasks/task_e_68d2f91506b8832e9b5f564dc7563cae