### PR TITLE
Add backup swap handling to account and global save writes

### DIFF
--- a/Assets/Scripts/Core/Save/AccountProfileService.cs
+++ b/Assets/Scripts/Core/Save/AccountProfileService.cs
@@ -237,12 +237,16 @@ namespace Core.Save
 
             string path = GetAccountPath(save.usernameSlug);
             string tempPath = path + ".tmp";
+            string backupPath = path + ".bak";
             string json = JsonUtility.ToJson(save, true);
 
             try
             {
                 await Task.Run(() =>
                 {
+                    bool backupCreated = false;
+                    bool swapSucceeded = false;
+
                     // Write the JSON payload to a temp file first so the main save is only
                     // touched once we know the data reached disk successfully.
                     using (var tempStream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None))
@@ -255,36 +259,110 @@ namespace Core.Save
 
                     try
                     {
-                        // Grab an exclusive handle on the destination file (creating it when
-                        // missing) so any concurrent readers/writers fail fast.
-                        using (var destinationLock = new FileStream(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None))
-                        {
-                            destinationLock.Flush(true);
-                        }
-                    }
-                    catch (Exception lockEx)
-                    {
-                        throw new IOException($"AccountManager: Unable to access save file '{path}' for writing.", lockEx);
-                    }
-
-                    try
-                    {
                         if (File.Exists(path))
                         {
-                            File.Delete(path);
+                            try
+                            {
+                                // Grab an exclusive handle on the destination file so any
+                                // concurrent access fails fast before we touch the data.
+                                using (var destinationLock = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+                                {
+                                    destinationLock.Flush(true);
+                                }
+                            }
+                            catch (Exception lockEx)
+                            {
+                                throw new IOException($"AccountManager: Unable to access save file '{path}' for writing.", lockEx);
+                            }
+
+                            if (File.Exists(backupPath))
+                            {
+                                try
+                                {
+                                    File.Delete(backupPath);
+                                }
+                                catch (Exception deleteEx)
+                                {
+                                    throw new IOException($"AccountManager: Unable to clear stale backup '{backupPath}' before saving.", deleteEx);
+                                }
+                            }
+
+                            File.Move(path, backupPath);
+                            backupCreated = true;
                         }
 
-                        File.Move(tempPath, path);
-
-                        // Defensive cleanup in case the platform leaves the temp file behind.
-                        if (File.Exists(tempPath))
+                        try
                         {
-                            File.Delete(tempPath);
+                            File.Move(tempPath, path);
+                            swapSucceeded = true;
+                        }
+                        catch (Exception moveEx)
+                        {
+                            throw new IOException($"AccountManager: Unable to swap temp save '{tempPath}' into '{path}'.", moveEx);
+                        }
+
+                        if (backupCreated)
+                        {
+                            try
+                            {
+                                if (File.Exists(backupPath))
+                                {
+                                    File.Delete(backupPath);
+                                }
+                                backupCreated = false;
+                            }
+                            catch (Exception cleanupEx)
+                            {
+                                throw new IOException($"AccountManager: Failed to delete backup save '{backupPath}' after writing '{path}'.", cleanupEx);
+                            }
                         }
                     }
-                    catch (Exception swapEx)
+                    catch (Exception operationEx)
                     {
-                        throw new IOException($"AccountManager: Unable to swap temp save '{tempPath}' into '{path}'.", swapEx);
+                        if (backupCreated && !swapSucceeded)
+                        {
+                            try
+                            {
+                                if (!File.Exists(path) && File.Exists(backupPath))
+                                {
+                                    File.Move(backupPath, path);
+                                }
+                                backupCreated = false;
+                            }
+                            catch (Exception restoreEx)
+                            {
+                                throw new IOException($"AccountManager: Failed to restore backup save '{backupPath}' after swap failure.", new AggregateException(operationEx, restoreEx));
+                            }
+                        }
+
+                        throw;
+                    }
+                    finally
+                    {
+                        try
+                        {
+                            if (File.Exists(tempPath))
+                                File.Delete(tempPath);
+                        }
+                        catch
+                        {
+                            // Ignored; temp cleanup best-effort.
+                        }
+
+                        if (backupCreated && swapSucceeded)
+                        {
+                            try
+                            {
+                                if (File.Exists(backupPath))
+                                {
+                                    File.Delete(backupPath);
+                                }
+                            }
+                            catch
+                            {
+                                // Ignored here; an earlier exception already signalled the issue.
+                            }
+                        }
                     }
                 }).ConfigureAwait(false);
             }

--- a/Assets/Scripts/Core/Save/SaveManager.cs
+++ b/Assets/Scripts/Core/Save/SaveManager.cs
@@ -594,11 +594,15 @@ namespace Core.Save
                 return;
 
             string tempPath = GlobalFilePath + ".tmp";
+            string backupPath = GlobalFilePath + ".bak";
 
             try
             {
                 Directory.CreateDirectory(AccountManager.BaseDirectory);
                 string json = JsonUtility.ToJson(globalCache);
+
+                bool backupCreated = false;
+                bool swapSucceeded = false;
 
                 using (var tempStream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None))
                 using (var writer = new StreamWriter(tempStream, Encoding.UTF8))
@@ -610,33 +614,108 @@ namespace Core.Save
 
                 try
                 {
-                    using (var destinationLock = new FileStream(GlobalFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None))
-                    {
-                        destinationLock.Flush(true);
-                    }
-                }
-                catch (Exception lockEx)
-                {
-                    throw new IOException($"SaveManager: Unable to access global save file '{GlobalFilePath}' for writing.", lockEx);
-                }
-
-                try
-                {
                     if (File.Exists(GlobalFilePath))
                     {
-                        File.Delete(GlobalFilePath);
+                        try
+                        {
+                            using (var destinationLock = new FileStream(GlobalFilePath, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+                            {
+                                destinationLock.Flush(true);
+                            }
+                        }
+                        catch (Exception lockEx)
+                        {
+                            throw new IOException($"SaveManager: Unable to access global save file '{GlobalFilePath}' for writing.", lockEx);
+                        }
+
+                        if (File.Exists(backupPath))
+                        {
+                            try
+                            {
+                                File.Delete(backupPath);
+                            }
+                            catch (Exception deleteEx)
+                            {
+                                throw new IOException($"SaveManager: Unable to clear stale global backup '{backupPath}' before saving.", deleteEx);
+                            }
+                        }
+
+                        File.Move(GlobalFilePath, backupPath);
+                        backupCreated = true;
                     }
 
-                    File.Move(tempPath, GlobalFilePath);
-
-                    if (File.Exists(tempPath))
+                    try
                     {
-                        File.Delete(tempPath);
+                        File.Move(tempPath, GlobalFilePath);
+                        swapSucceeded = true;
+                    }
+                    catch (Exception moveEx)
+                    {
+                        throw new IOException($"SaveManager: Unable to swap temp global save '{tempPath}' into '{GlobalFilePath}'.", moveEx);
+                    }
+
+                    if (backupCreated)
+                    {
+                        try
+                        {
+                            if (File.Exists(backupPath))
+                            {
+                                File.Delete(backupPath);
+                            }
+                            backupCreated = false;
+                        }
+                        catch (Exception cleanupEx)
+                        {
+                            throw new IOException($"SaveManager: Failed to delete global backup '{backupPath}' after writing '{GlobalFilePath}'.", cleanupEx);
+                        }
                     }
                 }
-                catch (Exception swapEx)
+                catch (Exception operationEx)
                 {
-                    throw new IOException($"SaveManager: Unable to swap temp global save '{tempPath}' into '{GlobalFilePath}'.", swapEx);
+                    if (backupCreated && !swapSucceeded)
+                    {
+                        try
+                        {
+                            if (!File.Exists(GlobalFilePath) && File.Exists(backupPath))
+                            {
+                                File.Move(backupPath, GlobalFilePath);
+                            }
+                            backupCreated = false;
+                        }
+                        catch (Exception restoreEx)
+                        {
+                            throw new IOException($"SaveManager: Failed to restore global backup '{backupPath}' after swap failure.", new AggregateException(operationEx, restoreEx));
+                        }
+                    }
+
+                    throw;
+                }
+                finally
+                {
+                    try
+                    {
+                        if (File.Exists(tempPath))
+                            File.Delete(tempPath);
+                    }
+                    catch
+                    {
+                        // Ignore temp cleanup failure.
+                    }
+
+                    if (backupCreated && swapSucceeded)
+                    {
+                        try
+                        {
+                            if (File.Exists(backupPath))
+                            {
+                                File.Delete(backupPath);
+                            }
+                        }
+                        catch
+                        {
+                            // Cleanup best effort when an earlier exception already surfaced.
+                        }
+                    }
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- add backup-file swap flow to AccountProfileService.SaveAsync so existing saves are renamed before replacements
- apply the same backup handling, restoration, and cleanup to SaveManager.SaveGlobalStore

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8231b2094832ebcad423c9480af82