### PR TITLE
Integrate NPC damage logging with admin menu

### DIFF
--- a/Assets/Scripts/NPC/Combat/NpcCombatant.cs
+++ b/Assets/Scripts/NPC/Combat/NpcCombatant.cs
@@ -30,6 +30,8 @@ namespace NPC
         public static IReadOnlyList<NpcCombatant> ActiveCombatants => activeCombatants;
 
         [SerializeField] private NpcCombatProfile profile;
+        [SerializeField, Tooltip("When enabled this NPC will emit detailed damage logs to the console for debugging.")]
+        private bool logDamage = false;
         [SerializeField, Tooltip("Centralised hitsplat sprite references assigned via the inspector.")]
         private HitSplatLibrary hitSplatLibrary;
 
@@ -60,6 +62,16 @@ namespace NPC
         public int CurrentHP => currentHp;
         public int MaxHP => profile != null ? profile.HitpointsLevel : currentHp;
         public NpcCombatProfile Profile => profile;
+
+        /// <summary>
+        /// When true this NPC will emit verbose console logging whenever damage is applied.
+        /// Exposed so the AdminF2Menu can toggle the behaviour at runtime for QA.
+        /// </summary>
+        public bool LogDamage
+        {
+            get => logDamage;
+            set => logDamage = value;
+        }
 
         /// <summary>Returns true when this NPC can be affected by the frozen status effect.</summary>
         public bool IsFreezable => profile == null || !profile.NotFreezable;
@@ -142,7 +154,10 @@ namespace NPC
                 }
             }
             currentHp = Mathf.Max(0, currentHp - finalAmount);
-            Debug.Log($"{name} took {finalAmount} damage ({currentHp}/{MaxHP}).");
+            if (logDamage)
+            {
+                Debug.Log($"{name} took {finalAmount} damage ({currentHp}/{MaxHP}).", this);
+            }
             if (finalAmount > 0)
             {
                 flashEffect?.TriggerFlash(finalAmount, MaxHP);

--- a/Assets/Scripts/Skills/AdminF2Menu.cs
+++ b/Assets/Scripts/Skills/AdminF2Menu.cs
@@ -4,6 +4,7 @@ using UnityEngine.SceneManagement;
 using Player;
 using Beastmaster;
 using Pets;
+using NPC;
 using BankSystem;
 using Skills.Cooking;
 using Skills.Fishing;
@@ -368,6 +369,8 @@ namespace Skills
                 () => firemakingSkillBehaviour.EnableDebugLogging,
                 value => firemakingSkillBehaviour.EnableDebugLogging = value);
 
+            DrawNpcDamageLoggingControls();
+
             // Allow QA to mirror floating text popups in the console for firemaking/cooking debugging.
             bool echoFloatingText = FloatingText.DebugLogMessages;
             bool requestedEchoFloatingText = GUILayout.Toggle(echoFloatingText, "Echo Floating Text to Console");
@@ -546,6 +549,57 @@ namespace Skills
                 setValue(updated);
 
             GUI.enabled = previousEnabled;
+        }
+
+        /// <summary>
+        /// Draws Admin menu controls that allow QA to toggle NPC combat damage logging at runtime.
+        /// </summary>
+        private void DrawNpcDamageLoggingControls()
+        {
+            GUILayout.Space(10f);
+            GUILayout.Label("NPC Debug");
+
+            var combatants = NpcCombatant.ActiveCombatants;
+            bool anyCombatants = false;
+
+            for (int i = 0; i < combatants.Count; i++)
+            {
+                var combatant = combatants[i];
+                if (combatant == null)
+                    continue;
+
+                anyCombatants = true;
+
+                bool current = combatant.LogDamage;
+                bool updated = GUILayout.Toggle(current, $"{combatant.name} Damage Logs");
+
+                if (updated != current)
+                    combatant.LogDamage = updated;
+            }
+
+            if (!anyCombatants)
+            {
+                GUILayout.Label("No NPC combatants active.");
+                return;
+            }
+
+            if (GUILayout.Button("Enable Damage Logs for All NPCs"))
+            {
+                foreach (var combatant in combatants)
+                {
+                    if (combatant != null)
+                        combatant.LogDamage = true;
+                }
+            }
+
+            if (GUILayout.Button("Disable Damage Logs for All NPCs"))
+            {
+                foreach (var combatant in combatants)
+                {
+                    if (combatant != null)
+                        combatant.LogDamage = false;
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- expose a runtime `LogDamage` property on `NpcCombatant` so debug tooling can flip verbose damage logs
- extend the Admin F2 menu with NPC damage logging toggles, including enable/disable all controls

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6db006380832e84f6565b1b1bca3a