### PR TITLE
Prevent cooking while bonfire fueling

### DIFF
--- a/Assets/Scripts/Skills/Cooking/Core/CookingController.cs
+++ b/Assets/Scripts/Skills/Cooking/Core/CookingController.cs
@@ -139,6 +139,20 @@ namespace Skills.Cooking
                 return false;
             }
 
+            if (firemakingSkill == null)
+                firemakingSkill = GetComponent<FiremakingSkill>();
+
+            if (firemakingSkill != null && firemakingSkill.IsFeedingBonfire &&
+                node.TryGetComponent<FiremakingBonfireObject>(out var bonfire) &&
+                firemakingSkill.ActiveBonfire == bonfire)
+            {
+                // When Firemaking is actively fueling this exact bonfire we avoid interrupting the
+                // workflow so the Firemaking controller can continue consuming queued logs.
+                failureMessage = string.Empty;
+                cachedFailureMessage = string.Empty;
+                return false;
+            }
+
             var searchResult = CookingInventoryHelper.FindCookableRecipe(inventory, CookingSkill, inventory.selectedIndex);
 
             if (inventory != null && firemakingSkill != null && inventory.selectedIndex >= 0)


### PR DESCRIPTION
## Summary
- ensure the cooking controller does not interrupt firemaking when the bonfire is actively being fueled
- keep cooking failure messaging silent so log feeding can continue uninterrupted on combined bonfire stations

## Testing
- not run (playtest required in Unity editor)


------
https://chatgpt.com/codex/tasks/task_e_68d5230d2604832eb52b5b6ff60abba3