### PR TITLE
Add admin toggle for floating text console echo

### DIFF
--- a/Assets/Scripts/Skills/AdminF2Menu.cs
+++ b/Assets/Scripts/Skills/AdminF2Menu.cs
@@ -16,6 +16,7 @@ using Status.Antifire;
 using Status.Poison;
 using Status.Freeze;
 using World;
+using UI;
 
 namespace Skills
 {
@@ -366,6 +367,12 @@ namespace Skills
                 () => firemakingSkillBehaviour != null,
                 () => firemakingSkillBehaviour.EnableDebugLogging,
                 value => firemakingSkillBehaviour.EnableDebugLogging = value);
+
+            // Allow QA to mirror floating text popups in the console for firemaking/cooking debugging.
+            bool echoFloatingText = FloatingText.DebugLogMessages;
+            bool requestedEchoFloatingText = GUILayout.Toggle(echoFloatingText, "Echo Floating Text to Console");
+            if (requestedEchoFloatingText != echoFloatingText)
+                FloatingText.DebugLogMessages = requestedEchoFloatingText;
 
             bool teleportToggle = World.Minimap.DebugTeleportOnClickEnabled;
             bool requestedTeleportToggle = GUILayout.Toggle(teleportToggle, "Minimap Teleport On Click");

--- a/Assets/Scripts/UI/FloatingText.cs
+++ b/Assets/Scripts/UI/FloatingText.cs
@@ -18,6 +18,20 @@ namespace UI
         private Camera mainCamera;
         private float remainingLifetime;
 
+        /// <summary>
+        ///     Backing field for <see cref="DebugLogMessages"/> so the toggle persists between spawn calls.
+        /// </summary>
+        private static bool debugLogMessages;
+
+        /// <summary>
+        ///     When enabled via the admin debug menu, every floating text message is echoed to the console.
+        /// </summary>
+        public static bool DebugLogMessages
+        {
+            get => debugLogMessages;
+            set => debugLogMessages = value;
+        }
+
         public static void Show(string message, Vector3 position, Color? color = null, float? size = null, Sprite background = null)
         {
             GameObject go = new GameObject("FloatingText", typeof(Canvas));
@@ -58,6 +72,12 @@ namespace UI
             float finalSize = size ?? instance.textSize;
             instance.uiText.fontSize = Mathf.RoundToInt(64 * finalSize);
             instance.remainingLifetime = instance.lifetime;
+
+            if (debugLogMessages)
+            {
+                // Mirror the popup in the console so QA can diagnose why the message appeared.
+                Debug.Log($"[FloatingText] {message}");
+            }
         }
 
         private void Awake()


### PR DESCRIPTION
## Summary
- add an Admin F2 menu toggle that mirrors floating text popups to the console for debugging cooking and bonfire flows
- extend the floating text utility with a debug logging option that prints popup messages when enabled

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d300127bbc832e9c723c7111b160b5