### PR TITLE
Fix cooking and bonfire progress bar resets

### DIFF
--- a/Assets/Scripts/Skills/Cooking/UI/CookingHUD.cs
+++ b/Assets/Scripts/Skills/Cooking/UI/CookingHUD.cs
@@ -44,6 +44,11 @@ namespace Skills.Cooking
         private float segmentDuration = Ticker.TickDuration;
         private float progressStep = 1f;
 
+        /// <summary>
+        ///     Tolerance used when detecting when a new cooking cycle starts so the bar can reset cleanly.
+        /// </summary>
+        private const float ProgressResetThreshold = 0.001f;
+
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         private static void Bootstrap()
         {
@@ -273,6 +278,13 @@ namespace Skills.Cooking
             UpdateSegmentSettings();
             currentFill = progressFill != null ? progressFill.fillAmount : currentFill;
             float normalized = Mathf.Clamp01(skill.CookProgressNormalized);
+
+            if (normalized + ProgressResetThreshold < currentFill)
+            {
+                currentFill = normalized;
+                SetProgressFill(normalized);
+            }
+
             float targetFill = Mathf.Clamp01(currentFill + progressStep);
             nextFill = Mathf.Max(normalized, targetFill);
         }

--- a/Assets/Scripts/Skills/Firemaking/UI/FiremakingHUD.cs
+++ b/Assets/Scripts/Skills/Firemaking/UI/FiremakingHUD.cs
@@ -44,6 +44,11 @@ namespace Skills.Firemaking
         private float tickTimer;
         private float segmentDuration = Ticker.TickDuration;
         private float progressStep = 1f;
+
+        /// <summary>
+        ///     Tolerance used when detecting when a new progress cycle begins so the bar can reset cleanly.
+        /// </summary>
+        private const float ProgressResetThreshold = 0.001f;
         private FiremakingHudMode mode = FiremakingHudMode.None;
         private FiremakingBonfireObject activeBonfire;
         private SkillManager skillManager;
@@ -365,6 +370,13 @@ namespace Skills.Firemaking
                 normalized = Mathf.Clamp01(skill.IgnitionProgressNormalized);
             else if (mode == FiremakingHudMode.Bonfire)
                 normalized = Mathf.Clamp01(skill.BonfireFeedingProgressNormalized);
+
+            // If the skill reports a lower progress value we have started a new cycle (new log/feed).
+            if (normalized + ProgressResetThreshold < currentFill)
+            {
+                currentFill = normalized;
+                SetProgressFill(normalized);
+            }
 
             // Ensure the bar always advances even if the skill reports stale progress (e.g. after a failure retry).
             float targetFill = Mathf.Clamp01(currentFill + progressStep);


### PR DESCRIPTION
## Summary
- reset the Firemaking HUD progress bar whenever a new bonfire cycle begins so the fill returns to zero
- mirror the same reset handling for the Cooking HUD so repeated cooks animate correctly

## Testing
- not run (Unity editor required)

------
https://chatgpt.com/codex/tasks/task_e_68d515551d68832e9ba9ff5c2091ce1b