### PR TITLE
Add pet floating text anchors for Phoenix cry

### DIFF
--- a/Assets/Scripts/Pets/PetDropSystem.cs
+++ b/Assets/Scripts/Pets/PetDropSystem.cs
@@ -21,6 +21,11 @@ namespace Pets
         public static PetDefinition ActivePet => activePetDef;
         public static GameObject ActivePetObject => activePetGO;
         public static PetCombatController ActivePetCombat => activePetGO != null ? activePetGO.GetComponent<PetCombatController>() : null;
+
+        /// <summary>
+        ///     Provides the floating-text controller for the active pet instance when available.
+        /// </summary>
+        public static PetFloatingTextController ActivePetFloatingText => activePetGO != null ? activePetGO.GetComponent<PetFloatingTextController>() : null;
         public static bool DebugPetRolls { get; set; }
         public static bool GuardModeEnabled { get; set; }
         public static bool PetInventoryVisible { get; set; }
@@ -248,6 +253,26 @@ namespace Pets
         }
 
         /// <summary>
+        ///     Attempts to display floating text using the active pet's anchor when available.
+        /// </summary>
+        /// <param name="message">Message to display above the active pet.</param>
+        /// <param name="color">Optional colour override.</param>
+        /// <param name="size">Optional text scale override.</param>
+        /// <param name="background">Optional background sprite for the text.</param>
+        /// <returns>True when the message is shown successfully.</returns>
+        public static bool TryShowFloatingText(string message, Color? color = null, float? size = null, Sprite background = null)
+        {
+            if (string.IsNullOrEmpty(message))
+                return false;
+
+            var controller = ActivePetFloatingText;
+            if (controller == null)
+                return false;
+
+            return controller.TryShowMessage(message, color, size, background);
+        }
+
+        /// <summary>
         /// Spawns a pet directly at the given world position.
         /// </summary>
         public static GameObject SpawnPet(PetDefinition pet, Vector3 position)
@@ -287,6 +312,8 @@ namespace Pets
                 var storage = activePetGO.GetComponent<PetStorage>();
                 storage?.StartCoroutine(storage.OpenDelayed());
             }
+
+            ActivePetFloatingText?.RefreshAnchorPosition();
 
             return activePetGO;
         }

--- a/Assets/Scripts/Pets/PetFloatingTextController.cs
+++ b/Assets/Scripts/Pets/PetFloatingTextController.cs
@@ -1,0 +1,159 @@
+using UI;
+using UnityEngine;
+
+namespace Pets
+{
+    /// <summary>
+    ///     Maintains a floating-text anchor for pet feedback so pets can emit contextual messages.
+    /// </summary>
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(SpriteRenderer))]
+    public sealed class PetFloatingTextController : MonoBehaviour
+    {
+        [SerializeField] private SpriteRenderer spriteRenderer;
+        [SerializeField] private Transform floatingTextAnchor;
+        [SerializeField] private float verticalPadding = 0.25f;
+        [SerializeField] private Vector3 manualWorldOffset;
+
+        /// <summary>
+        ///     Gets the transform used as the floating-text anchor for this pet.
+        /// </summary>
+        public Transform FloatingTextAnchor => floatingTextAnchor;
+
+        /// <summary>
+        ///     Gets the current world-space anchor position, falling back to the pet root when no anchor exists.
+        /// </summary>
+        public Vector3 AnchorWorldPosition => floatingTextAnchor != null ? floatingTextAnchor.position : transform.position;
+
+        /// <summary>
+        ///     Ensures dependencies are wired and the anchor is positioned when the component wakes.
+        /// </summary>
+        private void Awake()
+        {
+            PrepareAnchor();
+        }
+
+        /// <summary>
+        ///     Reapplies anchor preparation whenever the component is enabled so pet spawn/restore flows stay aligned.
+        /// </summary>
+        private void OnEnable()
+        {
+            PrepareAnchor();
+        }
+
+        /// <summary>
+        ///     Keeps serialized references valid while editing prefabs or scene instances.
+        /// </summary>
+        private void OnValidate()
+        {
+            PrepareAnchor();
+        }
+
+        /// <summary>
+        ///     Updates the floating-text anchor to sit above the pet sprite each frame.
+        /// </summary>
+        private void LateUpdate()
+        {
+            RefreshAnchorPosition();
+        }
+
+        /// <summary>
+        ///     Attempts to display a floating text message at the pet's anchor using the shared UI helper.
+        /// </summary>
+        /// <param name="message">Message to display.</param>
+        /// <param name="color">Optional colour override.</param>
+        /// <param name="size">Optional scale override.</param>
+        /// <param name="background">Optional sprite displayed behind the text.</param>
+        /// <returns>True when the message is shown successfully.</returns>
+        public bool TryShowMessage(string message, Color? color = null, float? size = null, Sprite background = null)
+        {
+            if (string.IsNullOrEmpty(message))
+                return false;
+
+            CacheSpriteRenderer();
+            EnsureAnchor();
+            if (floatingTextAnchor == null)
+                return false;
+
+            RefreshAnchorPosition();
+            FloatingText.Show(message, AnchorWorldPosition, color, size, background);
+            return true;
+        }
+
+        /// <summary>
+        ///     Repositions the floating-text anchor above the sprite bounds, applying manual offsets when configured.
+        /// </summary>
+        public void RefreshAnchorPosition()
+        {
+            CacheSpriteRenderer();
+            EnsureAnchor();
+            if (floatingTextAnchor == null)
+                return;
+
+            Vector3 worldCenter = transform.position;
+            float spriteHalfHeight = 0f;
+
+            if (spriteRenderer != null && spriteRenderer.sprite != null)
+            {
+                var bounds = spriteRenderer.bounds;
+                worldCenter = bounds.center;
+                spriteHalfHeight = bounds.extents.y;
+            }
+
+            Vector3 worldPosition = worldCenter + Vector3.up * (spriteHalfHeight + verticalPadding) + manualWorldOffset;
+            floatingTextAnchor.position = worldPosition;
+            floatingTextAnchor.rotation = Quaternion.identity;
+            floatingTextAnchor.localScale = Vector3.one;
+        }
+
+        /// <summary>
+        ///     Caches the sprite renderer reference when missing so bounds can be evaluated reliably.
+        /// </summary>
+        private void CacheSpriteRenderer()
+        {
+            if (spriteRenderer == null)
+                spriteRenderer = GetComponent<SpriteRenderer>();
+        }
+
+        /// <summary>
+        ///     Ensures an anchor transform exists and is parented correctly beneath the pet root.
+        /// </summary>
+        private void EnsureAnchor()
+        {
+            if (floatingTextAnchor == null)
+            {
+                var existing = transform.Find("FloatingTextAnchor");
+                if (existing != null)
+                {
+                    floatingTextAnchor = existing;
+                }
+                else
+                {
+                    var anchorGO = new GameObject("FloatingTextAnchor");
+                    floatingTextAnchor = anchorGO.transform;
+                    floatingTextAnchor.SetParent(transform, false);
+                }
+            }
+
+            if (floatingTextAnchor == null)
+                return;
+
+            if (floatingTextAnchor.parent != transform)
+                floatingTextAnchor.SetParent(transform, false);
+
+            floatingTextAnchor.localPosition = Vector3.zero;
+            floatingTextAnchor.localRotation = Quaternion.identity;
+            floatingTextAnchor.localScale = Vector3.one;
+        }
+
+        /// <summary>
+        ///     Sets up cached references and anchor placement, used by all lifecycle entry points.
+        /// </summary>
+        private void PrepareAnchor()
+        {
+            CacheSpriteRenderer();
+            EnsureAnchor();
+            RefreshAnchorPosition();
+        }
+    }
+}

--- a/Assets/Scripts/Pets/PetSpawner.cs
+++ b/Assets/Scripts/Pets/PetSpawner.cs
@@ -172,6 +172,11 @@ namespace Pets
                 go.AddComponent<CookingObject>();
             }
 
+            var floatingTextController = go.GetComponent<PetFloatingTextController>();
+            if (floatingTextController == null)
+                floatingTextController = go.AddComponent<PetFloatingTextController>();
+            floatingTextController.RefreshAnchorPosition();
+
             return go;
         }
     }

--- a/Assets/Scripts/Skills/Firemaking/Core/FiremakingSkill.cs
+++ b/Assets/Scripts/Skills/Firemaking/Core/FiremakingSkill.cs
@@ -44,6 +44,7 @@ namespace Skills.Firemaking
         private const float PhoenixDoubleXpChance = 1f / 20f;
         private const float PhoenixDoubleXpBonus = 1f; // Adds +100% XP when triggered
         private const string PhoenixDoubleXpMessage = "Your phoenix flares brightly, doubling your Firemaking XP!";
+        private const string PhoenixDoubleXpCry = "Bwaaaak";
 
         private SkillManager skills;
         private Dictionary<string, FiremakingLogDefinition> logLookup;
@@ -981,10 +982,25 @@ namespace Skills.Firemaking
         /// <param name="result">Result data provided by the gathering reward processor.</param>
         private void ShowPhoenixDoubleXpFeedback(in GatheringRewardResult result)
         {
+            ShowPhoenixCry();
+
             Vector3 position = result.HasResourcePosition
                 ? result.ResourcePosition
                 : (result.Anchor != null ? result.Anchor.position : transform.position);
             ShowFeedback(PhoenixDoubleXpMessage, position);
+        }
+
+        /// <summary>
+        ///     Emits the Phoenix pet's signature cry above the pet when the double XP proc triggers.
+        /// </summary>
+        private void ShowPhoenixCry()
+        {
+            var activePet = PetDropSystem.ActivePet;
+            if (activePet == null || !string.Equals(activePet.id, PhoenixPetId, StringComparison.Ordinal))
+                return;
+
+            if (PetDropSystem.TryShowFloatingText(PhoenixDoubleXpCry))
+                LogDebug("Phoenix cry displayed for double XP proc.");
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- add a reusable PetFloatingTextController that keeps a floating-text anchor aligned above pet sprites
- attach the controller to spawned pets and expose helper accessors on PetDropSystem for floating feedback
- trigger the Phoenix's floating text cry alongside the existing double XP message in Firemaking

## Testing
- not run (Unity editor not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d423df3648832e927a7c4aab4e514b