### PR TITLE
Improve bonfire log auto-selection and cooking hand-off

### DIFF
--- a/Assets/Scripts/Skills/Cooking/Core/CookingController.cs
+++ b/Assets/Scripts/Skills/Cooking/Core/CookingController.cs
@@ -149,6 +149,9 @@ namespace Skills.Cooking
                     return false;
                 }
 
+                if (ShouldSilenceBonfireLogAvailability(node))
+                    return false;
+
                 failureMessage = !string.IsNullOrEmpty(searchResult.FailureMessage)
                     ? searchResult.FailureMessage
                     : "You need something raw to cook";
@@ -163,6 +166,9 @@ namespace Skills.Cooking
                     cachedFailureMessage = failureMessage;
                     return false;
                 }
+
+                if (ShouldSilenceBonfireLogAvailability(node))
+                    return false;
 
                 failureMessage = !string.IsNullOrEmpty(searchResult.FailureMessage)
                     ? searchResult.FailureMessage
@@ -218,6 +224,27 @@ namespace Skills.Cooking
                 failureMessage = combinedMessage;
 
             return true;
+        }
+
+        /// <summary>
+        ///     Determines whether the current interaction targets a bonfire with available logs, allowing the
+        ///     Firemaking controller to process the click without surfacing additional cooking failure text.
+        /// </summary>
+        private bool ShouldSilenceBonfireLogAvailability(CookingObject node)
+        {
+            if (node == null || inventory == null)
+                return false;
+
+            if (!node.TryGetComponent<FiremakingBonfireObject>(out _))
+                return false;
+
+            if (firemakingSkill == null)
+                firemakingSkill = GetComponent<FiremakingSkill>();
+
+            if (firemakingSkill == null)
+                return false;
+
+            return firemakingSkill.HasAnyLogsInInventory(inventory);
         }
 
         /// <inheritdoc />

--- a/Assets/Scripts/Skills/Firemaking/Core/FiremakingBonfireController.cs
+++ b/Assets/Scripts/Skills/Firemaking/Core/FiremakingBonfireController.cs
@@ -209,13 +209,17 @@ namespace Skills.Firemaking
             if (TryGetCombinedBonfireCookingFailure(node, cookableResult, out failureMessage))
                 return false;
 
-            if (selectedIndex < 0)
+            int logSlot = selectedIndex;
+            if (logSlot < 0)
+                logSlot = ResolvePendingLogSlot(-1);
+
+            if (logSlot < 0)
             {
                 failureMessage = "Select a log to feed the bonfire.";
                 return false;
             }
 
-            if (!Skill.TryStartBonfireFeeding(node, selectedIndex, out failureMessage))
+            if (!Skill.TryStartBonfireFeeding(node, logSlot, out failureMessage))
                 return false;
 
             ClearPendingBonfire();


### PR DESCRIPTION
## Summary
- allow bonfire interactions to auto-select the first available log slot when no inventory slot is highlighted
- ensure cooking controller suppresses duplicate failure text when bonfire logs are available so firemaking handles the click

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d41a811e00832ead0b03475f1f4ea7