### PR TITLE
Align floating text in LateUpdate

### DIFF
--- a/Assets/Scripts/UI/FloatingText.cs
+++ b/Assets/Scripts/UI/FloatingText.cs
@@ -17,6 +17,7 @@ namespace UI
         private Vector3 worldPosition;
         private Camera mainCamera;
         private float remainingLifetime;
+        private bool needsInitialSnap = true;
 
         /// <summary>
         ///     Backing field for <see cref="DebugLogMessages"/> so the toggle persists between spawn calls.
@@ -72,6 +73,7 @@ namespace UI
             float finalSize = size ?? instance.textSize;
             instance.uiText.fontSize = Mathf.RoundToInt(64 * finalSize);
             instance.remainingLifetime = instance.lifetime;
+            instance.needsInitialSnap = true;
 
             if (debugLogMessages)
             {
@@ -85,13 +87,25 @@ namespace UI
             remainingLifetime = lifetime;
         }
 
-        private void Update()
+        private void LateUpdate()
         {
-            worldPosition += floatSpeed * Time.deltaTime;
+            // Ensure we always have the latest camera reference in case the active camera changed mid-session.
             if (mainCamera == null)
                 mainCamera = Camera.main;
-            if (rectTransform != null && mainCamera != null)
+
+            if (rectTransform == null || mainCamera == null)
+                return;
+
+            // Reapply the first projection in LateUpdate so the spawn frame respects any camera movement that
+            // occurred after the popup was created earlier in the frame.
+            if (needsInitialSnap)
+            {
                 rectTransform.position = mainCamera.WorldToScreenPoint(worldPosition);
+                needsInitialSnap = false;
+            }
+
+            worldPosition += floatSpeed * Time.deltaTime;
+            rectTransform.position = mainCamera.WorldToScreenPoint(worldPosition);
 
             remainingLifetime -= Time.deltaTime;
             if (remainingLifetime <= 0f)


### PR DESCRIPTION
## Summary
- move floating text reprojection into LateUpdate so canvas alignment follows camera motion
- reapply the initial screen-space projection after the camera updates while keeping lifetime countdown in the same loop

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d67fe64184832e91d4edfc5fca4da8