### PR TITLE
Adjust Phoenix cry text color and casing

### DIFF
--- a/Assets/Scripts/Skills/Firemaking/Core/FiremakingSkill.cs
+++ b/Assets/Scripts/Skills/Firemaking/Core/FiremakingSkill.cs
@@ -44,7 +44,7 @@ namespace Skills.Firemaking
         private const float PhoenixDoubleXpChance = 1f / 20f;
         private const float PhoenixDoubleXpBonus = 1f; // Adds +100% XP when triggered
         private const string PhoenixDoubleXpMessage = "Your phoenix flares brightly, doubling your Firemaking XP!";
-        private const string PhoenixDoubleXpCry = "Bwaaaak";
+        private const string PhoenixDoubleXpCry = "BWAAAAAK";
 
         private SkillManager skills;
         private Dictionary<string, FiremakingLogDefinition> logLookup;
@@ -1036,7 +1036,7 @@ namespace Skills.Firemaking
             if (activePet == null || !string.Equals(activePet.id, PhoenixPetId, StringComparison.Ordinal))
                 return;
 
-            if (PetDropSystem.TryShowFloatingText(PhoenixDoubleXpCry))
+            if (PetDropSystem.TryShowFloatingText(PhoenixDoubleXpCry, Color.red))
                 LogDebug("Phoenix cry displayed for double XP proc.");
         }
 


### PR DESCRIPTION
## Summary
- update the Phoenix double XP cry string so the feedback appears as an uppercase "BWAAAAAK"
- tint the Phoenix floating text feedback red when the double XP proc triggers to emphasize the event

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d51848c898832eb48683d8befdc010