### PR TITLE
Improve atomic save file writes

### DIFF
--- a/Assets/Scripts/Core/Save/AccountProfileService.cs
+++ b/Assets/Scripts/Core/Save/AccountProfileService.cs
@@ -243,17 +243,48 @@ namespace Core.Save
             {
                 await Task.Run(() =>
                 {
-                    File.WriteAllText(tempPath, json, Encoding.UTF8);
-                    if (File.Exists(path))
+                    // Write the JSON payload to a temp file first so the main save is only
+                    // touched once we know the data reached disk successfully.
+                    using (var tempStream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None))
+                    using (var writer = new StreamWriter(tempStream, Encoding.UTF8))
                     {
-                        File.Replace(tempPath, path, null);
+                        writer.Write(json);
+                        writer.Flush();
+                        tempStream.Flush(true);
                     }
-                    else
+
+                    try
+                    {
+                        // Grab an exclusive handle on the destination file (creating it when
+                        // missing) so any concurrent readers/writers fail fast.
+                        using (var destinationLock = new FileStream(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None))
+                        {
+                            destinationLock.Flush(true);
+                        }
+                    }
+                    catch (Exception lockEx)
+                    {
+                        throw new IOException($"AccountManager: Unable to access save file '{path}' for writing.", lockEx);
+                    }
+
+                    try
                     {
                         if (File.Exists(path))
+                        {
                             File.Delete(path);
+                        }
 
                         File.Move(tempPath, path);
+
+                        // Defensive cleanup in case the platform leaves the temp file behind.
+                        if (File.Exists(tempPath))
+                        {
+                            File.Delete(tempPath);
+                        }
+                    }
+                    catch (Exception swapEx)
+                    {
+                        throw new IOException($"AccountManager: Unable to swap temp save '{tempPath}' into '{path}'.", swapEx);
                     }
                 }).ConfigureAwait(false);
             }

--- a/Assets/Scripts/Core/Save/SaveManager.cs
+++ b/Assets/Scripts/Core/Save/SaveManager.cs
@@ -378,17 +378,44 @@ namespace Core.Save
             {
                 Directory.CreateDirectory(AccountManager.BaseDirectory);
                 string json = JsonUtility.ToJson(globalCache);
-                File.WriteAllText(tempPath, json, Encoding.UTF8);
-                if (File.Exists(GlobalFilePath))
+
+                using (var tempStream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None))
+                using (var writer = new StreamWriter(tempStream, Encoding.UTF8))
                 {
-                    File.Replace(tempPath, GlobalFilePath, null);
+                    writer.Write(json);
+                    writer.Flush();
+                    tempStream.Flush(true);
                 }
-                else
+
+                try
+                {
+                    using (var destinationLock = new FileStream(GlobalFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None))
+                    {
+                        destinationLock.Flush(true);
+                    }
+                }
+                catch (Exception lockEx)
+                {
+                    throw new IOException($"SaveManager: Unable to access global save file '{GlobalFilePath}' for writing.", lockEx);
+                }
+
+                try
                 {
                     if (File.Exists(GlobalFilePath))
+                    {
                         File.Delete(GlobalFilePath);
+                    }
 
                     File.Move(tempPath, GlobalFilePath);
+
+                    if (File.Exists(tempPath))
+                    {
+                        File.Delete(tempPath);
+                    }
+                }
+                catch (Exception swapEx)
+                {
+                    throw new IOException($"SaveManager: Unable to swap temp global save '{tempPath}' into '{GlobalFilePath}'.", swapEx);
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- write account profile saves through a FileStream-backed temp file and swap into place with delete/move for broader platform support
- apply the same portable temp-file swap logic to the global save store and ensure temp cleanup after successful moves

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d81fb70368832eb48c13687bd9c5e0