### PR TITLE
Fix log slot redeclaration in bonfire controller

### DIFF
--- a/Assets/Scripts/Skills/Firemaking/Core/FiremakingBonfireController.cs
+++ b/Assets/Scripts/Skills/Firemaking/Core/FiremakingBonfireController.cs
@@ -193,8 +193,8 @@ namespace Skills.Firemaking
 
             if (cookableResult.CanCook)
             {
-                int logSlot = ResolvePendingLogSlot(selectedIndex);
-                QueuePendingBonfire(node, logSlot);
+                int queuedLogSlot = ResolvePendingLogSlot(selectedIndex);
+                QueuePendingBonfire(node, queuedLogSlot);
                 return false;
             }
 


### PR DESCRIPTION
## Summary
- rename the temporary log slot variable when queueing bonfire fueling so it no longer clashes with the later log slot declaration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d41eeadc34832e8811bb35306dd7a6