### PR TITLE
Add faction-aware aggression targeting for NPC combatants

### DIFF
--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -97,13 +97,21 @@ namespace NPC
             if (!combatant.IsAlive)
                 return;
             var profile = combatant.Profile;
-            if (profile == null || (!profile.IsAggressive && threatLevels.Count == 0))
+            if (profile == null)
                 return;
+
+            float aggroRadius = wanderer != null ? wanderer.AggroRadius : 5f;
+            bool hasThreat = threatLevels.Count > 0;
+            var myFaction = combatant as IFactionProvider;
+
+            if (!profile.IsAggressive && !hasThreat)
+            {
+                if (myFaction == null || !HasAggressiveFactionTargets(myFaction, aggroRadius))
+                    return;
+            }
 
             if (playerTarget == null)
                 playerTarget = FindObjectOfType<PlayerCombatTarget>();
-
-            float aggroRadius = wanderer != null ? wanderer.AggroRadius : 5f;
             foreach (var t in new List<CombatTarget>(threatLevels.Keys))
             {
                 var unityTarget = t as Object;
@@ -158,12 +166,15 @@ namespace NPC
 
             if (playerTarget != null && playerTarget.IsAlive)
             {
-                float playerDist = Vector2.Distance(playerTarget.transform.position, spawnPosition);
-                if (playerDist <= aggroRadius)
-                    potentials.Add(playerTarget);
+                bool playerHasThreat = threatLevels.ContainsKey(playerTarget);
+                if (profile.IsAggressive || playerHasThreat)
+                {
+                    float playerDist = Vector2.Distance(playerTarget.transform.position, spawnPosition);
+                    if (playerDist <= aggroRadius)
+                        potentials.Add(playerTarget);
+                }
             }
 
-            var myFaction = combatant as IFactionProvider;
             if (myFaction != null)
             {
                 var activeCombatants = NpcCombatant.ActiveCombatants;
@@ -176,6 +187,10 @@ namespace NPC
                         continue;
                     var otherFaction = npc as IFactionProvider;
                     if (otherFaction == null || !myFaction.IsEnemy(otherFaction.Faction))
+                        continue;
+                    bool hasExistingThreat = threatLevels.ContainsKey(npc);
+                    bool factionAggressive = FactionUtility.IsAggressiveTowardFaction(myFaction.Faction, otherFaction.Faction);
+                    if (!profile.IsAggressive && !factionAggressive && !hasExistingThreat)
                         continue;
                     float dist = Vector2.Distance(npc.transform.position, spawnPosition);
                     if (dist <= aggroRadius)
@@ -382,6 +397,38 @@ namespace NPC
                 wanderer?.ForceReturnToOrigin();
                 SetCombatState(false);
             }
+        }
+
+        /// <summary>
+        /// Determines whether any hostile faction targets that this NPC is configured to
+        /// proactively attack are currently within the supplied aggro radius.
+        /// </summary>
+        /// <param name="myFaction">Faction component representing this NPC.</param>
+        /// <param name="aggroRadius">Radius within which aggression should be evaluated.</param>
+        private bool HasAggressiveFactionTargets(IFactionProvider myFaction, float aggroRadius)
+        {
+            var active = NpcCombatant.ActiveCombatants;
+            for (int i = 0; i < active.Count; i++)
+            {
+                var npc = active[i];
+                if (npc == null || npc == combatant)
+                    continue;
+                if (!npc.isActiveAndEnabled || !npc.IsAlive)
+                    continue;
+
+                if (npc is not IFactionProvider otherFaction)
+                    continue;
+                if (!myFaction.IsEnemy(otherFaction.Faction))
+                    continue;
+                if (!FactionUtility.IsAggressiveTowardFaction(myFaction.Faction, otherFaction.Faction))
+                    continue;
+
+                float distance = Vector2.Distance(npc.transform.position, spawnPosition);
+                if (distance <= aggroRadius)
+                    return true;
+            }
+
+            return false;
         }
 
         private void CleanupDestroyedTargetReferences(CombatTarget target)

--- a/Assets/Scripts/NPC/NpcFaction.cs
+++ b/Assets/Scripts/NPC/NpcFaction.cs
@@ -39,10 +39,26 @@ namespace NPC
             /* GoblinRed */  { false,   true,       false },
         };
 
+        // Aggression matrix: [aggressor, target] => will proactively attack when nearby.
+        private static readonly bool[,] AggressiveRelationships =
+        {
+            //                Neutral, GoblinGreen, GoblinRed
+            /* Neutral */    { false,   false,      false },
+            /* GoblinGreen */{ false,   false,      true  },
+            /* GoblinRed */  { false,   true,       false },
+        };
+
         /// <summary>
         /// Determine if two factions are enemies.
         /// </summary>
         public static bool IsEnemy(FactionId a, FactionId b) => Relationships[(int)a, (int)b];
+
+        /// <summary>
+        /// Determine if <paramref name="aggressor"/> will initiate combat when spotting
+        /// <paramref name="target"/>.
+        /// </summary>
+        public static bool IsAggressiveTowardFaction(FactionId aggressor, FactionId target) =>
+            AggressiveRelationships[(int)aggressor, (int)target];
     }
 }
 

--- a/Assets/Tests/NpcFactionTests.cs
+++ b/Assets/Tests/NpcFactionTests.cs
@@ -22,5 +22,14 @@ public class NpcFactionTests
             Assert.IsFalse(FactionUtility.IsEnemy(id, FactionId.Neutral));
         }
     }
+
+    [Test]
+    public void GoblinClansAreAggressiveTowardEachOtherOnly()
+    {
+        Assert.IsTrue(FactionUtility.IsAggressiveTowardFaction(FactionId.GoblinGreen, FactionId.GoblinRed));
+        Assert.IsTrue(FactionUtility.IsAggressiveTowardFaction(FactionId.GoblinRed, FactionId.GoblinGreen));
+        Assert.IsFalse(FactionUtility.IsAggressiveTowardFaction(FactionId.GoblinGreen, FactionId.Neutral));
+        Assert.IsFalse(FactionUtility.IsAggressiveTowardFaction(FactionId.GoblinRed, FactionId.Neutral));
+    }
 }
 


### PR DESCRIPTION
## Summary
- add faction aggression matrix so hostile clans can proactively fight each other without aggroing neutrals
- update BaseNpcCombat to respect faction aggression rules while keeping player aggression unchanged
- extend faction unit tests to cover the new aggression queries

## Testing
- not run (Unity tests require editor environment)

------
https://chatgpt.com/codex/tasks/task_e_68d9106fea64832eb9577a2d93d90e70