### PR TITLE
Cache active NPC combatants for faction targeting

### DIFF
--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -152,9 +152,13 @@ namespace NPC
             var myFaction = combatant as IFactionProvider;
             if (myFaction != null)
             {
-                foreach (var npc in FindObjectsOfType<NpcCombatant>())
+                var activeCombatants = NpcCombatant.ActiveCombatants;
+                for (int i = 0; i < activeCombatants.Count; i++)
                 {
-                    if (npc == combatant || !npc.IsAlive)
+                    var npc = activeCombatants[i];
+                    if (npc == null || npc == combatant)
+                        continue;
+                    if (!npc.isActiveAndEnabled || !npc.IsAlive)
                         continue;
                     var otherFaction = npc as IFactionProvider;
                     if (otherFaction == null || !myFaction.IsEnemy(otherFaction.Faction))

--- a/Assets/Scripts/NPC/Combat/NpcCombatant.cs
+++ b/Assets/Scripts/NPC/Combat/NpcCombatant.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 using Combat;
 using MyGame.Drops;
@@ -15,6 +16,19 @@ namespace NPC
     [DisallowMultipleComponent, RequireComponent(typeof(NpcDropper)), RequireComponent(typeof(FrozenStatusController))]
     public class NpcCombatant : MonoBehaviour, CombatTarget, IFactionProvider
     {
+        /// <summary>
+        /// Global cache of NPC combatants that are currently active in the scene. This allows
+        /// other systems to iterate nearby NPCs without paying the cost of repeated
+        /// <see cref="Object.FindObjectsOfType{T}()"/> calls each frame.
+        /// </summary>
+        private static readonly List<NpcCombatant> activeCombatants = new();
+
+        /// <summary>
+        /// Read-only view of the currently active NPC combatants. Consumers should treat the
+        /// collection as volatile; items may be removed if NPCs are disabled or destroyed.
+        /// </summary>
+        public static IReadOnlyList<NpcCombatant> ActiveCombatants => activeCombatants;
+
         [SerializeField] private NpcCombatProfile profile;
         [SerializeField, Tooltip("Centralised hitsplat sprite references assigned via the inspector.")]
         private HitSplatLibrary hitSplatLibrary;
@@ -36,6 +50,7 @@ namespace NPC
         private int npcDamage;
         private Sprite poisonHitsplat;
         private FloatingTextAnchorUtility.AnchorCache hitsplatAnchorCache;
+        private bool isRegisteredWithRegistry;
 
         public event System.Action<int, int> OnHealthChanged; // current, max
         public event System.Action OnDeath;
@@ -89,6 +104,23 @@ namespace NPC
                 applier.applyChance = profile.PoisonChance;
                 applier.requiresDamage = profile.PoisonRequiresDamage;
             }
+        }
+
+        private void OnEnable()
+        {
+            RegisterCombatant();
+        }
+
+        private void OnDisable()
+        {
+            UnregisterCombatant();
+        }
+
+        private void OnDestroy()
+        {
+            // OnDisable is invoked before OnDestroy, but we defensively unregister in case
+            // destruction occurs while the component is disabled.
+            UnregisterCombatant();
         }
 
         /// <summary>Apply damage to this NPC.</summary>
@@ -227,6 +259,30 @@ namespace NPC
 
             if (sharedHitSplatLibrary != null)
                 hitSplatLibrary = sharedHitSplatLibrary;
+        }
+
+        /// <summary>
+        /// Adds this combatant to the global registry if it is not already present.
+        /// </summary>
+        private void RegisterCombatant()
+        {
+            if (isRegisteredWithRegistry)
+                return;
+
+            activeCombatants.Add(this);
+            isRegisteredWithRegistry = true;
+        }
+
+        /// <summary>
+        /// Removes this combatant from the global registry if it is currently registered.
+        /// </summary>
+        private void UnregisterCombatant()
+        {
+            if (!isRegisteredWithRegistry)
+                return;
+
+            activeCombatants.Remove(this);
+            isRegisteredWithRegistry = false;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a lightweight registry on `NpcCombatant` to track active NPCs
- query the cached combatant list in `BaseNpcCombat` instead of `FindObjectsOfType`
- guard registry cleanup on disable/destroy so stale NPC references are removed

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6b6bc8034832e8d630297ae7c8f42