### PR TITLE
Add floating hitsplat anchor resolution utility

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -87,10 +87,14 @@ namespace Combat
         [SerializeField, Tooltip("Centralised hitsplat sprite references assigned via the inspector.")]
         private HitSplatLibrary hitSplatLibrary;
 
+        [SerializeField, Tooltip("Vertical offset used when no dedicated floating text anchor is found.")]
+        private float hitsplatFallbackOffset = 1.1f;
+
         private Sprite damageHitsplat;
         private Sprite zeroHitsplat;
         private Sprite maxHitHitsplat;
         private IReadOnlyDictionary<SpellElement, Sprite> elementHitsplats;
+        private readonly Dictionary<Transform, FloatingTextAnchorUtility.AnchorCache> hitsplatAnchorCache = new Dictionary<Transform, FloatingTextAnchorUtility.AnchorCache>();
 
         private void Awake()
         {
@@ -439,22 +443,23 @@ namespace Combat
                 finalDamage = target.ApplyDamage(damage, type, element, source);
                 Sprite sprite;
                 Color textColor = Color.white;
+                Vector3 hitsplatPosition = FloatingTextAnchorUtility.ResolveAnchorPosition(target.transform, hitsplatFallbackOffset, hitsplatAnchorCache);
                 if (finalDamage == 0)
                 {
                     sprite = zeroHitsplat;
-                    FloatingText.Show("0", target.transform.position, textColor, null, sprite);
+                    FloatingText.Show("0", hitsplatPosition, textColor, null, sprite);
                 }
                 else if (type == DamageType.Magic && elementHitsplats != null && elementHitsplats.TryGetValue(element, out var elemSprite) && elemSprite != null)
                 {
                     sprite = elemSprite;
                     if (element == SpellElement.Air)
                         textColor = Color.black;
-                    FloatingText.Show(finalDamage.ToString(), target.transform.position, textColor, null, sprite);
+                    FloatingText.Show(finalDamage.ToString(), hitsplatPosition, textColor, null, sprite);
                 }
                 else
                 {
                     sprite = finalDamage == maxHit ? maxHitHitsplat : damageHitsplat;
-                    FloatingText.Show(finalDamage.ToString(), target.transform.position, textColor, null, sprite);
+                    FloatingText.Show(finalDamage.ToString(), hitsplatPosition, textColor, null, sprite);
                 }
                 AwardXp(finalDamage, style, type);
                 if (finalDamage > 0 && !target.IsAlive)
@@ -467,7 +472,8 @@ namespace Combat
             }
             else
             {
-                FloatingText.Show("0", target.transform.position, Color.white, null, zeroHitsplat);
+                Vector3 hitsplatPosition = FloatingTextAnchorUtility.ResolveAnchorPosition(target.transform, hitsplatFallbackOffset, hitsplatAnchorCache);
+                FloatingText.Show("0", hitsplatPosition, Color.white, null, zeroHitsplat);
                 Debug.Log($"Player missed {targetName}.");
                 OnAttackLanded?.Invoke(0, false);
             }

--- a/Assets/Scripts/NPC/Combat/NpcCombatant.cs
+++ b/Assets/Scripts/NPC/Combat/NpcCombatant.cs
@@ -19,6 +19,9 @@ namespace NPC
         [SerializeField, Tooltip("Centralised hitsplat sprite references assigned via the inspector.")]
         private HitSplatLibrary hitSplatLibrary;
 
+        [SerializeField, Tooltip("Vertical offset applied when no floating text anchor is present.")]
+        private float hitsplatFallbackOffset = 1f;
+
         /// <summary>
         /// Shared cached reference so NPCs can automatically use the global hitsplat
         /// library without paying the cost of repeated Resources lookups.
@@ -32,6 +35,7 @@ namespace NPC
         private int playerDamage;
         private int npcDamage;
         private Sprite poisonHitsplat;
+        private FloatingTextAnchorUtility.AnchorCache hitsplatAnchorCache;
 
         public event System.Action<int, int> OnHealthChanged; // current, max
         public event System.Action OnDeath;
@@ -113,7 +117,10 @@ namespace NPC
             }
             OnHealthChanged?.Invoke(currentHp, MaxHP);
             if (type == DamageType.Poison && poisonHitsplat != null)
-                FloatingText.Show(finalAmount.ToString(), transform.position, Color.white, null, poisonHitsplat);
+            {
+                Vector3 hitsplatPosition = FloatingTextAnchorUtility.ResolveAnchorPosition(transform, hitsplatFallbackOffset, ref hitsplatAnchorCache);
+                FloatingText.Show(finalAmount.ToString(), hitsplatPosition, Color.white, null, poisonHitsplat);
+            }
             var combatSource = source as CombatTarget;
             bool creditedToPlayer = false;
             if (combatSource != null)

--- a/Assets/Scripts/Pets/PetCombatController.cs
+++ b/Assets/Scripts/Pets/PetCombatController.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 using Combat;
 using EquipmentSystem;
@@ -21,6 +22,9 @@ namespace Pets
         [SerializeField, Tooltip("Centralised hitsplat sprite references assigned via the inspector.")]
         private HitSplatLibrary hitSplatLibrary;
 
+        [SerializeField, Tooltip("Vertical offset for hitsplats when no floating text anchor exists.")]
+        private float hitsplatFallbackOffset = 1f;
+
         /// <summary>
         /// Shared cache so pets reuse a single hitsplat library loaded from the Resources
         /// folder whenever no explicit reference has been assigned in the inspector.
@@ -39,6 +43,7 @@ namespace Pets
         private Sprite damageHitsplat;
         private Sprite zeroHitsplat;
         private Sprite maxHitHitsplat;
+        private readonly Dictionary<Transform, FloatingTextAnchorUtility.AnchorCache> hitsplatAnchorCache = new Dictionary<Transform, FloatingTextAnchorUtility.AnchorCache>();
 
         public bool IsAlive => true;
         public DamageType PreferredDefenceType => DamageType.Melee;
@@ -236,7 +241,8 @@ namespace Pets
                     source = ownerTarget;
                 int finalDamage = target.ApplyDamage(dmg, attacker.DamageType, SpellElement.None, source);
                 var sprite = finalDamage == maxHit ? maxHitHitsplat : damageHitsplat;
-                FloatingText.Show(finalDamage.ToString(), target.transform.position, Color.white, null, sprite);
+                Vector3 hitsplatPosition = FloatingTextAnchorUtility.ResolveAnchorPosition(target.transform, hitsplatFallbackOffset, hitsplatAnchorCache);
+                FloatingText.Show(finalDamage.ToString(), hitsplatPosition, Color.white, null, sprite);
                 if (npc != null)
                 {
                     var npcAttack = npc.GetComponent<NpcAttackController>();
@@ -246,7 +252,8 @@ namespace Pets
             }
             else
             {
-                FloatingText.Show("0", target.transform.position, Color.white, null, zeroHitsplat);
+                Vector3 hitsplatPosition = FloatingTextAnchorUtility.ResolveAnchorPosition(target.transform, hitsplatFallbackOffset, hitsplatAnchorCache);
+                FloatingText.Show("0", hitsplatPosition, Color.white, null, zeroHitsplat);
             }
         }
 

--- a/Assets/Scripts/Player/PlayerCombatTarget.cs
+++ b/Assets/Scripts/Player/PlayerCombatTarget.cs
@@ -18,6 +18,9 @@ namespace Player
         [SerializeField, Tooltip("Centralised hitsplat sprite references assigned via the inspector.")]
         private HitSplatLibrary hitSplatLibrary;
 
+        [SerializeField, Tooltip("Vertical offset applied when spawning hitsplats without an explicit anchor.")]
+        private float hitsplatFallbackOffset = 1.1f;
+
         private PlayerHitpoints hitpoints;
         private Sprite damageHitsplat;
         private Sprite zeroHitsplat;
@@ -25,6 +28,7 @@ namespace Player
         private Sprite poisonHitsplat;
         private IReadOnlyDictionary<SpellElement, Sprite> elementHitsplats;
         private AntifireProtectionController antifireProtection;
+        private FloatingTextAnchorUtility.AnchorCache hitsplatAnchorCache;
 
         private void Awake()
         {
@@ -92,7 +96,8 @@ namespace Player
             }
             else
                 sprite = damageHitsplat;
-            FloatingText.Show(mitigatedAmount.ToString(), transform.position, textColor, null, sprite);
+            Vector3 hitsplatPosition = FloatingTextAnchorUtility.ResolveAnchorPosition(transform, hitsplatFallbackOffset, ref hitsplatAnchorCache);
+            FloatingText.Show(mitigatedAmount.ToString(), hitsplatPosition, textColor, null, sprite);
 
             if (mitigatedAmount != amount)
                 Debug.Log($"Player took {mitigatedAmount} damage ({amount} before antifire mitigation).");

--- a/Assets/Scripts/UI/FloatingTextAnchorUtility.cs
+++ b/Assets/Scripts/UI/FloatingTextAnchorUtility.cs
@@ -1,0 +1,164 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace UI
+{
+    /// <summary>
+    /// Utility helpers that resolve the ideal world position for floating combat text. The
+    /// resolution order mirrors OSRS behaviour: prefer a dedicated <c>FloatingTextAnchor</c>,
+    /// fall back to sprite or collider bounds, then finally apply a configurable upward
+    /// offset to the root transform.
+    /// </summary>
+    public static class FloatingTextAnchorUtility
+    {
+        /// <summary>
+        /// Cached data used to avoid repeated hierarchy scans for floating text anchors.
+        /// </summary>
+        public struct AnchorCache
+        {
+            internal Transform anchor;
+            internal bool hasAttemptedSearch;
+            internal int anchorInstanceId;
+
+            /// <summary>Invalidate any cached anchor data so a fresh lookup occurs.</summary>
+            public void Invalidate()
+            {
+                anchor = null;
+                hasAttemptedSearch = false;
+                anchorInstanceId = 0;
+            }
+        }
+
+        private const string AnchorName = "FloatingTextAnchor";
+
+        /// <summary>
+        /// Resolve the best floating text position, maintaining cache state for the supplied
+        /// transform so future calls reuse the same anchor when possible.
+        /// </summary>
+        /// <param name="root">The transform that owns the combat target.</param>
+        /// <param name="fallbackOffset">
+        /// Upward offset applied when no anchor, sprite, or collider bounds are available.
+        /// </param>
+        /// <param name="cache">Mutable cache state tied to the target transform.</param>
+        /// <returns>The world position where the hitsplat should appear.</returns>
+        public static Vector3 ResolveAnchorPosition(Transform root, float fallbackOffset, ref AnchorCache cache)
+        {
+            if (root == null)
+                return Vector3.zero;
+
+            // When the cached anchor is valid we can skip the more expensive hierarchy search.
+            if (cache.anchor != null)
+            {
+                if (cache.anchor)
+                    return cache.anchor.position;
+
+                // The previously cached anchor has been destroyed. Clear cached data so we
+                // perform a fresh lookup and avoid stale references.
+                cache.Invalidate();
+            }
+            else if (cache.anchorInstanceId != 0)
+            {
+                // Unity null comparison can become true when a cached anchor is destroyed, but
+                // we still want to attempt a fresh lookup in case a replacement exists.
+                cache.Invalidate();
+            }
+
+            if (!cache.hasAttemptedSearch)
+            {
+                cache.anchor = FindFloatingTextAnchor(root);
+                cache.hasAttemptedSearch = true;
+                cache.anchorInstanceId = cache.anchor != null ? cache.anchor.GetInstanceID() : 0;
+                if (cache.anchor != null)
+                    return cache.anchor.position;
+            }
+
+            if (TryGetSpriteBounds(root, out var spriteBounds))
+                return spriteBounds.center + Vector3.up * spriteBounds.extents.y;
+
+            if (TryGetColliderBounds(root, out var colliderBounds))
+                return colliderBounds.center + Vector3.up * colliderBounds.extents.y;
+
+            return root.position + Vector3.up * fallbackOffset;
+        }
+
+        /// <summary>
+        /// Resolve the best floating text position while storing cache state inside the
+        /// provided dictionary. This variant is convenient for systems that track many
+        /// concurrent targets, such as the player or pets attacking multiple enemies.
+        /// </summary>
+        /// <param name="root">The transform that owns the combat target.</param>
+        /// <param name="fallbackOffset">
+        /// Upward offset applied when no anchor, sprite, or collider bounds are available.
+        /// </param>
+        /// <param name="cache">
+        /// Dictionary keyed by the target transform that stores anchor cache data.
+        /// </param>
+        /// <returns>The world position where the hitsplat should appear.</returns>
+        public static Vector3 ResolveAnchorPosition(Transform root, float fallbackOffset, IDictionary<Transform, AnchorCache> cache)
+        {
+            if (root == null)
+                return Vector3.zero;
+
+            if (cache == null)
+            {
+                var tempCache = default(AnchorCache);
+                return ResolveAnchorPosition(root, fallbackOffset, ref tempCache);
+            }
+
+            if (!cache.TryGetValue(root, out var anchorCache))
+                anchorCache = default;
+
+            var position = ResolveAnchorPosition(root, fallbackOffset, ref anchorCache);
+            cache[root] = anchorCache;
+            return position;
+        }
+
+        /// <summary>Search the hierarchy for a child named <c>FloatingTextAnchor</c>.</summary>
+        private static Transform FindFloatingTextAnchor(Transform root)
+        {
+            var transforms = root.GetComponentsInChildren<Transform>(true);
+            for (int i = 0; i < transforms.Length; i++)
+            {
+                var child = transforms[i];
+                if (child != null && child != root && child.name == AnchorName)
+                    return child;
+            }
+            return null;
+        }
+
+        /// <summary>Attempt to pull sprite renderer bounds from the target hierarchy.</summary>
+        private static bool TryGetSpriteBounds(Transform root, out Bounds bounds)
+        {
+            var renderer = root.GetComponentInChildren<SpriteRenderer>();
+            if (renderer != null)
+            {
+                bounds = renderer.bounds;
+                return true;
+            }
+
+            bounds = default;
+            return false;
+        }
+
+        /// <summary>Attempt to pull collider bounds from the target hierarchy.</summary>
+        private static bool TryGetColliderBounds(Transform root, out Bounds bounds)
+        {
+            var collider2D = root.GetComponentInChildren<Collider2D>();
+            if (collider2D != null)
+            {
+                bounds = collider2D.bounds;
+                return true;
+            }
+
+            var collider3D = root.GetComponentInChildren<Collider>();
+            if (collider3D != null)
+            {
+                bounds = collider3D.bounds;
+                return true;
+            }
+
+            bounds = default;
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `FloatingTextAnchorUtility` to centralise floating text anchor discovery with sprite/collider fallbacks
- update combat-related controllers to use the shared helper, cache anchor lookups, and expose tweakable fallback offsets

## Testing
- not run (Unity editor required)


------
https://chatgpt.com/codex/tasks/task_e_68d6854f50c0832e851e16e383ec1df3