### PR TITLE
Ensure poison controller cache on player respawn

### DIFF
--- a/Assets/Scripts/Player/PlayerRespawnSystem.cs
+++ b/Assets/Scripts/Player/PlayerRespawnSystem.cs
@@ -110,6 +110,17 @@ namespace Player
             {
                 playerMover?.StopMovement();
                 combatController?.CancelCombat();
+                if (poisonController == null && hitpoints != null)
+                {
+                    // Cache the poison controller the first time it is needed so subsequent deaths
+                    // can immediately clear lingering poison damage-over-time effects.
+                    poisonController = hitpoints.GetComponent<PoisonController>();
+
+                    // If the hitpoints component lives on a different GameObject than the poison
+                    // controller, rebuild all cached player references so the lookup succeeds.
+                    if (poisonController == null)
+                        FindPlayer();
+                }
                 poisonController?.CurePoison(0f);
                 if (BuffTimerService.Instance != null && hitpoints != null)
                     BuffTimerService.Instance.RemoveAllBuffs(hitpoints.gameObject, BuffEndReason.Manual);


### PR DESCRIPTION
## Summary
- ensure the player respawn system rebuilds its poison controller cache before clearing poison on death
- keep the null-safe poison cure call so repeated deaths reuse the cached component

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3faafed04832eb341e0da5e0c9f69