### PR TITLE
Add cooldown tracking for gathering floating text

### DIFF
--- a/Assets/Scripts/Skills/Common/GatheringController.cs
+++ b/Assets/Scripts/Skills/Common/GatheringController.cs
@@ -2,7 +2,6 @@ using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.InputSystem;
 using Player;
-using UI;
 using Core.Input;
 
 namespace Skills.Common
@@ -652,7 +651,7 @@ namespace Skills.Common
                 displayed = GatheringFloatingTextService.TryShowNow(message, anchor, resourcePosition.Value);
 
             if (!displayed && !resourcePosition.HasValue)
-                FloatingText.Show(message, anchor.position);
+                GatheringFloatingTextService.TryShowAtAnchor(message, anchor);
         }
 
         /// <summary>

--- a/Assets/Scripts/Skills/Common/GatheringFloatingTextService.cs
+++ b/Assets/Scripts/Skills/Common/GatheringFloatingTextService.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Collections.Generic;
 using UI;
 using UnityEngine;
 using Util;
@@ -8,14 +9,16 @@ namespace Skills.Common
 {
     /// <summary>
     ///     Persistent helper that centralises floating text behaviour for gathering skills.
-    ///     Designers can tweak the interaction radius and XP popup delay from a single
-    ///     location while gameplay code reuses the shared range validation helpers.
+    ///     Designers can tweak the interaction radius, XP popup delay, and the shared
+    ///     minimum popup interval from a single location while gameplay code reuses the
+    ///     shared range validation helpers.
     /// </summary>
     [DisallowMultipleComponent]
     public sealed class GatheringFloatingTextService : MonoBehaviour
     {
         private const float DefaultRadius = 3f;
         private const float DefaultXpDelayTicks = 5f;
+        private const float DefaultMinimumPopupIntervalTicks = 1f;
 
         /// <summary>
         ///     Provides direct access to the active singleton instance when available.
@@ -31,6 +34,21 @@ namespace Skills.Common
         [SerializeField]
         [Tooltip("Fallback XP popup delay (in ticks) used when a caller does not supply an override.")]
         private float defaultXpPopupDelayTicks = DefaultXpDelayTicks;
+
+        [Header("Popup Cooldown")]
+        [SerializeField]
+        [Tooltip("Minimum interval (in ticks) enforced between floating text popups for the same anchor."
+                 + " OnValidate keeps the seconds field aligned so designers can author values in ticks if preferred.")]
+        private float minimumPopupIntervalTicks = DefaultMinimumPopupIntervalTicks;
+
+        [SerializeField]
+        [Tooltip("Minimum interval (in seconds) enforced between floating text popups for the same anchor."
+                 + " Adjusting this value also updates the tick configuration so teams can tune whichever unit is more intuitive.")]
+        private float minimumPopupIntervalSeconds = DefaultMinimumPopupIntervalTicks * Ticker.TickDuration;
+
+        [SerializeField]
+        [Tooltip("Runtime tracker storing the last display time for each anchor so cooldowns remain consistent across skills.")]
+        private AnchorCooldownDictionary anchorCooldowns = new AnchorCooldownDictionary();
 
         /// <summary>
         ///     Ensures the singleton is spawned before gameplay scenes begin loading.
@@ -59,12 +77,30 @@ namespace Skills.Common
                 return;
 
             StopAllCoroutines();
+            anchorCooldowns?.Clear();
         }
 
         private void OnValidate()
         {
             feedbackRadius = Mathf.Max(0f, feedbackRadius);
             defaultXpPopupDelayTicks = Mathf.Max(0f, defaultXpPopupDelayTicks);
+            minimumPopupIntervalTicks = Mathf.Max(0f, minimumPopupIntervalTicks);
+            minimumPopupIntervalSeconds = Mathf.Max(0f, minimumPopupIntervalSeconds);
+
+            float tickSeconds = minimumPopupIntervalTicks * Ticker.TickDuration;
+            if (minimumPopupIntervalSeconds < tickSeconds)
+            {
+                minimumPopupIntervalSeconds = tickSeconds;
+            }
+            else if (Ticker.TickDuration > Mathf.Epsilon)
+            {
+                minimumPopupIntervalTicks = minimumPopupIntervalSeconds / Ticker.TickDuration;
+            }
+
+            if (anchorCooldowns == null)
+                anchorCooldowns = new AnchorCooldownDictionary();
+
+            anchorCooldowns.PruneNullEntries();
         }
 
         /// <summary>
@@ -87,8 +123,26 @@ namespace Skills.Common
             if (!instance.IsWithinRange(anchorPosition, sourcePosition))
                 return false;
 
-            FloatingText.Show(message, anchorPosition);
-            return true;
+            return instance.TryShowAtAnchorInternal(message, playerAnchor);
+        }
+
+        /// <summary>
+        ///     Attempts to display floating text using the supplied anchor without performing a range validation.
+        ///     Useful for helpers that only know about the player anchor but still want cooldown enforcement.
+        /// </summary>
+        /// <param name="message">Text to display.</param>
+        /// <param name="anchor">Transform used for placement and cooldown tracking.</param>
+        /// <returns><c>true</c> when the popup was shown; otherwise <c>false</c>.</returns>
+        public static bool TryShowAtAnchor(string message, Transform anchor)
+        {
+            if (string.IsNullOrWhiteSpace(message) || anchor == null)
+                return false;
+
+            var instance = RequireInstance();
+            if (instance == null)
+                return false;
+
+            return instance.TryShowAtAnchorInternal(message, anchor);
         }
 
         /// <summary>
@@ -113,6 +167,10 @@ namespace Skills.Common
                 return false;
 
             float ticks = instance.ResolveDelayTicks(delayTicks);
+            float delaySeconds = Mathf.Max(0f, ticks * Ticker.TickDuration);
+            if (instance.ShouldThrottleAnchor(anchor, delaySeconds))
+                return false;
+
             instance.StartCoroutine(instance.ShowXpPopupAfterDelayRoutine(xp, anchor, sourcePosition, ticks));
             return true;
         }
@@ -156,7 +214,154 @@ namespace Skills.Common
             if (!IsWithinRange(anchorPosition, sourcePosition))
                 yield break;
 
-            FloatingText.Show($"+{xp} XP", anchorPosition);
+            if (!TryShowAtAnchorInternal($"+{xp} XP", anchor))
+                yield break;
+        }
+
+        private bool TryShowAtAnchorInternal(string message, Transform anchor)
+        {
+            if (string.IsNullOrWhiteSpace(message) || anchor == null)
+                return false;
+
+            if (!TryConsumeAnchorCooldown(anchor))
+                return false;
+
+            FloatingText.Show(message, anchor.position);
+            return true;
+        }
+
+        private bool TryConsumeAnchorCooldown(Transform anchor)
+        {
+            if (anchor == null)
+                return false;
+
+            if (anchorCooldowns == null)
+                anchorCooldowns = new AnchorCooldownDictionary();
+
+            anchorCooldowns.PruneNullEntries();
+
+            float cooldownSeconds = GetMinimumPopupIntervalSeconds();
+            float now = Time.unscaledTime;
+            if (cooldownSeconds > 0f &&
+                anchorCooldowns.TryGetLastShown(anchor, out float lastShown) &&
+                now - lastShown < cooldownSeconds)
+            {
+                return false;
+            }
+
+            anchorCooldowns.SetLastShown(anchor, now);
+            return true;
+        }
+
+        private bool ShouldThrottleAnchor(Transform anchor, float plannedDelaySeconds)
+        {
+            if (anchor == null)
+                return true;
+
+            if (anchorCooldowns == null)
+                anchorCooldowns = new AnchorCooldownDictionary();
+
+            anchorCooldowns.PruneNullEntries();
+
+            float cooldownSeconds = GetMinimumPopupIntervalSeconds();
+            if (cooldownSeconds <= 0f)
+                return false;
+
+            if (!anchorCooldowns.TryGetLastShown(anchor, out float lastShown))
+                return false;
+
+            float now = Time.unscaledTime;
+            float checkTime = now + Mathf.Max(0f, plannedDelaySeconds);
+            return checkTime - lastShown < cooldownSeconds;
+        }
+
+        private float GetMinimumPopupIntervalSeconds()
+        {
+            float fromTicks = Mathf.Max(0f, minimumPopupIntervalTicks) * Ticker.TickDuration;
+            return Mathf.Max(Mathf.Max(0f, minimumPopupIntervalSeconds), fromTicks);
+        }
+
+        [System.Serializable]
+        private sealed class AnchorCooldownDictionary : ISerializationCallbackReceiver
+        {
+            [SerializeField]
+            private List<Transform> anchors = new List<Transform>();
+
+            [SerializeField]
+            private List<float> timestamps = new List<float>();
+
+            private readonly Dictionary<Transform, float> runtimeMap = new Dictionary<Transform, float>();
+            private readonly List<Transform> pruneBuffer = new List<Transform>();
+
+            public bool TryGetLastShown(Transform anchor, out float timestamp)
+            {
+                if (anchor == null)
+                {
+                    timestamp = 0f;
+                    return false;
+                }
+
+                return runtimeMap.TryGetValue(anchor, out timestamp);
+            }
+
+            public void SetLastShown(Transform anchor, float timestamp)
+            {
+                if (anchor == null)
+                    return;
+
+                runtimeMap[anchor] = timestamp;
+            }
+
+            public void PruneNullEntries()
+            {
+                pruneBuffer.Clear();
+                foreach (var pair in runtimeMap)
+                {
+                    if (pair.Key == null)
+                        pruneBuffer.Add(pair.Key);
+                }
+
+                for (int i = 0; i < pruneBuffer.Count; i++)
+                {
+                    runtimeMap.Remove(pruneBuffer[i]);
+                }
+
+                pruneBuffer.Clear();
+            }
+
+            public void Clear()
+            {
+                runtimeMap.Clear();
+                anchors.Clear();
+                timestamps.Clear();
+            }
+
+            public void OnBeforeSerialize()
+            {
+                anchors.Clear();
+                timestamps.Clear();
+
+                foreach (var pair in runtimeMap)
+                {
+                    anchors.Add(pair.Key);
+                    timestamps.Add(pair.Value);
+                }
+            }
+
+            public void OnAfterDeserialize()
+            {
+                runtimeMap.Clear();
+
+                int count = Mathf.Min(anchors.Count, timestamps.Count);
+                for (int i = 0; i < count; i++)
+                {
+                    Transform anchor = anchors[i];
+                    if (anchor == null)
+                        continue;
+
+                    runtimeMap[anchor] = timestamps[i];
+                }
+            }
         }
     }
 }

--- a/Assets/Scripts/Skills/Common/GatheringRewardContextBuilder.cs
+++ b/Assets/Scripts/Skills/Common/GatheringRewardContextBuilder.cs
@@ -2,7 +2,6 @@ using System;
 using Inventory;
 using Pets;
 using Skills;
-using UI;
 using UnityEngine;
 
 namespace Skills.Common
@@ -177,7 +176,7 @@ namespace Skills.Common
                                 displayed = GatheringFloatingTextService.TryShowNow(message, result.Anchor, result.ResourcePosition);
 
                             if (!displayed && !result.HasResourcePosition)
-                                FloatingText.Show(message, result.Anchor.position);
+                                GatheringFloatingTextService.TryShowAtAnchor(message, result.Anchor);
                         }
                     }
 

--- a/Assets/Scripts/Skills/Common/GatheringRewardProcessor.cs
+++ b/Assets/Scripts/Skills/Common/GatheringRewardProcessor.cs
@@ -2,7 +2,6 @@ using System;
 using Inventory;
 using Pets;
 using Skills;
-using UI;
 using UnityEngine;
 
 namespace Skills.Common
@@ -116,7 +115,7 @@ namespace Skills.Common
                         displayed = GatheringFloatingTextService.TryShowNow(fullMessage, anchor, resourcePosition.Value);
 
                     if (!displayed && !resourcePosition.HasValue)
-                        FloatingText.Show(fullMessage, anchor.position);
+                        GatheringFloatingTextService.TryShowAtAnchor(fullMessage, anchor);
                 }
                 result.InventoryFull = true;
                 result.NewLevel = result.PreviousLevel;
@@ -142,7 +141,7 @@ namespace Skills.Common
                         displayed = GatheringFloatingTextService.TryShowNow(rewardMessage, anchor, resourcePosition.Value);
 
                     if (!displayed && !resourcePosition.HasValue)
-                        FloatingText.Show(rewardMessage, anchor.position);
+                        GatheringFloatingTextService.TryShowAtAnchor(rewardMessage, anchor);
                 }
             }
 

--- a/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
+++ b/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
@@ -2,7 +2,6 @@ using System;
 using UnityEngine;
 using Inventory;
 using Util;
-using UI;
 using BankSystem;
 using Pets;
 using Skills.Outfits;
@@ -214,7 +213,7 @@ namespace Skills.Cooking
                     displayed = GatheringFloatingTextService.TryShowNow("Burned", anchor, stationPosition.Value);
 
                 if (!displayed && !stationPosition.HasValue)
-                    FloatingText.Show("Burned", anchor.position);
+                    GatheringFloatingTextService.TryShowAtAnchor("Burned", anchor);
                 LogDebug($"Burned {currentRecipe.cookedItemId} (burn chance {burnChance:P2})");
             }
             else

--- a/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using UnityEngine;
 using Inventory;
 using Util;
-using UI;
 using Pets;
 using Core;
 using BankSystem;
@@ -176,7 +175,7 @@ namespace Skills.Fishing
                         displayed = GatheringFloatingTextService.TryShowNow("You need bait", anchor, spotPosition.Value);
 
                     if (!displayed && !spotPosition.HasValue)
-                        FloatingText.Show("You need bait", anchor.position);
+                        GatheringFloatingTextService.TryShowAtAnchor("You need bait", anchor);
                     LogDebug("Bait requirement not met; cancelling fishing session.");
                     StopFishing();
                     return;
@@ -190,7 +189,7 @@ namespace Skills.Fishing
                         displayed = GatheringFloatingTextService.TryShowNow(message, anchor, spotPosition.Value);
 
                     if (!displayed && !spotPosition.HasValue)
-                        FloatingText.Show(message, anchor.position);
+                        GatheringFloatingTextService.TryShowAtAnchor(message, anchor);
                 }
                 else
                 {
@@ -200,7 +199,7 @@ namespace Skills.Fishing
                         displayed = GatheringFloatingTextService.TryShowNow(fallbackMessage, anchor, spotPosition.Value);
 
                     if (!displayed && !spotPosition.HasValue)
-                        FloatingText.Show(fallbackMessage, anchor.position);
+                        GatheringFloatingTextService.TryShowAtAnchor(fallbackMessage, anchor);
                 }
             }
 
@@ -369,7 +368,7 @@ namespace Skills.Fishing
                     displayed = GatheringFloatingTextService.TryShowNow("Your inventory is full", anchor, spotPosition.Value);
 
                 if (!displayed && !spotPosition.HasValue)
-                    FloatingText.Show("Your inventory is full", anchor.position);
+                    GatheringFloatingTextService.TryShowAtAnchor("Your inventory is full", anchor);
                 return;
             }
 
@@ -379,7 +378,7 @@ namespace Skills.Fishing
                 rewardDisplayed = GatheringFloatingTextService.TryShowNow(message, anchor, spotPosition.Value);
 
             if (!rewardDisplayed && !spotPosition.HasValue)
-                FloatingText.Show(message, anchor.position);
+                GatheringFloatingTextService.TryShowAtAnchor(message, anchor);
         }
 
         private FishingTool MapTool(FishingToolDefinition tool)
@@ -426,7 +425,7 @@ namespace Skills.Fishing
                         displayed = GatheringFloatingTextService.TryShowNow("You need bait", anchor, spotPosition.Value);
 
                     if (!displayed && !spotPosition.HasValue)
-                        FloatingText.Show("You need bait", anchor.position);
+                        GatheringFloatingTextService.TryShowAtAnchor("You need bait", anchor);
                     LogDebug("Unable to start fishing: missing bait.");
                     return;
                 }


### PR DESCRIPTION
## Summary
- add configurable popup cooldown controls and per-anchor throttling inside `GatheringFloatingTextService`
- expose a `TryShowAtAnchor` helper and gate immediate/delayed popups behind the shared cooldown tracker
- route gathering skill fallback messages through the shared helper and document how to tune the delay

## Testing
- not run (Unity editor tests are not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d3d59fe8b8832eb23978e0f0f25189