### PR TITLE
Extend pixel perfect camera type resolution

### DIFF
--- a/Assets/Scripts/Player/CameraFollow2D.cs
+++ b/Assets/Scripts/Player/CameraFollow2D.cs
@@ -332,7 +332,8 @@ namespace Player
             {
                 "UnityEngine.U2D.PixelPerfectCamera, Unity.2D.PixelPerfect.Runtime",
                 "UnityEngine.U2D.PixelPerfectCamera, Unity.2D.PixelPerfect",
-                "UnityEngine.Experimental.Rendering.Universal.PixelPerfectCamera, Unity.RenderPipelines.Universal.Runtime"
+                "UnityEngine.Experimental.Rendering.Universal.PixelPerfectCamera, Unity.RenderPipelines.Universal.Runtime",
+                "UnityEngine.Rendering.Universal.PixelPerfectCamera, Unity.RenderPipelines.Universal.Runtime"
             };
 
             foreach (string candidate in candidateTypeNames)


### PR DESCRIPTION
## Summary
- extend the pixel-perfect camera type resolution helper to search the new Unity Rendering Universal PixelPerfectCamera type

## Testing
- not run (Unity play mode required)

------
https://chatgpt.com/codex/tasks/task_e_68d8fc00b91c832e86d64c27207acff5