### PR TITLE
Align NPC attack standoff distances

### DIFF
--- a/Assets/Scripts/Combat/NpcCombatProfile.cs
+++ b/Assets/Scripts/Combat/NpcCombatProfile.cs
@@ -37,6 +37,12 @@ namespace Combat
         [Tooltip("Seconds to keep aggro on a target after it moves beyond the chase radius.")]
         public float AggroTimeoutSeconds = 5f;
 
+        [Header("Attack Range")]
+        [Tooltip("Preferred distance when using ranged attacks. Defaults to a mid-range bow distance if unset.")]
+        [Min(0f)] public float RangedAttackRange = 6f;
+        [Tooltip("Preferred distance when using magic attacks. Defaults to a typical strike spell range if unset.")]
+        [Min(0f)] public float MagicAttackRange = 7f;
+
         [Tooltip("When enabled the NPC ignores freeze effects while still taking damage.")]
         public bool NotFreezable;
 
@@ -58,5 +64,25 @@ namespace Combat
         public bool PoisonRequiresDamage = true;
 
         public List<ElementalModifier> elementalModifiers = new();
+
+        private const float MINIMUM_ATTACK_RANGE = 0.1f;
+        private const float DEFAULT_RANGED_RANGE = 6f;
+        private const float DEFAULT_MAGIC_RANGE = 7f;
+
+        /// <summary>
+        /// Returns the preferred attack distance based on the configured <see cref="AttackType"/>,
+        /// falling back to sensible defaults when no explicit range has been supplied.
+        /// </summary>
+        public float GetPreferredAttackRange()
+        {
+            return AttackType switch
+            {
+                DamageType.Ranged => Mathf.Max(MINIMUM_ATTACK_RANGE,
+                    RangedAttackRange > 0f ? RangedAttackRange : DEFAULT_RANGED_RANGE),
+                DamageType.Magic => Mathf.Max(MINIMUM_ATTACK_RANGE,
+                    MagicAttackRange > 0f ? MagicAttackRange : DEFAULT_MAGIC_RANGE),
+                _ => Mathf.Max(MINIMUM_ATTACK_RANGE, CombatMath.MELEE_RANGE)
+            };
+        }
     }
 }

--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -259,7 +259,11 @@ namespace NPC
             WaitForSeconds cachedAttackDelay = null;
             int cachedAttackSpeedTicks = -1;
 
-            // Wait until the player is within melee range before performing the first attack.
+            // Wait until the target is within the preferred range for the active attack style
+            // before performing each swing so melee, ranged, and magic NPCs respect their
+            // configured stand-off distances.
+            const float DISTANCE_EPSILON = 0.05f;
+
             while (combatant.IsAlive && target != null && target.IsAlive)
             {
                 // Determine the current attack speed, defaulting to four ticks when no profile
@@ -275,13 +279,14 @@ namespace NPC
                 }
 
                 float distance = Vector2.Distance(target.transform.position, transform.position);
+                float desiredDistance = profile != null ? profile.GetPreferredAttackRange() : CombatMath.MELEE_RANGE;
                 if (distance > 15f)
                 {
                     wanderer?.ForceReturnToOrigin();
                     break;
                 }
 
-                if (distance <= CombatMath.MELEE_RANGE)
+                if (distance <= desiredDistance + DISTANCE_EPSILON)
                 {
                     ResolveAttack(target);
                     yield return cachedAttackDelay;

--- a/Assets/Scripts/NPC/Movement/NpcWanderer.cs
+++ b/Assets/Scripts/NPC/Movement/NpcWanderer.cs
@@ -44,6 +44,7 @@ namespace NPC
         private float _waitTimer;
         private Vector2 _lastPos;
         private readonly System.Collections.Generic.List<Transform> _combatTargets = new();
+        private NpcCombatant _combatant;
 
         // Per-tick interpolation
         private Vector2 _from;
@@ -85,6 +86,7 @@ namespace NPC
         {
             _rb = GetComponent<Rigidbody2D>();
             if (_rb != null) _rb.bodyType = RigidbodyType2D.Kinematic;
+            _combatant = GetComponent<NpcCombatant>();
             if (spriteAnimator == null)
                 spriteAnimator = GetComponent<NpcSpriteAnimator>() ?? GetComponentInChildren<NpcSpriteAnimator>();
         }
@@ -261,9 +263,27 @@ namespace NPC
             _tickerSubscribed = true;
         }
 
+        /// <summary>
+        /// Resolves the preferred attack distance for the attached combatant so pursuit stops at
+        /// the same range the combat loop expects when firing attacks.
+        /// </summary>
+        private float GetPreferredAttackRange()
+        {
+            if (_combatant == null)
+                _combatant = GetComponent<NpcCombatant>();
+
+            var profile = _combatant != null ? _combatant.Profile : null;
+            if (profile == null)
+                return CombatMath.MELEE_RANGE;
+
+            float range = profile.GetPreferredAttackRange();
+            return range > 0f ? range : CombatMath.MELEE_RANGE;
+        }
+
         public void OnTick()
         {
             float delta = Ticker.TickDuration;
+            const float DISTANCE_EPSILON = 0.05f;
 
             if (_frozen)
             {
@@ -291,10 +311,11 @@ namespace NPC
                 if (closest != null)
                 {
                     Vector2 targetPos = closest.position;
-                    if (best > CombatMath.MELEE_RANGE)
+                    float desiredRange = Mathf.Max(GetPreferredAttackRange(), DISTANCE_EPSILON);
+                    if (best > desiredRange + DISTANCE_EPSILON)
                     {
                         Vector2 direction = (targetPos - _from).normalized;
-                        Vector2 desired = targetPos - direction * CombatMath.MELEE_RANGE;
+                        Vector2 desired = targetPos - direction * desiredRange;
                         Vector2 step = Vector2.MoveTowards(_from, desired, moveSpeed * delta);
                         if (useAreaSize)
                         {


### PR DESCRIPTION
## Summary
- add configurable ranged and magic standoff distances to `NpcCombatProfile`
- update NPC attack routines to respect profile-defined preferred ranges for each attack style
- keep `NpcWanderer` pursuit logic aligned with the combat range check to prevent oscillation

## Testing
- not run (Unity play mode required)


------
https://chatgpt.com/codex/tasks/task_e_68d832477484832e88e9fa9d6ec05398