### PR TITLE
Add rainbow gradient to skilling HUD progress bars

### DIFF
--- a/Assets/Scripts/Skills/Common/UI/SkillingProgressColorGradient.cs
+++ b/Assets/Scripts/Skills/Common/UI/SkillingProgressColorGradient.cs
@@ -1,0 +1,47 @@
+using UnityEngine;
+
+namespace Skills.Common.UI
+{
+    /// <summary>
+    /// Provides a shared rainbow gradient for skilling HUD progress bars so each bar smoothly
+    /// transitions through the traditional red-to-violet RuneScape spectrum as the player advances.
+    /// </summary>
+    public static class SkillingProgressColorGradient
+    {
+        /// <summary>
+        /// Cached rainbow colours ordered from empty (red) to full (violet). The list mirrors the
+        /// classic OSRS skilling feedback palette while ensuring each segment blends smoothly.
+        /// </summary>
+        private static readonly Color[] RainbowStops =
+        {
+            new Color(1f, 0f, 0f),        // Red
+            new Color(1f, 0.49803922f, 0f), // Orange (#FF7F00)
+            new Color(1f, 1f, 0f),        // Yellow
+            new Color(0f, 1f, 0f),        // Green
+            new Color(0f, 0f, 1f),        // Blue
+            new Color(0.29411766f, 0f, 0.50980395f), // Indigo (#4B0082)
+            new Color(0.56078434f, 0f, 1f) // Violet (#8F00FF)
+        };
+
+        /// <summary>
+        /// Evaluates the rainbow gradient for the provided normalised progress value.
+        /// </summary>
+        /// <param name="normalizedProgress">Progress between 0 (start) and 1 (complete).</param>
+        /// <returns>The colour that corresponds to the requested point along the rainbow.</returns>
+        public static Color Evaluate(float normalizedProgress)
+        {
+            if (RainbowStops.Length == 0)
+                return Color.white;
+
+            float clamped = Mathf.Clamp01(normalizedProgress);
+            float scaled = clamped * (RainbowStops.Length - 1);
+            int index = Mathf.FloorToInt(scaled);
+
+            if (index >= RainbowStops.Length - 1)
+                return RainbowStops[RainbowStops.Length - 1];
+
+            float localT = scaled - index;
+            return Color.Lerp(RainbowStops[index], RainbowStops[index + 1], localT);
+        }
+    }
+}

--- a/Assets/Scripts/Skills/Cooking/UI/CookingHUD.cs
+++ b/Assets/Scripts/Skills/Cooking/UI/CookingHUD.cs
@@ -215,8 +215,7 @@ namespace Skills.Cooking
             currentFill = 0f;
             nextFill = progressStep;
             tickTimer = 0f;
-            if (progressFill != null)
-                progressFill.fillAmount = 0f;
+            SetProgressFill(0f);
             if (progressRoot != null)
             {
                 progressRoot.SetActive(true);
@@ -254,12 +253,12 @@ namespace Skills.Cooking
             tickTimer += Time.deltaTime;
             if (segmentDuration <= 0f)
             {
-                progressFill.fillAmount = nextFill;
+                SetProgressFill(nextFill);
                 return;
             }
 
             float t = Mathf.Clamp01(tickTimer / segmentDuration);
-            progressFill.fillAmount = Mathf.Lerp(currentFill, nextFill, t);
+            SetProgressFill(Mathf.Lerp(currentFill, nextFill, t));
         }
 
         public void OnTick()
@@ -305,12 +304,11 @@ namespace Skills.Cooking
             var fill = new GameObject("Fill");
             fill.transform.SetParent(bg.transform, false);
             progressFill = fill.AddComponent<Image>();
-            progressFill.color = new Color(1f, 0.64f, 0f, 1f);
             progressFill.sprite = bgSprite;
             progressFill.type = Image.Type.Filled;
             progressFill.fillMethod = Image.FillMethod.Horizontal;
             progressFill.fillOrigin = (int)Image.OriginHorizontal.Left;
-            progressFill.fillAmount = 0f;
+            SetProgressFill(0f);
             var fillRect = progressFill.rectTransform;
             fillRect.anchorMin = Vector2.zero;
             fillRect.anchorMax = Vector2.one;
@@ -340,6 +338,16 @@ namespace Skills.Cooking
 
             PersistentSceneGate.SceneEvaluationChanged += HandleSceneGateEvaluation;
             sceneGateSubscribed = true;
+        }
+
+        private void SetProgressFill(float normalizedValue)
+        {
+            if (progressFill == null)
+                return;
+
+            float clamped = Mathf.Clamp01(normalizedValue);
+            progressFill.fillAmount = clamped;
+            progressFill.color = SkillingProgressColorGradient.Evaluate(clamped);
         }
 
         private void HandleSceneGateEvaluation(Scene scene, bool allowed)

--- a/Assets/Scripts/Skills/Firemaking/UI/FiremakingHUD.cs
+++ b/Assets/Scripts/Skills/Firemaking/UI/FiremakingHUD.cs
@@ -226,8 +226,7 @@ namespace Skills.Firemaking
             currentFill = 0f;
             nextFill = progressStep;
             tickTimer = 0f;
-            if (progressFill != null)
-                progressFill.fillAmount = 0f;
+            SetProgressFill(0f);
             if (progressRoot != null)
             {
                 progressRoot.SetActive(true);
@@ -255,8 +254,7 @@ namespace Skills.Firemaking
             currentFill = 0f;
             nextFill = progressStep;
             tickTimer = 0f;
-            if (progressFill != null)
-                progressFill.fillAmount = 0f;
+            SetProgressFill(0f);
             if (progressRoot != null)
             {
                 progressRoot.SetActive(true);
@@ -324,12 +322,12 @@ namespace Skills.Firemaking
             tickTimer += Time.deltaTime;
             if (segmentDuration <= 0f)
             {
-                progressFill.fillAmount = nextFill;
+                SetProgressFill(nextFill);
                 return;
             }
 
             float t = Mathf.Clamp01(tickTimer / segmentDuration);
-            progressFill.fillAmount = Mathf.Lerp(currentFill, nextFill, t);
+            SetProgressFill(Mathf.Lerp(currentFill, nextFill, t));
         }
 
         public void OnTick()
@@ -400,12 +398,11 @@ namespace Skills.Firemaking
             var fill = new GameObject("Fill");
             fill.transform.SetParent(bg.transform, false);
             progressFill = fill.AddComponent<Image>();
-            progressFill.color = Color.green;
             progressFill.sprite = bgSprite;
             progressFill.type = Image.Type.Filled;
             progressFill.fillMethod = Image.FillMethod.Horizontal;
             progressFill.fillOrigin = (int)Image.OriginHorizontal.Left;
-            progressFill.fillAmount = 0f;
+            SetProgressFill(0f);
             var fillRect = progressFill.rectTransform;
             fillRect.anchorMin = Vector2.zero;
             fillRect.anchorMax = Vector2.one;
@@ -436,6 +433,20 @@ namespace Skills.Firemaking
 
             PersistentSceneGate.SceneEvaluationChanged += HandleSceneGateEvaluation;
             sceneGateSubscribed = true;
+        }
+
+        /// <summary>
+        /// Applies the requested fill amount and synchronises the rainbow gradient with the current progress.
+        /// </summary>
+        /// <param name="normalizedValue">Progress value between 0 and 1.</param>
+        private void SetProgressFill(float normalizedValue)
+        {
+            if (progressFill == null)
+                return;
+
+            float clamped = Mathf.Clamp01(normalizedValue);
+            progressFill.fillAmount = clamped;
+            progressFill.color = SkillingProgressColorGradient.Evaluate(clamped);
         }
 
         private void HandleSceneGateEvaluation(Scene scene, bool allowed)

--- a/Assets/Scripts/Skills/Fishing/UI/FishingHUD.cs
+++ b/Assets/Scripts/Skills/Fishing/UI/FishingHUD.cs
@@ -185,11 +185,11 @@ namespace Skills.Fishing
             var fill = new GameObject("Fill");
             fill.transform.SetParent(bg.transform, false);
             progressImage = fill.AddComponent<Image>();
-            progressImage.color = Color.blue;
+            progressImage.color = SkillingProgressColorGradient.Evaluate(0f);
             progressImage.sprite = bgSprite;
             progressImage.type = Image.Type.Filled;
             progressImage.fillMethod = Image.FillMethod.Horizontal;
-            progressImage.fillAmount = 0f;
+            SetProgressFill(0f);
             var fillRect = progressImage.rectTransform;
             fillRect.anchorMin = Vector2.zero;
             fillRect.anchorMax = Vector2.one;
@@ -215,7 +215,7 @@ namespace Skills.Fishing
         {
             EnsureProgressObjects();
             target = spot.transform;
-            progressImage.fillAmount = 0f;
+            SetProgressFill(0f);
             currentFill = 0f;
             tickTimer = 0f;
             step = skill.CurrentCatchIntervalTicks > 0 ? 1f / skill.CurrentCatchIntervalTicks : 0f;
@@ -295,12 +295,12 @@ namespace Skills.Fishing
             tickTimer += Time.deltaTime;
             if (segmentDuration <= 0f)
             {
-                progressImage.fillAmount = nextFill;
+                SetProgressFill(nextFill);
                 return;
             }
 
             float t = Mathf.Clamp01(tickTimer / segmentDuration);
-            progressImage.fillAmount = Mathf.Lerp(currentFill, nextFill, t);
+            SetProgressFill(Mathf.Lerp(currentFill, nextFill, t));
         }
 
         public void OnTick()
@@ -316,8 +316,7 @@ namespace Skills.Fishing
                 currentFill = 0f;
                 nextFill = 0f;
                 awaitingResetTick = false;
-                if (progressImage != null)
-                    progressImage.fillAmount = 0f;
+                SetProgressFill(0f);
                 return;
             }
 
@@ -326,8 +325,7 @@ namespace Skills.Fishing
                 awaitingResetTick = false;
                 currentFill = 0f;
                 nextFill = step;
-                if (progressImage != null)
-                    progressImage.fillAmount = 0f;
+                SetProgressFill(0f);
                 return;
             }
 
@@ -361,6 +359,16 @@ namespace Skills.Fishing
 
             PersistentSceneGate.SceneEvaluationChanged += HandleSceneGateEvaluation;
             sceneGateSubscribed = true;
+        }
+
+        private void SetProgressFill(float normalizedValue)
+        {
+            if (progressImage == null)
+                return;
+
+            float clamped = Mathf.Clamp01(normalizedValue);
+            progressImage.fillAmount = clamped;
+            progressImage.color = SkillingProgressColorGradient.Evaluate(clamped);
         }
 
         private void HandleSceneGateEvaluation(Scene scene, bool allowed)

--- a/Assets/Scripts/Skills/Mining/UI/MiningUI.cs
+++ b/Assets/Scripts/Skills/Mining/UI/MiningUI.cs
@@ -190,11 +190,11 @@ namespace Skills.Mining
             var fill = new GameObject("Fill");
             fill.transform.SetParent(bg.transform, false);
             progressImage = fill.AddComponent<Image>();
-            progressImage.color = Color.green;
+            progressImage.color = SkillingProgressColorGradient.Evaluate(0f);
             progressImage.sprite = bgSprite;
             progressImage.type = Image.Type.Filled;
             progressImage.fillMethod = Image.FillMethod.Horizontal;
-            progressImage.fillAmount = 0f;
+            SetProgressFill(0f);
             var fillRect = progressImage.rectTransform;
             fillRect.anchorMin = Vector2.zero;
             fillRect.anchorMax = Vector2.one;
@@ -220,7 +220,7 @@ namespace Skills.Mining
         {
             EnsureProgressObjects();
             target = rock.transform;
-            progressImage.fillAmount = 0f;
+            SetProgressFill(0f);
             currentFill = 0f;
             tickTimer = 0f;
             step = skill.CurrentSwingSpeedTicks > 0 ? 1f / skill.CurrentSwingSpeedTicks : 0f;
@@ -297,12 +297,12 @@ namespace Skills.Mining
             tickTimer += Time.deltaTime;
             if (segmentDuration <= 0f)
             {
-                progressImage.fillAmount = nextFill;
+                SetProgressFill(nextFill);
                 return;
             }
 
             float t = Mathf.Clamp01(tickTimer / segmentDuration);
-            progressImage.fillAmount = Mathf.Lerp(currentFill, nextFill, t);
+            SetProgressFill(Mathf.Lerp(currentFill, nextFill, t));
         }
 
         public void OnTick()
@@ -318,8 +318,7 @@ namespace Skills.Mining
                 currentFill = 0f;
                 nextFill = 0f;
                 awaitingResetTick = false;
-                if (progressImage != null)
-                    progressImage.fillAmount = 0f;
+                SetProgressFill(0f);
                 return;
             }
 
@@ -328,8 +327,7 @@ namespace Skills.Mining
                 awaitingResetTick = false;
                 currentFill = 0f;
                 nextFill = step;
-                if (progressImage != null)
-                    progressImage.fillAmount = 0f;
+                SetProgressFill(0f);
                 return;
             }
 
@@ -363,6 +361,16 @@ namespace Skills.Mining
 
             PersistentSceneGate.SceneEvaluationChanged += HandleSceneGateEvaluation;
             sceneGateSubscribed = true;
+        }
+
+        private void SetProgressFill(float normalizedValue)
+        {
+            if (progressImage == null)
+                return;
+
+            float clamped = Mathf.Clamp01(normalizedValue);
+            progressImage.fillAmount = clamped;
+            progressImage.color = SkillingProgressColorGradient.Evaluate(clamped);
         }
 
         private void HandleSceneGateEvaluation(Scene scene, bool allowed)

--- a/Assets/Scripts/Skills/Woodcutting/UI/WoodcuttingHUD.cs
+++ b/Assets/Scripts/Skills/Woodcutting/UI/WoodcuttingHUD.cs
@@ -188,11 +188,11 @@ namespace Skills.Woodcutting
             var fill = new GameObject("Fill");
             fill.transform.SetParent(bg.transform, false);
             progressImage = fill.AddComponent<Image>();
-            progressImage.color = Color.green;
+            progressImage.color = SkillingProgressColorGradient.Evaluate(0f);
             progressImage.sprite = bgSprite;
             progressImage.type = Image.Type.Filled;
             progressImage.fillMethod = Image.FillMethod.Horizontal;
-            progressImage.fillAmount = 0f;
+            SetProgressFill(0f);
             var fillRect = progressImage.rectTransform;
             fillRect.anchorMin = Vector2.zero;
             fillRect.anchorMax = Vector2.one;
@@ -218,7 +218,7 @@ namespace Skills.Woodcutting
         {
             EnsureProgressObjects();
             target = tree.transform;
-            progressImage.fillAmount = 0f;
+            SetProgressFill(0f);
             currentFill = 0f;
             tickTimer = 0f;
             step = skill.CurrentChopIntervalTicks > 0 ? 1f / skill.CurrentChopIntervalTicks : 0f;
@@ -298,12 +298,12 @@ namespace Skills.Woodcutting
             tickTimer += Time.deltaTime;
             if (segmentDuration <= 0f)
             {
-                progressImage.fillAmount = nextFill;
+                SetProgressFill(nextFill);
                 return;
             }
 
             float t = Mathf.Clamp01(tickTimer / segmentDuration);
-            progressImage.fillAmount = Mathf.Lerp(currentFill, nextFill, t);
+            SetProgressFill(Mathf.Lerp(currentFill, nextFill, t));
         }
 
         public void OnTick()
@@ -319,8 +319,7 @@ namespace Skills.Woodcutting
                 currentFill = 0f;
                 nextFill = 0f;
                 awaitingResetTick = false;
-                if (progressImage != null)
-                    progressImage.fillAmount = 0f;
+                SetProgressFill(0f);
                 return;
             }
 
@@ -330,8 +329,7 @@ namespace Skills.Woodcutting
                 awaitingResetTick = false;
                 currentFill = 0f;
                 nextFill = step;
-                if (progressImage != null)
-                    progressImage.fillAmount = 0f;
+                SetProgressFill(0f);
                 return;
             }
 
@@ -348,6 +346,16 @@ namespace Skills.Woodcutting
             {
                 nextFill = Mathf.Min(1f, currentFill + step);
             }
+        }
+
+        private void SetProgressFill(float normalizedValue)
+        {
+            if (progressImage == null)
+                return;
+
+            float clamped = Mathf.Clamp01(normalizedValue);
+            progressImage.fillAmount = clamped;
+            progressImage.color = SkillingProgressColorGradient.Evaluate(clamped);
         }
 
         private void EnsureSceneLoadedSubscription()


### PR DESCRIPTION
## Summary
- add a shared rainbow gradient evaluator for skilling HUD progress bars
- update cooking, firemaking, fishing, mining, and woodcutting HUDs to lerp through the rainbow as they fill
- ensure all skilling progress bars reset to the gradient start when a new action begins

## Testing
- not run (Unity editor required)

------
https://chatgpt.com/codex/tasks/task_e_68d456e9afc0832ea8255974529c701d