### PR TITLE
Reset NPC damage credit on aggro timeout

### DIFF
--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -61,6 +61,7 @@ namespace NPC
             threatLevels.Clear();
             lastDamageTimes.Clear();
             hasHitPlayer = false;
+            combatant?.ClearDamageContributors("ResetCombatState invoked");
             if (resetSpawnPosition)
                 spawnPosition = transform.position;
             wanderer?.ExitCombat();
@@ -92,6 +93,46 @@ namespace NPC
             lastDamageTimes[attacker] = Time.time;
         }
 
+        /// <summary>
+        /// Determines whether any player-controlled combatant has contributed damage within the
+        /// supplied time window.
+        /// </summary>
+        /// <param name="windowSeconds">Time window in seconds. When zero or negative, any recorded
+        /// contribution counts regardless of age.</param>
+        /// <param name="secondsSinceMostRecent">Outputs the number of seconds since the most recent
+        /// qualifying contribution when one is found. Undefined when no contributors are present.</param>
+        public bool HasRecentPlayerContribution(float windowSeconds, out float secondsSinceMostRecent)
+        {
+            secondsSinceMostRecent = float.PositiveInfinity;
+            if (lastDamageTimes.Count == 0)
+                return false;
+
+            float now = Time.time;
+            float allowedWindow = windowSeconds > 0f ? windowSeconds : float.PositiveInfinity;
+            bool found = false;
+
+            foreach (var kvp in lastDamageTimes)
+            {
+                if (!IsPlayerControlled(kvp.Key))
+                    continue;
+
+                float elapsed = now - kvp.Value;
+                if (elapsed > allowedWindow)
+                    continue;
+
+                if (!found || elapsed < secondsSinceMostRecent)
+                    secondsSinceMostRecent = elapsed;
+                found = true;
+            }
+
+            return found;
+        }
+
+        private static bool IsPlayerControlled(CombatTarget target)
+        {
+            return target is PlayerCombatTarget || target is PetCombatController;
+        }
+
         protected virtual void Update()
         {
             if (!combatant.IsAlive)
@@ -119,6 +160,7 @@ namespace NPC
                 bool unityMissing = unityTarget == null || !TryResolveTargetTransform(t, unityTarget, out targetTransform);
 
                 bool remove = unityMissing;
+                bool removedForAggroTimeout = false;
                 if (!remove && !t.IsAlive)
                     remove = true;
 
@@ -129,6 +171,25 @@ namespace NPC
                     {
                         wanderer?.ForceReturnToOrigin();
                         remove = true;
+                    }
+                    else if (profile != null && profile.AggroTimeoutSeconds > 0f)
+                    {
+                        float distanceFromSpawn = Vector2.Distance(targetTransform.position, spawnPosition);
+                        float chaseRadius = wanderer != null ? wanderer.AggroRadius : 5f;
+                        if (distanceFromSpawn > chaseRadius && lastDamageTimes.TryGetValue(t, out float lastDamage))
+                        {
+                            float elapsed = Time.time - lastDamage;
+                            if (elapsed >= profile.AggroTimeoutSeconds)
+                            {
+                                remove = true;
+                                removedForAggroTimeout = true;
+                                if (combatant != null && combatant.LogDamage)
+                                {
+                                    string targetName = targetTransform != null ? targetTransform.name : "unknown";
+                                    Debug.Log($"{name} removed threat {targetName} after {elapsed:F1}s outside chase radius (timeout {profile.AggroTimeoutSeconds:F1}s).", this);
+                                }
+                            }
+                        }
                     }
                 }
 
@@ -150,6 +211,9 @@ namespace NPC
                 RemoveCachedTargetFromDictionary(threatLevels, t);
                 RemoveCachedTargetFromDictionary(lastDamageTimes, t);
                 RemoveCachedTargetFromDictionary(activeAttacks, t);
+
+                if (removedForAggroTimeout)
+                    combatant?.ClearDamageContributors("Aggro timeout cleared credit");
             }
 
             if (threatLevels.Count == 0 && activeAttacks.Count == 0)

--- a/Assets/Scripts/NPC/Combat/NpcCombatant.cs
+++ b/Assets/Scripts/NPC/Combat/NpcCombatant.cs
@@ -93,7 +93,7 @@ namespace NPC
             {
                 flashEffect = gameObject.AddComponent<NpcFlashEffect>();
             }
-            ResetDamageCounters();
+            ClearDamageContributors("Awake initialisation");
             OnHealthChanged?.Invoke(currentHp, MaxHP);
 
             EnsureHitSplatLibrary();
@@ -168,6 +168,7 @@ namespace NPC
                 Vector3 hitsplatPosition = FloatingTextAnchorUtility.ResolveAnchorPosition(transform, hitsplatFallbackOffset, ref hitsplatAnchorCache);
                 FloatingText.Show(finalAmount.ToString(), hitsplatPosition, Color.white, null, poisonHitsplat);
             }
+            var combat = GetComponent<BaseNpcCombat>();
             var combatSource = source as CombatTarget;
             bool creditedToPlayer = false;
             if (combatSource != null)
@@ -194,7 +195,6 @@ namespace NPC
                 {
                     npcDamage += finalAmount;
                 }
-                var combat = GetComponent<BaseNpcCombat>();
                 combat?.AddThreat(combatSource, finalAmount);
                 combat?.RecordDamageFrom(combatSource);
                 if (combat != null && !combat.InCombat)
@@ -216,11 +216,30 @@ namespace NPC
                 // Trigger drops before other death listeners in case they
                 // destroy this NPC immediately (e.g. when killed by pets).
                 var dropper = GetComponent<NpcDropper>();
+                float dropCreditWindow = profile != null
+                    ? Mathf.Max(profile.AggroTimeoutSeconds, CombatMath.TICK_SECONDS)
+                    : CombatMath.TICK_SECONDS;
+                bool hasRecentPlayerContribution = false;
+                float secondsSincePlayerContribution = float.PositiveInfinity;
+                if (combat != null)
+                    hasRecentPlayerContribution = combat.HasRecentPlayerContribution(dropCreditWindow, out secondsSincePlayerContribution);
+
+                if (logDamage)
+                {
+                    string contributionSummary = hasRecentPlayerContribution
+                        ? $"last player contribution {secondsSincePlayerContribution:F1}s ago (window {dropCreditWindow:F1}s)"
+                        : $"no player contribution within the {dropCreditWindow:F1}s window";
+                    Debug.Log($"{name} evaluating drop credit: playerDamage={playerDamage}, npcDamage={npcDamage}, {contributionSummary}.", this);
+                }
+
+                Debug.Assert(!hasRecentPlayerContribution || playerDamage > 0,
+                    $"{name} recorded recent player damage but has no tracked playerDamage. Ensure ClearDamageContributors is invoked when combat resets.");
+
                 if (killedByPlayer || playerDamage > npcDamage)
                     dropper?.OnDeath();
 
-                ResetDamageCounters();
-                GetComponent<BaseNpcCombat>()?.ResetCombatState();
+                ClearDamageContributors("NPC death resolution");
+                combat?.ResetCombatState();
                 if (wanderer != null) wanderer.enabled = false;
                 OnDeath?.Invoke();
                 if (collider2D) collider2D.enabled = false;
@@ -250,8 +269,25 @@ namespace NPC
             transform.position = spawn;
             wanderer?.SetOrigin(spawn);
             combat?.ResetCombatState(true);
-            ResetDamageCounters();
+            ClearDamageContributors("Respawned");
             OnHealthChanged?.Invoke(currentHp, MaxHP);
+        }
+
+        /// <summary>
+        /// Public helper used by other systems to clear any cached damage attribution. This wraps
+        /// the legacy <see cref="ResetDamageCounters"/> logic so threat resets, retreats, or
+        /// timeout events always wipe player/NPC damage tallies in a single, auditable place.
+        /// </summary>
+        /// <param name="reason">Optional human readable context written to the console when
+        /// <see cref="LogDamage"/> is enabled.</param>
+        public void ClearDamageContributors(string reason = null)
+        {
+            ResetDamageCounters();
+            if (logDamage)
+            {
+                string context = string.IsNullOrEmpty(reason) ? "without context" : reason;
+                Debug.Log($"{name} cleared damage contributors ({context}).", this);
+            }
         }
 
         private void ResetDamageCounters()


### PR DESCRIPTION
## Summary
- add a public helper on `NpcCombatant` to clear cached damage contributors with optional debug logging
- ensure drop credit evaluation logs/asserts recent player contributions and call the helper during combat resets and respawns
- extend `BaseNpcCombat` to time out stale threats, log removals, and clear damage tallies when aggro or combat state resets

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68d926471334832e8f35393f223c2d4e