### PR TITLE
Prevent camera zoom while debug menus are open

### DIFF
--- a/Assets/Scripts/Player/CameraFollow2D.cs
+++ b/Assets/Scripts/Player/CameraFollow2D.cs
@@ -4,8 +4,10 @@ using System;
 using System.Reflection;
 using BankSystem;
 using Core.Input;
+using Inventory;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using Skills;
 using World;
 #if ENABLE_INPUT_SYSTEM
 using UnityEngine.InputSystem;
@@ -235,6 +237,14 @@ namespace Player
                 return;
 
             if (BankUI.Instance != null && BankUI.Instance.IsOpen)
+                return;
+
+            // Prevent camera zoom adjustments while developer menus are open so scrolling within
+            // those windows does not inadvertently modify the world view.
+            if (InventoryDebugMenu.Instance != null && InventoryDebugMenu.Instance.Visible)
+                return;
+
+            if (AdminF2Menu.IsVisible)
                 return;
 
             float scrollDelta = ReadZoomInput();

--- a/Assets/Scripts/Skills/AdminF2Menu.cs
+++ b/Assets/Scripts/Skills/AdminF2Menu.cs
@@ -34,6 +34,13 @@ namespace Skills
 
         public static AdminF2Menu Instance => instance;
 
+        /// <summary>
+        /// Indicates whether the Admin F2 debug menu is currently visible.
+        /// External systems can query this to disable gameplay input while the
+        /// menu overlays the screen.
+        /// </summary>
+        public static bool IsVisible => instance != null && instance.visible;
+
         private bool sceneGateSubscribed;
 
         private PlayerHitpoints hitpoints;


### PR DESCRIPTION
## Summary
- expose the Admin F2 debug menu visibility state so other systems can query it
- prevent the world camera from reacting to scroll input while the F1 inventory debug menu or F2 admin menu are open

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da50201788832eb1d0f0a66ccacc72