### PR TITLE
Ensure wanderers clear stale combat targets

### DIFF
--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -126,9 +126,12 @@ namespace NPC
                         if (c != null)
                             StopCoroutine(c);
                         activeAttacks.Remove(t);
-                        if (targetTransform != null)
-                            wanderer?.ExitCombat(targetTransform);
                     }
+
+                    // Always notify the wanderer that this combatant is no longer engaged, even when
+                    // the cached transform instance has been Unity-nullified. Passing the cached
+                    // reference allows the wanderer to purge any lingering slot keyed to the target.
+                    wanderer?.ExitCombat(targetTransform);
                 }
             }
 
@@ -306,9 +309,11 @@ namespace NPC
 
             bool onlyTrackedTarget = activeAttacks.Count <= 1;
 
-            if (cachedTargetTransform != null)
-                wanderer?.ExitCombat(cachedTargetTransform);
-            else if (onlyTrackedTarget)
+            // Always pass the cached transform back to the wanderer (even when it compares equal to
+            // null) so any stale combat slot keyed by this target reference is released immediately.
+            wanderer?.ExitCombat(cachedTargetTransform);
+
+            if (cachedTargetTransform == null && onlyTrackedTarget)
                 wanderer?.ExitCombat();
 
             RemoveCachedTargetFromDictionary(activeAttacks, cachedTarget);

--- a/Assets/Scripts/NPC/Movement/NpcWanderer.cs
+++ b/Assets/Scripts/NPC/Movement/NpcWanderer.cs
@@ -299,8 +299,15 @@ namespace NPC
                 _from = _rb != null ? _rb.position : (Vector2)transform.position;
                 Transform closest = null;
                 float best = float.MaxValue;
-                foreach (var t in _combatTargets)
+                for (int i = _combatTargets.Count - 1; i >= 0; i--)
                 {
+                    Transform t = _combatTargets[i];
+                    if (t == null)
+                    {
+                        _combatTargets.RemoveAt(i);
+                        continue;
+                    }
+
                     float d = Vector2.Distance(_from, t.position);
                     if (d < best)
                     {


### PR DESCRIPTION
## Summary
- ensure BaseNpcCombat always notifies the wanderer when targets are removed so stale combat slots are cleared
- harden the wanderer's tick loop to skip and prune null combat targets before using their transforms

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d84226d44c832e81c88cfe3d8e8ffc