### PR TITLE
Add shared camera zoom input support

### DIFF
--- a/Assets/InputSystem_Actions.inputactions
+++ b/Assets/InputSystem_Actions.inputactions
@@ -113,6 +113,15 @@
                     "processors": "",
                     "interactions": "Press",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "ZoomCamera",
+                    "type": "Value",
+                    "id": "07a16281-cffb-4996-b26b-0a471b65b728",
+                    "expectedControlType": "Axis",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -575,6 +584,28 @@
                     "processors": "",
                     "groups": "Gamepad",
                     "action": "OpenMenu",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "5ae59107-0521-4b9b-9a40-ddfdb351f325",
+                    "path": "<Mouse>/scroll/y",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse",
+                    "action": "ZoomCamera",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "eba3d66a-5027-4546-b7a6-3866609874ba",
+                    "path": "<Gamepad>/rightStick/y",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "ZoomCamera",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/Scripts/Player/CameraFollow2D.cs
+++ b/Assets/Scripts/Player/CameraFollow2D.cs
@@ -1,7 +1,11 @@
 ﻿// Assets/Scripts/Camera/CameraFollow2D.cs
 
+using Core.Input;
 using UnityEngine;
 using World;
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+#endif
 
 namespace Player
 {
@@ -13,6 +17,26 @@ namespace Player
         [Tooltip("0 = instant, higher = smoother (e.g., 0.12)")]
         public float smoothTime = 0.12f;
 
+        [Header("Zoom")]
+        [Tooltip("Orthographic size applied when the camera starts. 0 keeps the current camera size.")]
+        public float defaultZoom = 25f;
+        [Tooltip("Minimum orthographic size allowed when zooming in.")]
+        public float minZoom = 10f;
+        [Tooltip("Maximum orthographic size allowed when zooming out.")]
+        public float maxZoom = 40f;
+        [Tooltip("How much the target zoom changes per scroll tick or controller input.")]
+        public float zoomStep = 2f;
+        [Tooltip("Interpolation speed when smoothing zoom transitions. 0 applies the target instantly.")]
+        public float zoomSmoothing = 12f;
+
+#if ENABLE_INPUT_SYSTEM
+        [Header("Input")]
+        [Tooltip("Optional PlayerInput override used to locate the ZoomCamera action.")]
+        [SerializeField] private PlayerInput playerInput;
+        [Tooltip("Input action reference representing the ZoomCamera control.")]
+        [SerializeField] private InputActionReference zoomActionReference;
+#endif
+
         [Header("Pixel Snapping")]
         public bool snapToPixels = true;
         public int pixelsPerUnit = 64;
@@ -23,15 +47,45 @@ namespace Player
 
         private Vector3 velocity;
         private Camera cam;
+        private float targetZoom;
+#if ENABLE_INPUT_SYSTEM
+        private InputAction zoomAction;
+        private bool zoomActionEnabledByResolver;
+#endif
 
         protected override void Awake()
         {
             base.Awake();
             cam = GetComponent<Camera>();
+            InitialiseZoomTargets();
+        }
+
+        private void OnEnable()
+        {
+            SceneTransitionManager.RegisterPersistentObject(this);
+#if ENABLE_INPUT_SYSTEM
+            zoomAction = InputActionResolver.Resolve(playerInput, zoomActionReference, "ZoomCamera", out zoomActionEnabledByResolver);
+#endif
+        }
+
+        private void OnDisable()
+        {
+#if ENABLE_INPUT_SYSTEM
+            if (zoomAction != null && zoomActionEnabledByResolver)
+            {
+                zoomAction.Disable();
+            }
+
+            zoomAction = null;
+            zoomActionEnabledByResolver = false;
+#endif
+            SceneTransitionManager.UnregisterPersistentObject(this);
         }
 
         void LateUpdate()
         {
+            UpdateZoom();
+
             if (!target)
             {
                 var playerObj = GameObject.FindGameObjectWithTag("Player");
@@ -75,6 +129,110 @@ namespace Player
             }
 
             transform.position = pos;
+        }
+
+        /// <summary>
+        ///     Configures the starting zoom so the camera respects configured limits right away.
+        /// </summary>
+        private void InitialiseZoomTargets()
+        {
+            if (cam == null)
+                return;
+
+            GetOrderedZoomBounds(out float lowerBound, out float upperBound);
+
+            float initialSize = cam.orthographicSize;
+
+            if (defaultZoom > 0f)
+                initialSize = defaultZoom;
+
+            targetZoom = Mathf.Clamp(initialSize, lowerBound, upperBound);
+            cam.orthographicSize = targetZoom;
+        }
+
+        /// <summary>
+        ///     Reads zoom input, honours minimap focus rules, and applies smoothed zoom changes.
+        /// </summary>
+        private void UpdateZoom()
+        {
+            if (cam == null)
+                return;
+
+            float scrollDelta = ReadZoomInput();
+
+            if (!Mathf.Approximately(scrollDelta, 0f))
+            {
+                bool minimapBlocksZoom = false;
+                var minimap = Minimap.Instance;
+
+                if (minimap != null)
+                {
+                    Vector2 pointerPosition = InputActionResolver.GetPointerScreenPosition(Vector2.zero);
+                    minimapBlocksZoom = minimap.ShouldBlockWorldCameraZoom(pointerPosition);
+                }
+
+                if (!minimapBlocksZoom)
+                {
+                    GetOrderedZoomBounds(out float lowerBound, out float upperBound);
+                    float newTarget = targetZoom - scrollDelta * Mathf.Abs(zoomStep);
+                    targetZoom = Mathf.Clamp(newTarget, lowerBound, upperBound);
+                }
+            }
+
+            ApplyZoomSmoothing();
+        }
+
+        /// <summary>
+        ///     Applies smoothing so the camera interpolates toward the target zoom gracefully.
+        /// </summary>
+        private void ApplyZoomSmoothing()
+        {
+            GetOrderedZoomBounds(out float lowerBound, out float upperBound);
+            targetZoom = Mathf.Clamp(targetZoom, lowerBound, upperBound);
+
+            if (zoomSmoothing <= 0f)
+            {
+                cam.orthographicSize = targetZoom;
+                return;
+            }
+
+            float t = Mathf.Clamp01(zoomSmoothing * Time.deltaTime);
+            cam.orthographicSize = Mathf.Lerp(cam.orthographicSize, targetZoom, t);
+        }
+
+        /// <summary>
+        ///     Returns the configured zoom bounds in ascending order so clamps behave predictably even if
+        ///     the inspector values were supplied in reverse.
+        /// </summary>
+        private void GetOrderedZoomBounds(out float lowerBound, out float upperBound)
+        {
+            if (minZoom <= maxZoom)
+            {
+                lowerBound = minZoom;
+                upperBound = maxZoom;
+            }
+            else
+            {
+                lowerBound = maxZoom;
+                upperBound = minZoom;
+            }
+        }
+
+        /// <summary>
+        ///     Reads the zoom delta from the resolved input action, falling back to the mouse scroll
+        ///     value so editor builds continue to function without a PlayerInput component.
+        /// </summary>
+        private float ReadZoomInput()
+        {
+#if ENABLE_INPUT_SYSTEM
+            if (zoomAction != null)
+                return zoomAction.ReadValue<float>();
+
+            if (Mouse.current != null)
+                return Mouse.current.scroll.ReadValue().y;
+#endif
+
+            return 0f;
         }
     }
 }

--- a/Assets/Scripts/World/Minimap.cs
+++ b/Assets/Scripts/World/Minimap.cs
@@ -505,21 +505,37 @@ namespace World
         /// <param name="screenPosition">The pointer position in screen space.</param>
         private void HandleExpandedScrollZoom(float scrollDelta, Vector3 screenPosition)
         {
-            if (mapCamera == null || expandedMapRect == null || !IsExpanded)
+            if (mapCamera == null)
                 return;
 
             if (Mathf.Approximately(scrollDelta, 0f))
                 return;
 
-            var referenceCamera = minimapCanvas != null ? minimapCanvas.worldCamera : null;
-            if (!RectTransformUtility.RectangleContainsScreenPoint(expandedMapRect, screenPosition, referenceCamera))
-                return;
-
-            if (PointerHitsBlockingControl(screenPosition))
+            if (!ShouldBlockWorldCameraZoom(new Vector2(screenPosition.x, screenPosition.y)))
                 return;
 
             float newSize = Mathf.Clamp(mapCamera.orthographicSize - scrollDelta * ZoomStep, MinZoom, MaxZoom);
             mapCamera.orthographicSize = newSize;
+        }
+
+        /// <summary>
+        ///     Determines whether the expanded minimap should consume the current scroll event rather than
+        ///     allowing the world camera to zoom.
+        /// </summary>
+        /// <param name="screenPosition">Pointer position in screen space.</param>
+        public bool ShouldBlockWorldCameraZoom(Vector2 screenPosition)
+        {
+            if (!IsExpanded || expandedMapRect == null)
+                return false;
+
+            var referenceCamera = minimapCanvas != null ? minimapCanvas.worldCamera : null;
+            if (!RectTransformUtility.RectangleContainsScreenPoint(expandedMapRect, screenPosition, referenceCamera))
+                return false;
+
+            if (PointerHitsBlockingControl(screenPosition))
+                return false;
+
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- add a ZoomCamera value action with mouse wheel and gamepad bindings to the player input map
- extend CameraFollow2D with configurable zoom limits, smoothing, and shared input resolution
- expose a Minimap helper so the world camera ignores scroll events consumed by the expanded map

## Testing
- Not run (Unity editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d8eaa59274832ebb67f40452d3e4ee