### PR TITLE
Auto-hide inventory drop menu when cursor leaves

### DIFF
--- a/Assets/Scripts/Inventory/InventoryDropMenu.cs
+++ b/Assets/Scripts/Inventory/InventoryDropMenu.cs
@@ -14,6 +14,8 @@ namespace Inventory
         private int slotIndex;
         private Font font;
         private RectTransform rect;
+        private Canvas menuCanvas;
+        private Camera canvasCamera;
 
         public static InventoryDropMenu Create(Transform parent, Font font)
         {
@@ -30,6 +32,17 @@ namespace Inventory
         private void Awake()
         {
             rect ??= GetComponent<RectTransform>();
+            menuCanvas = GetComponentInParent<Canvas>();
+
+            // Cache the correct camera reference so hover checks work with any canvas render mode.
+            if (menuCanvas != null && menuCanvas.renderMode != RenderMode.ScreenSpaceOverlay)
+            {
+                canvasCamera = menuCanvas.worldCamera;
+            }
+            else
+            {
+                canvasCamera = null;
+            }
         }
 
         private void Update()
@@ -37,9 +50,19 @@ namespace Inventory
             if (!gameObject.activeSelf)
                 return;
 
+            var isCursorOverMenu = RectTransformUtility.RectangleContainsScreenPoint(rect, Input.mousePosition, canvasCamera);
+
+            // Immediately hide the menu when the cursor leaves so it behaves like the OSRS context menu.
+            if (!isCursorOverMenu)
+            {
+                Hide();
+                return;
+            }
+
             if (Input.GetMouseButtonDown(0) || Input.GetMouseButtonDown(1))
             {
-                if (!RectTransformUtility.RectangleContainsScreenPoint(rect, Input.mousePosition))
+                // Reuse the hover state so clicks outside still close the menu without recalculating the hit test.
+                if (!isCursorOverMenu)
                     Hide();
             }
         }


### PR DESCRIPTION
## Summary
- cache the inventory drop menu's canvas and camera references for hover hit testing
- hide the drop menu as soon as the cursor leaves while preserving the existing click-to-close behaviour

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d3bd35584c832ea593e1eec0409703