### PR TITLE
Adjust bonfire selection flow between firemaking and cooking

### DIFF
--- a/Assets/Scripts/Skills/Cooking/Core/CookingController.cs
+++ b/Assets/Scripts/Skills/Cooking/Core/CookingController.cs
@@ -141,6 +141,19 @@ namespace Skills.Cooking
 
             var searchResult = CookingInventoryHelper.FindCookableRecipe(inventory, CookingSkill, inventory.selectedIndex);
 
+            if (inventory != null && firemakingSkill != null && inventory.selectedIndex >= 0)
+            {
+                // When the player has a log highlighted, allow the firemaking controller to consume
+                // the interaction instead of beginning a cooking action immediately.
+                var selectedSlot = inventory.GetSlot(inventory.selectedIndex);
+                if (selectedSlot.item != null && firemakingSkill.GetDefinitionForItem(selectedSlot.item.id) != null)
+                {
+                    failureMessage = string.Empty;
+                    cachedFailureMessage = string.Empty;
+                    return false;
+                }
+            }
+
             if (!searchResult.HasRecipe)
             {
                 if (TryHandleCombinedBonfireFailure(node, out failureMessage))

--- a/Assets/Scripts/Skills/Firemaking/Core/FiremakingBonfireController.cs
+++ b/Assets/Scripts/Skills/Firemaking/Core/FiremakingBonfireController.cs
@@ -187,20 +187,46 @@ namespace Skills.Firemaking
             }
 
             int selectedIndex = inventory.selectedIndex;
+            bool hasManualSelection = selectedIndex >= 0;
+            bool selectedSlotIsLog = false;
+
+            if (hasManualSelection)
+            {
+                // Resolve whether the highlighted slot already targets a registered log so we can
+                // immediately feed the bonfire without deferring to the cooking controller.
+                var selectedSlot = inventory.GetSlot(selectedIndex);
+                if (selectedSlot.item != null && Skill != null)
+                    selectedSlotIsLog = Skill.GetDefinitionForItem(selectedSlot.item.id) != null;
+            }
 
             var cookableResult = CookingInventoryHelper.FindCookableRecipe(inventory, cookingSkill, selectedIndex);
             bool selectedSlotCookable = cookableResult.HasRecipe && cookableResult.UsesPreferredSlot;
 
-            if (cookableResult.CanCook)
-            {
-                int queuedLogSlot = ResolvePendingLogSlot(selectedIndex);
-                QueuePendingBonfire(node, queuedLogSlot);
-                return false;
-            }
-
             if (selectedSlotCookable)
             {
                 ClearPendingBonfire();
+                return false;
+            }
+
+            int resolvedLogSlot = selectedSlotIsLog ? selectedIndex : -1;
+
+            if (cookableResult.CanCook && !selectedSlotIsLog)
+            {
+                if (!hasManualSelection)
+                {
+                    // Legacy behaviour: clicking the bonfire without selecting an item should cook
+                    // first and only queue log fueling once fish stop cooking.
+                    if (resolvedLogSlot < 0)
+                        resolvedLogSlot = ResolvePendingLogSlot(selectedIndex);
+                    QueuePendingBonfire(node, resolvedLogSlot);
+                }
+                else
+                {
+                    // Manual selections that are not logs should avoid queuing logs so cooking can
+                    // process the item without unexpected fueling afterwards.
+                    ClearPendingBonfire();
+                }
+
                 return false;
             }
 
@@ -209,9 +235,10 @@ namespace Skills.Firemaking
             if (TryGetCombinedBonfireCookingFailure(node, cookableResult, out failureMessage))
                 return false;
 
-            int logSlot = selectedIndex;
-            if (logSlot < 0)
-                logSlot = ResolvePendingLogSlot(-1);
+            if (resolvedLogSlot < 0)
+                resolvedLogSlot = ResolvePendingLogSlot(selectedIndex);
+
+            int logSlot = resolvedLogSlot;
 
             if (logSlot < 0)
             {


### PR DESCRIPTION
## Summary
- ensure the bonfire controller prioritises manual log selections, only queues logs for legacy bonfire-first clicks, and clears queues when a cookable is highlighted
- prevent the cooking controller from starting when a firemaking log is selected so the firemaking interaction can consume the input

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d51d377a24832eba6d7bda807c6118