### PR TITLE
Track poison source for proper damage attribution

### DIFF
--- a/Assets/Editor/PoisonDebugMenu.cs
+++ b/Assets/Editor/PoisonDebugMenu.cs
@@ -42,7 +42,7 @@ public static class PoisonDebugMenu
             controller = go.AddComponent<PoisonController>();
         var cfg = Resources.Load<PoisonConfig>($"Status/Poison/{id}");
         if (cfg != null)
-            controller.ApplyPoison(cfg);
+            controller.ApplyPoison(cfg, null);
         Debug.Log($"Applied {id} at {Time.time}");
     }
 

--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -467,7 +467,7 @@ namespace Combat
                 Debug.Log($"Player dealt {finalDamage} damage to {targetName}.");
                 var applier = GetComponentInChildren<OnHitPoisonApplier>();
                 if (applier != null && targetMb != null)
-                    applier.TryApply(targetMb.gameObject, finalDamage > 0);
+                    applier.TryApply(targetMb.gameObject, finalDamage > 0, source);
                 OnAttackLanded?.Invoke(finalDamage, hit);
             }
             else

--- a/Assets/Scripts/Combat/OnHitPoisonApplier.cs
+++ b/Assets/Scripts/Combat/OnHitPoisonApplier.cs
@@ -22,7 +22,8 @@ namespace Combat
         /// </summary>
         /// <param name="target">Target game object.</param>
         /// <param name="didDealDamage">Whether the hit dealt damage.</param>
-        public void TryApply(GameObject target, bool didDealDamage)
+        /// <param name="applier">Combatant attempting to apply the poison.</param>
+        public void TryApply(GameObject target, bool didDealDamage, CombatTarget applier)
         {
             if (poison == null || target == null)
                 return;
@@ -32,7 +33,7 @@ namespace Combat
                 return;
             var controller = target.GetComponent<PoisonController>();
             if (controller != null && !controller.IsImmune)
-                controller.ApplyPoison(poison);
+                controller.ApplyPoison(poison, applier);
         }
     }
 }

--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -408,7 +408,7 @@ namespace NPC
                 var applier = GetComponentInChildren<OnHitPoisonApplier>();
                 var targetMb = target as MonoBehaviour;
                 if (applier != null && targetMb != null)
-                    applier.TryApply(targetMb.gameObject, finalDamage > 0);
+                    applier.TryApply(targetMb.gameObject, finalDamage > 0, combatant);
             }
             else
             {

--- a/Assets/Scripts/Skills/AdminF2Menu.cs
+++ b/Assets/Scripts/Skills/AdminF2Menu.cs
@@ -570,7 +570,7 @@ namespace Skills
                 }
             }
 
-            controller.ApplyPoison(poisonPConfig);
+            controller.ApplyPoison(poisonPConfig, null);
         }
 
         /// <summary>

--- a/Assets/Scripts/Status/BuffStateSaveBridge.cs
+++ b/Assets/Scripts/Status/BuffStateSaveBridge.cs
@@ -519,7 +519,7 @@ namespace Status
             }
 
             controller.ImmunityTimer = 0f;
-            controller.ApplyPoison(config);
+            controller.ApplyPoison(config, null);
 
             var effect = controller.ActiveEffect;
             bool effectRestored = false;

--- a/Assets/Scripts/Status/Poison/PoisonController.cs
+++ b/Assets/Scripts/Status/Poison/PoisonController.cs
@@ -22,6 +22,8 @@ namespace Status.Poison
         private int ticksUntilNextDamage;
         private int intervalTicks;
         private bool tickerSubscribed;
+        // Tracks the last combatant who applied poison so delayed ticks attribute damage correctly.
+        private CombatTarget lastPoisonSource;
         // Cached timer definition so removal payloads mirror the most recent HUD entry.
         private BuffTimerDefinition lastPoisonDefinition;
         private bool hasLastPoisonDefinition;
@@ -84,13 +86,17 @@ namespace Status.Poison
         /// <summary>
         /// Apply a poison configuration to this entity, refreshing if already poisoned.
         /// </summary>
-        public void ApplyPoison(PoisonConfig cfg)
+        /// <param name="cfg">Configuration describing the poison.</param>
+        /// <param name="source">Combatant responsible for applying the poison.</param>
+        public void ApplyPoison(PoisonConfig cfg, CombatTarget source)
         {
             ResolveStatsComponent();
             if (IsImmune || cfg == null)
                 return;
             if (stats != null && !stats.IsAlive)
                 return;
+            // Cache the attacker so poison ticks are attributed to the correct combatant.
+            lastPoisonSource = source;
             if (active == null)
             {
                 active = new PoisonEffect(cfg);
@@ -118,6 +124,7 @@ namespace Status.Poison
             UnsubscribeFromTicker();
             immunityTimer = Mathf.Max(immunityTimer, immunitySeconds);
             hasPendingBuffTimer = false;
+            lastPoisonSource = null;
         }
 
         /// <summary>
@@ -212,6 +219,7 @@ namespace Status.Poison
             intervalTicks = 0;
             UnsubscribeFromTicker();
             hasPendingBuffTimer = false;
+            lastPoisonSource = null;
         }
 
         /// <summary>
@@ -219,7 +227,8 @@ namespace Status.Poison
         /// </summary>
         private bool DealTrueDamageBridge(int amount)
         {
-            stats?.ApplyDamage(amount, DamageType.Poison, SpellElement.None, this);
+            var damageSource = (object)lastPoisonSource ?? this;
+            stats?.ApplyDamage(amount, DamageType.Poison, SpellElement.None, damageSource);
             return true;
         }
 
@@ -238,6 +247,7 @@ namespace Status.Poison
             NotifyBuffRemoved(cfg);
             OnPoisonEnd?.Invoke();
             active = null;
+            lastPoisonSource = null;
         }
 
         /// <summary>

--- a/Assets/Scripts/Status/Poison/PoisonSaveBridge.cs
+++ b/Assets/Scripts/Status/Poison/PoisonSaveBridge.cs
@@ -329,7 +329,7 @@ namespace Status.Poison
             {
                 float savedImmune = controller.ImmunityTimer;
                 controller.ImmunityTimer = 0f;
-                controller.ApplyPoison(config);
+                controller.ApplyPoison(config, null);
 
                 var effect = controller.ActiveEffect;
                 if (effect != null && effect.IsActive)


### PR DESCRIPTION
## Summary
- cache the combatant that applies poison so ticks are credited to the correct attacker
- pass the attacker CombatTarget through poison application sites and update save/debug utilities for the new signature

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6d67d892c832e93643b5968bb3537