### PR TITLE
Fix login timestamp persistence during saves

### DIFF
--- a/Assets/Scripts/Core/Save/AccountProfileService.cs
+++ b/Assets/Scripts/Core/Save/AccountProfileService.cs
@@ -206,7 +206,11 @@ namespace Core.Save
             EnsureBaseDirectory();
             EnsureDefaults(save, save.usernameSlug, save.username);
 
-            save.lastLoginUtc = DateTime.UtcNow.ToString("O");
+            if (string.IsNullOrEmpty(save.lastLoginUtc))
+            {
+                // Guard against overwriting the real login timestamp during background saves.
+                save.lastLoginUtc = DateTime.UtcNow.ToString("O");
+            }
 
             string path = GetAccountPath(save.usernameSlug);
             string tempPath = path + ".tmp";

--- a/Assets/Scripts/UI/Login/LoginScreenController.cs
+++ b/Assets/Scripts/UI/Login/LoginScreenController.cs
@@ -194,6 +194,9 @@ namespace UI.Login
             {
                 bool accountExists = AccountManager.TryLoadAccount(username, out AccountSave save);
 
+                // Capture the login moment so the account history reflects the successful authentication.
+                string loginTimestamp = DateTime.UtcNow.ToString("O");
+
                 if (accountExists)
                 {
                     if (!AccountManager.VerifyPassword(save, password))
@@ -210,6 +213,9 @@ namespace UI.Login
                     save = AccountManager.CreateNewAccount(username, password);
                     SetStatus($"Created new account for {save.username}.", successColour);
                 }
+
+                // Persist the login timestamp explicitly rather than letting autosaves advance it.
+                save.lastLoginUtc = loginTimestamp;
 
                 SaveManager.BindAccount(save, reload: true);
                 await AccountManager.SaveAsync(save);


### PR DESCRIPTION
## Summary
- prevent AccountManager.SaveAsync from overwriting lastLoginUtc during autosaves
- stamp the account with the current login time once authentication succeeds

## Testing
- not run (not run)

------
https://chatgpt.com/codex/tasks/task_e_68d7a00b0cc0832e97cc5d38ec398c6f