### PR TITLE
Align poison tick interval fallback

### DIFF
--- a/Assets/Scripts/Status/Poison/PoisonController.cs
+++ b/Assets/Scripts/Status/Poison/PoisonController.cs
@@ -13,8 +13,6 @@ namespace Status.Poison
         [Tooltip("Stats component implementing CombatTarget for this entity.")]
         [SerializeField] private MonoBehaviour statsComponent;
 
-        private const float DefaultPoisonInterval = 15f;
-
         private CombatTarget stats;
         private CombatController combat;
         private PoisonEffect active;
@@ -161,7 +159,9 @@ namespace Status.Poison
 
             if (lifetimeSeconds > 0f && cfg.decayAmountPerStep > 0 && cfg.hitsPerDecayStep > 0)
             {
-                float intervalSeconds = cfg.tickIntervalSeconds > 0f ? cfg.tickIntervalSeconds : DefaultPoisonInterval;
+                float intervalSeconds = cfg.tickIntervalSeconds > 0f
+                    ? cfg.tickIntervalSeconds
+                    : PoisonDefaults.DefaultIntervalSeconds;
                 int decayAmount = Mathf.Max(1, cfg.decayAmountPerStep);
                 int hitsPerStep = Mathf.Max(1, cfg.hitsPerDecayStep);
                 // Determine how many full decay steps have completed so we can subtract their elapsed ticks.
@@ -289,7 +289,9 @@ namespace Status.Poison
                 return;
             }
 
-            float intervalSeconds = cfg.tickIntervalSeconds > 0f ? cfg.tickIntervalSeconds : DefaultPoisonInterval;
+            float intervalSeconds = cfg.tickIntervalSeconds > 0f
+                ? cfg.tickIntervalSeconds
+                : PoisonDefaults.DefaultIntervalSeconds;
             intervalTicks = Mathf.Max(1, Mathf.CeilToInt(intervalSeconds / Ticker.TickDuration));
             float clampedTimer = Mathf.Clamp(currentTickTimer, 0f, intervalSeconds);
             float remainingSeconds = Mathf.Max(0f, intervalSeconds - clampedTimer);
@@ -305,7 +307,9 @@ namespace Status.Poison
             if (cfg == null)
                 return 0f;
 
-            float intervalSeconds = cfg.tickIntervalSeconds > 0f ? cfg.tickIntervalSeconds : DefaultPoisonInterval;
+            float intervalSeconds = cfg.tickIntervalSeconds > 0f
+                ? cfg.tickIntervalSeconds
+                : PoisonDefaults.DefaultIntervalSeconds;
             if (cfg.decayAmountPerStep <= 0 || cfg.hitsPerDecayStep <= 0)
                 return 0f;
 

--- a/Assets/Scripts/Status/Poison/PoisonEffect.cs
+++ b/Assets/Scripts/Status/Poison/PoisonEffect.cs
@@ -5,6 +5,15 @@ using Combat;
 namespace Status.Poison
 {
     /// <summary>
+    /// Shared poison utility values so controllers/effects remain synchronised.
+    /// </summary>
+    internal static class PoisonDefaults
+    {
+        /// <summary>Fallback tick interval when a config does not provide one.</summary>
+        public const float DefaultIntervalSeconds = 15f;
+    }
+
+    /// <summary>
     /// Runtime poison state and ticking logic.
     /// </summary>
     public class PoisonEffect
@@ -61,10 +70,13 @@ namespace Status.Poison
         {
             if (!active)
                 return;
+            float intervalSeconds = Config.tickIntervalSeconds > 0f
+                ? Config.tickIntervalSeconds
+                : PoisonDefaults.DefaultIntervalSeconds;
             TickTimer += delta;
-            if (TickTimer >= Config.tickIntervalSeconds)
+            if (TickTimer >= intervalSeconds)
             {
-                TickTimer -= Config.tickIntervalSeconds;
+                TickTimer -= intervalSeconds;
                 dealTrueDamage?.Invoke(CurrentDamage);
                 OnPoisonTick?.Invoke(CurrentDamage);
                 TicksSinceDecay++;


### PR DESCRIPTION
## Summary
- centralize the poison tick interval fallback so controllers and effects share the same constant
- make PoisonEffect tick logic respect the shared fallback when configs omit or disable the interval
- update PoisonController cadence calculations to use the shared interval constant

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6e2445584832ea9c699d95887f619