### PR TITLE
Allow manual minimap icon assignment

### DIFF
--- a/Assets/Scripts/World/Minimap.cs
+++ b/Assets/Scripts/World/Minimap.cs
@@ -63,8 +63,6 @@ namespace World
         private const float ZoomStep = 5f;
         private const float MinZoom = 5f;
         private const float MaxZoom = 100f;
-        private const float MarkerScale = 0.25f;
-        private const float SmallIconScaleMultiplier = 0.5f;
         private const int SmallMapZoomSteps = 3;
         private const float DefaultZoom = 25f;
         private float SmallMapZoom => DefaultZoom - ZoomStep * SmallMapZoomSteps;
@@ -376,7 +374,7 @@ namespace World
             {
                 if (!markers.Contains(marker))
                     markers.Add(marker);
-                CreateIcons(marker);
+                ValidateManualIcons(marker);
             }
         }
 
@@ -457,8 +455,8 @@ namespace World
                 foreach (var marker in markers)
                 {
                     if (marker == null) continue;
-                    UpdateIconPosition(marker.smallIcon, marker.transform.position, smallMapRect);
-                    UpdateIconPosition(marker.bigIcon, marker.transform.position, expandedMapRect);
+                    UpdateIconPosition(marker.SmallIcon, marker.transform.position, smallMapRect);
+                    UpdateIconPosition(marker.BigIcon, marker.transform.position, expandedMapRect);
                 }
             }
         }
@@ -718,7 +716,7 @@ namespace World
             if (!markers.Contains(marker))
                 markers.Add(marker);
 
-            CreateIcons(marker);
+            ValidateManualIcons(marker);
         }
 
         private void EnsureSceneGateSubscription()
@@ -767,31 +765,42 @@ namespace World
             iconCache.Clear();
         }
 
-        private void CreateIcons(MinimapMarker marker)
+        private void ValidateManualIcons(MinimapMarker marker)
         {
             if (marker == null)
                 return;
 
-            if (smallMapRect != null && marker.smallIcon == null)
+            if (smallMapRect != null && marker.SmallIcon == null)
             {
-                var smallGO = new GameObject("Marker", typeof(Image));
-                smallGO.transform.SetParent(smallMapRect, false);
-                var img = smallGO.GetComponent<Image>();
-                img.sprite = GetMarkerSprite(marker.type);
-                img.preserveAspect = true;
-                marker.smallIcon = img.rectTransform;
-                marker.smallIcon.localScale = Vector3.one * MarkerScale * SmallIconScaleMultiplier;
+                Debug.LogWarning(
+                    $"Minimap marker '{marker.name}' is missing a small icon assignment and will not appear on the minimap. " +
+                    "Assign a RectTransform reference to the marker so it can be positioned manually.");
             }
 
-            if (expandedMapRect != null && marker.bigIcon == null)
+            if (expandedMapRect != null && marker.BigIcon == null)
             {
-                var bigGO = new GameObject("Marker", typeof(Image));
-                bigGO.transform.SetParent(expandedMapRect, false);
-                var img = bigGO.GetComponent<Image>();
-                img.sprite = GetMarkerSprite(marker.type);
-                img.preserveAspect = true;
-                marker.bigIcon = img.rectTransform;
-                marker.bigIcon.localScale = Vector3.one * MarkerScale;
+                Debug.LogWarning(
+                    $"Minimap marker '{marker.name}' is missing an expanded icon assignment and will not appear on the expanded minimap. " +
+                    "Assign a RectTransform reference to the marker so it can be positioned manually.");
+            }
+
+            AssignSpriteIfMissing(marker.SmallIcon, marker.type);
+            AssignSpriteIfMissing(marker.BigIcon, marker.type);
+        }
+
+        private void AssignSpriteIfMissing(RectTransform icon, MinimapMarker.MarkerType type)
+        {
+            if (icon == null)
+                return;
+
+            var image = icon.GetComponent<Image>();
+            if (image == null)
+                return;
+
+            if (image.sprite == null)
+            {
+                image.sprite = GetMarkerSprite(type);
+                image.preserveAspect = true;
             }
         }
 
@@ -801,10 +810,6 @@ namespace World
                 return;
 
             markers.Remove(marker);
-            if (marker.smallIcon != null)
-                Destroy(marker.smallIcon.gameObject);
-            if (marker.bigIcon != null)
-                Destroy(marker.bigIcon.gameObject);
         }
 
         private Sprite GetMarkerSprite(MinimapMarker.MarkerType type)

--- a/Assets/Scripts/World/MinimapMarker.cs
+++ b/Assets/Scripts/World/MinimapMarker.cs
@@ -19,18 +19,47 @@ namespace World
         [Tooltip("Type of icon to display on the minimap.")]
         public MarkerType type = MarkerType.Bank;
 
-        // References to the generated UI icons so they can be updated/destroyed
-        internal RectTransform smallIcon;
-        internal RectTransform bigIcon;
+        [SerializeField]
+        [Tooltip("Manually assigned icon used on the small minimap.")]
+        private RectTransform smallIcon;
+
+        [SerializeField]
+        [Tooltip("Manually assigned icon used on the expanded minimap.")]
+        private RectTransform bigIcon;
+
+        /// <summary>
+        ///     Provides the small minimap icon to the <see cref="Minimap"/> for manual positioning.
+        /// </summary>
+        internal RectTransform SmallIcon => smallIcon;
+
+        /// <summary>
+        ///     Provides the expanded minimap icon to the <see cref="Minimap"/> for manual positioning.
+        /// </summary>
+        internal RectTransform BigIcon => bigIcon;
 
         private void OnEnable()
         {
+            SetIconActive(true);
             Minimap.Instance?.Register(this);
         }
 
         private void OnDisable()
         {
             Minimap.Instance?.Unregister(this);
+            SetIconActive(false);
+        }
+
+        /// <summary>
+        ///     Toggles the visibility of the manually assigned icon references.
+        /// </summary>
+        /// <param name="active">Whether the icons should be visible.</param>
+        private void SetIconActive(bool active)
+        {
+            if (smallIcon != null)
+                smallIcon.gameObject.SetActive(active);
+
+            if (bigIcon != null)
+                bigIcon.gameObject.SetActive(active);
         }
     }
 }


### PR DESCRIPTION
## Summary
- stop auto-instantiating minimap icons so markers rely on manually assigned RectTransforms
- add icon validation and sprite backfill when markers register with the minimap
- let minimap markers manage the visibility of designer-provided icon references on enable/disable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3af4efe48832ea05a874272c975ab