### PR TITLE
Adjust NPC damage flash default color

### DIFF
--- a/Assets/Scripts/NPC/Combat/NpcDamageFlash.cs
+++ b/Assets/Scripts/NPC/Combat/NpcDamageFlash.cs
@@ -14,7 +14,7 @@ namespace NPC
     {
         [Header("Flash Settings")]
         [SerializeField, Tooltip("Tint applied to the sprite while the damage flash is playing.")]
-        private Color flashColor = Color.white;
+        private Color flashColor = new Color(1f, 0.35f, 0.35f, 1f);
 
         [SerializeField, Tooltip("Duration of the flash animation in seconds.")]
         private float flashDuration = 0.1f;


### PR DESCRIPTION
## Summary
- update the default flash color in `NpcDamageFlash` to a high-contrast red tint so white-tinted sprites still visibly flash when damaged

## Testing
- not run (editor validation required)


------
https://chatgpt.com/codex/tasks/task_e_68d65d776684832eb8fa0a688c880d3f