### PR TITLE
Show heal amount in cooked food tooltips

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -1247,7 +1247,7 @@ namespace Inventory
 
             string name = !string.IsNullOrEmpty(item.itemName) ? item.itemName : item.name;
             tooltipNameText.text = name;
-            tooltipDescriptionText.text = item.description;
+            tooltipDescriptionText.text = BuildTooltipDescription(item);
 
             var tooltipRect = tooltip.GetComponent<RectTransform>();
             LayoutRebuilder.ForceRebuildLayoutImmediate(tooltipRect);
@@ -1270,7 +1270,7 @@ namespace Inventory
 
             string name = !string.IsNullOrEmpty(item.itemName) ? item.itemName : item.name;
             tooltipNameText.text = name;
-            tooltipDescriptionText.text = item.description;
+            tooltipDescriptionText.text = BuildTooltipDescription(item);
 
             var tooltipRect = tooltip.GetComponent<RectTransform>();
             LayoutRebuilder.ForceRebuildLayoutImmediate(tooltipRect);
@@ -1291,6 +1291,28 @@ namespace Inventory
         {
             if (tooltip != null)
                 tooltip.SetActive(false);
+        }
+
+        /// <summary>
+        /// Builds the tooltip body text for the provided item, overriding the default
+        /// description for consumables that restore hitpoints so players can see the
+        /// precise heal value at a glance.
+        /// </summary>
+        /// <param name="item">Item displayed in the tooltip.</param>
+        /// <returns>Formatted description string for the tooltip body.</returns>
+        private static string BuildTooltipDescription(ItemData item)
+        {
+            if (item == null)
+                return string.Empty;
+
+            // Cooked food and other consumables that heal the player expose their
+            // potency through ItemData.healAmount. Replace the flavour text with an
+            // OSRS-style heal summary so the tooltip communicates how much health is
+            // restored when consumed.
+            if (item.healAmount > 0)
+                return $"Heals +{item.healAmount} hp";
+
+            return item.description;
         }
 
         public void ShowDropMenu(int slotIndex, Vector2 position)


### PR DESCRIPTION
## Summary
- replace inventory tooltip descriptions for healing consumables with the heal amount so cooked food shows its restorative value

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da57f59f90832eaf51c3036815f27b