### PR TITLE
Stabilize GroundFlame burn iteration

### DIFF
--- a/Assets/Scripts/NPC/Combat/Projectiles/GroundFlame.cs
+++ b/Assets/Scripts/NPC/Combat/Projectiles/GroundFlame.cs
@@ -14,6 +14,7 @@ namespace NPC
         public float duration;
 
         private readonly HashSet<CombatTarget> targets = new HashSet<CombatTarget>();
+        private readonly List<CombatTarget> targetSnapshot = new List<CombatTarget>(8);
 
         private void Start()
         {
@@ -40,10 +41,26 @@ namespace NPC
             var wait = new WaitForSeconds(CombatMath.TICK_SECONDS);
             while (elapsed < duration)
             {
-                foreach (var tgt in targets)
+                // Copy the current targets into a snapshot so we can safely iterate even if the HashSet changes mid-loop.
+                targetSnapshot.Clear();
+                targetSnapshot.AddRange(targets);
+
+                var requiresCleanup = false;
+                foreach (var tgt in targetSnapshot)
                 {
-                    if (tgt != null)
-                        tgt.ApplyDamage(damagePerTick, DamageType.Burn, SpellElement.Fire, this);
+                    if (tgt == null || !tgt.IsAlive)
+                    {
+                        requiresCleanup = true;
+                        continue;
+                    }
+
+                    tgt.ApplyDamage(damagePerTick, DamageType.Burn, SpellElement.Fire, this);
+                }
+
+                if (requiresCleanup)
+                {
+                    // Remove any null or dead entries after processing so the main set stays accurate for the next tick.
+                    targets.RemoveWhere(target => target == null || !target.IsAlive);
                 }
                 elapsed += CombatMath.TICK_SECONDS;
                 yield return wait;


### PR DESCRIPTION
## Summary
- iterate over a cached list snapshot of active targets before applying burn damage ticks
- prune null or dead targets after each tick so the hash set stays clean without mutating mid-iteration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d830097008832ea205d49df918b7fb