### PR TITLE
Handle combined bonfire cooking failure messaging

### DIFF
--- a/Assets/Scripts/Skills/Cooking/Core/CookingController.cs
+++ b/Assets/Scripts/Skills/Cooking/Core/CookingController.cs
@@ -1,5 +1,6 @@
 using Inventory;
 using Skills.Common;
+using Skills.Firemaking;
 using UnityEngine;
 
 namespace Skills.Cooking
@@ -15,6 +16,10 @@ namespace Skills.Cooking
         [SerializeField]
         [Tooltip("Layer mask used when searching for cooking stations.")]
         private LayerMask cookingStationMask;
+
+        [SerializeField]
+        [Tooltip("Optional Firemaking skill reference used to coordinate bonfire messaging.")]
+        private FiremakingSkill firemakingSkill;
 
         /// <summary>
         ///     Layer name automatically used when the inspector has not provided a mask override.
@@ -40,6 +45,9 @@ namespace Skills.Cooking
                 inventory = GetComponent<Inventory.Inventory>();
             if (inventory == null && CookingSkill != null)
                 inventory = CookingSkill.GetComponent<Inventory.Inventory>();
+
+            if (firemakingSkill == null)
+                firemakingSkill = GetComponent<FiremakingSkill>();
 
             EnsureCookingStationMaskConfigured();
         }
@@ -135,6 +143,12 @@ namespace Skills.Cooking
 
             if (!searchResult.HasRecipe)
             {
+                if (TryHandleCombinedBonfireFailure(node, out failureMessage))
+                {
+                    cachedFailureMessage = failureMessage;
+                    return false;
+                }
+
                 failureMessage = !string.IsNullOrEmpty(searchResult.FailureMessage)
                     ? searchResult.FailureMessage
                     : "You need something raw to cook";
@@ -144,6 +158,12 @@ namespace Skills.Cooking
 
             if (!searchResult.HasRequiredQuantity)
             {
+                if (TryHandleCombinedBonfireFailure(node, out failureMessage))
+                {
+                    cachedFailureMessage = failureMessage;
+                    return false;
+                }
+
                 failureMessage = !string.IsNullOrEmpty(searchResult.FailureMessage)
                     ? searchResult.FailureMessage
                     : "You need something raw to cook";
@@ -164,6 +184,39 @@ namespace Skills.Cooking
             cachedRecipe = searchResult.Recipe;
             cachedRawItem = searchResult.RawItem;
             cachedQuantity = searchResult.Quantity;
+            return true;
+        }
+
+        /// <summary>
+        ///     Checks whether the current interaction targets a bonfire/cooking hybrid while the player
+        ///     lacks both raw ingredients and logs. Returns the combined failure message when the helper
+        ///     has not already issued it this frame so duplicate feedback is avoided.
+        /// </summary>
+        private bool TryHandleCombinedBonfireFailure(CookingObject node, out string failureMessage)
+        {
+            failureMessage = string.Empty;
+
+            if (node == null)
+                return false;
+
+            if (!node.TryGetComponent<FiremakingBonfireObject>(out _))
+                return false;
+
+            if (inventory == null)
+                return false;
+
+            if (firemakingSkill == null)
+                firemakingSkill = GetComponent<FiremakingSkill>();
+
+            if (firemakingSkill == null)
+                return false;
+
+            if (firemakingSkill.HasAnyLogsInInventory(inventory))
+                return false;
+
+            if (BonfireCookingMessageUtility.TryAcquireCombinedMessage(out var combinedMessage))
+                failureMessage = combinedMessage;
+
             return true;
         }
 

--- a/Assets/Scripts/Skills/Firemaking/Core/BonfireCookingMessageUtility.cs
+++ b/Assets/Scripts/Skills/Firemaking/Core/BonfireCookingMessageUtility.cs
@@ -1,0 +1,37 @@
+using UnityEngine;
+
+namespace Skills.Firemaking
+{
+    /// <summary>
+    ///     Coordinates the shared failure message used when a hybrid cooking/bonfire object detects
+    ///     that the player lacks both cookable ingredients and logs. Ensures only a single message
+    ///     is shown per interaction frame so duplicate floating text is avoided.
+    /// </summary>
+    public static class BonfireCookingMessageUtility
+    {
+        private const string CombinedFailureMessage = "You don't have any raw fish to cook, or logs to add";
+        private static int lastFrameIssued = -1;
+
+        /// <summary>
+        ///     Attempts to reserve the combined failure message for the current frame.
+        /// </summary>
+        /// <param name="message">Outputs the message when it has not been issued this frame.</param>
+        /// <returns>
+        ///     <c>true</c> when the caller should present feedback to the player. Subsequent calls in
+        ///     the same frame receive <c>false</c> so duplicate popups can be suppressed.
+        /// </returns>
+        public static bool TryAcquireCombinedMessage(out string message)
+        {
+            int currentFrame = Time.frameCount;
+            if (lastFrameIssued == currentFrame)
+            {
+                message = string.Empty;
+                return false;
+            }
+
+            lastFrameIssued = currentFrame;
+            message = CombinedFailureMessage;
+            return true;
+        }
+    }
+}

--- a/Assets/Scripts/Skills/Firemaking/Core/FiremakingBonfireController.cs
+++ b/Assets/Scripts/Skills/Firemaking/Core/FiremakingBonfireController.cs
@@ -187,6 +187,9 @@ namespace Skills.Firemaking
 
             ClearPendingBonfire();
 
+            if (TryGetCombinedBonfireCookingFailure(node, cookableResult, out failureMessage))
+                return false;
+
             if (selectedIndex < 0)
             {
                 failureMessage = "Select a log to feed the bonfire.";
@@ -212,6 +215,39 @@ namespace Skills.Firemaking
                 return 1 << interactableLayer;
 
             return Physics2D.AllLayers;
+        }
+
+        /// <summary>
+        ///     Determines whether the current interaction should surface the shared bonfire/cooking
+        ///     failure message instead of the standard log selection prompt.
+        /// </summary>
+        private bool TryGetCombinedBonfireCookingFailure(
+            FiremakingBonfireObject node,
+            CookingInventoryHelper.CookableInventorySearchResult cookableResult,
+            out string failureMessage)
+        {
+            failureMessage = string.Empty;
+
+            if (node == null)
+                return false;
+
+            if (!node.TryGetComponent<CookingObject>(out _))
+                return false;
+
+            bool lacksCookable = !cookableResult.HasRecipe || !cookableResult.HasRequiredQuantity;
+            if (!lacksCookable)
+                return false;
+
+            if (Skill == null || inventory == null)
+                return false;
+
+            if (Skill.HasAnyLogsInInventory(inventory))
+                return false;
+
+            if (BonfireCookingMessageUtility.TryAcquireCombinedMessage(out var combinedMessage))
+                failureMessage = combinedMessage;
+
+            return true;
         }
 
         /// <summary>

--- a/Assets/Scripts/Skills/Firemaking/Core/FiremakingSkill.cs
+++ b/Assets/Scripts/Skills/Firemaking/Core/FiremakingSkill.cs
@@ -230,6 +230,32 @@ namespace Skills.Firemaking
         }
 
         /// <summary>
+        ///     Determines whether the supplied inventory currently contains any registered Firemaking logs.
+        /// </summary>
+        /// <param name="sourceInventory">Inventory to inspect for log items.</param>
+        /// <returns><c>true</c> when at least one log is present.</returns>
+        public bool HasAnyLogsInInventory(Inventory.Inventory sourceInventory)
+        {
+            if (sourceInventory == null)
+                return false;
+
+            if (logLookup == null || logLookup.Count == 0)
+                return false;
+
+            for (int i = 0; i < sourceInventory.size; i++)
+            {
+                var entry = sourceInventory.GetSlot(i);
+                if (entry.item == null || string.IsNullOrEmpty(entry.item.id))
+                    continue;
+
+                if (GetDefinitionForItem(entry.item.id) != null)
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
         ///     Validates and begins a new ignition attempt using the specified inventory slot and world position.
         /// </summary>
         /// <param name="inventorySlot">Slot index containing the selected logs.</param>


### PR DESCRIPTION
## Summary
- coordinate a shared message utility so hybrid bonfire/cooking objects only raise one failure popup per click
- update the cooking and firemaking controllers to call the utility when the player lacks both raw food and logs
- expose a helper on FiremakingSkill for detecting logs in the player inventory to support the new checks

## Testing
- Not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68d3a83369e4832e81fee83afaac6638