### PR TITLE
Add NPC knockback handling

### DIFF
--- a/Assets/Prefabs/NPCS/NPC_GOBLIN.prefab
+++ b/Assets/Prefabs/NPCS/NPC_GOBLIN.prefab
@@ -23,6 +23,7 @@ GameObject:
   - component: {fileID: 4856330758820000550}
   - component: {fileID: 6410839004971985729}
   - component: {fileID: 3665449629679586575}
+  - component: {fileID: 330093352596913383}
   - component: {fileID: 8901135699789091071}
   m_Layer: 7
   m_Name: NPC_GOBLIN
@@ -371,6 +372,49 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0ade83d186a2426484d785699fb0c95b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::NPC.NpcFacing
+--- !u!114 &330093352596913383
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8077571585701284791}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2a6a9b1d4474b0f41b7f62e6a86fba13, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  enableKnockback: 1
+  baseDistance: 0.9
+  knockbackDuration: 0.3
+  scaleWithDamage: 1
+  distancePerDamagePoint: 0.03
+  maxScaledDistance: 1.8
+  clampToMovementBounds: 1
+  knockbackCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!114 &8901135699789091071
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/NPCS/NPC_GOBLIN_WARMAGE.prefab
+++ b/Assets/Prefabs/NPCS/NPC_GOBLIN_WARMAGE.prefab
@@ -23,6 +23,7 @@ GameObject:
   - component: {fileID: 4856330758820000550}
   - component: {fileID: 3665449629679586575}
   - component: {fileID: 8760582560412806108}
+  - component: {fileID: 686960219074157846}
   - component: {fileID: 6410839004971985729}
   m_Layer: 7
   m_Name: NPC_GOBLIN_WARMAGE
@@ -376,6 +377,49 @@ MonoBehaviour:
   burnPrefab: {fileID: 6111494187698877684, guid: 9e9effd4291159241bc8f42d478e4569, type: 3}
   dropHeight: 8
   meteorSpeed: 5
+--- !u!114 &686960219074157846
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8077571585701284791}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2a6a9b1d4474b0f41b7f62e6a86fba13, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  enableKnockback: 1
+  baseDistance: 1.1
+  knockbackDuration: 0.32
+  scaleWithDamage: 1
+  distancePerDamagePoint: 0.035
+  maxScaledDistance: 2.2
+  clampToMovementBounds: 1
+  knockbackCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!114 &6410839004971985729
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/NPC/Combat/NpcCombatant.cs
+++ b/Assets/Scripts/NPC/Combat/NpcCombatant.cs
@@ -34,6 +34,8 @@ namespace NPC
         private bool logDamage = false;
         [SerializeField, Tooltip("Centralised hitsplat sprite references assigned via the inspector.")]
         private HitSplatLibrary hitSplatLibrary;
+        [SerializeField, Tooltip("Optional knockback receiver for handling physical impulses when the NPC takes damage.")]
+        private NpcKnockbackReceiver knockbackReceiver;
 
         [SerializeField, Tooltip("Vertical offset applied when no floating text anchor is present.")]
         private float hitsplatFallbackOffset = 1f;
@@ -116,6 +118,8 @@ namespace NPC
             collider2D = GetComponent<Collider2D>();
             spriteRenderer = GetComponent<SpriteRenderer>();
             wanderer = GetComponent<NpcWanderer>();
+            if (knockbackReceiver == null)
+                knockbackReceiver = GetComponent<NpcKnockbackReceiver>();
             flashEffect = GetComponent<NpcFlashEffect>();
             if (flashEffect == null && spriteRenderer != null)
             {
@@ -202,12 +206,15 @@ namespace NPC
             var combat = GetComponent<BaseNpcCombat>();
             var combatSource = source as CombatTarget;
             bool creditedToPlayer = false;
+            Transform knockbackSource = null;
             if (combatSource != null)
             {
                 if (combatSource is PlayerCombatTarget)
                 {
                     playerDamage += damageToApply;
                     creditedToPlayer = true;
+                    if (combatSource is Component component)
+                        knockbackSource = component.transform;
                 }
                 else if (combatSource is PetCombatController pet)
                 {
@@ -216,6 +223,7 @@ namespace NPC
                     {
                         playerDamage += damageToApply;
                         creditedToPlayer = true;
+                        knockbackSource = pet.transform;
                     }
                     else
                     {
@@ -226,6 +234,10 @@ namespace NPC
                 {
                     npcDamage += damageToApply;
                 }
+
+                if (damageToApply > 0 && knockbackSource != null)
+                    knockbackReceiver?.ApplyKnockbackFrom(knockbackSource, damageToApply);
+
                 combat?.AddThreat(combatSource, damageToApply);
                 combat?.RecordDamageFrom(combatSource);
                 if (combat != null && !combat.InCombat)
@@ -234,7 +246,7 @@ namespace NPC
                     float radius = wanderer != null ? wanderer.AggroRadius : 5f;
                     if (dist > radius)
                         combat.ReengageFromRetreat(combatSource);
-                    }
+                }
                 combat?.BeginAttacking(combatSource);
             }
             else
@@ -296,6 +308,7 @@ namespace NPC
             if (spriteRenderer) spriteRenderer.enabled = true;
             if (wanderer != null) wanderer.enabled = true;
             var combat = GetComponent<BaseNpcCombat>();
+            knockbackReceiver?.CancelKnockback();
             Vector2 spawn = combat != null ? combat.SpawnPosition : (Vector2)transform.position;
             transform.position = spawn;
             wanderer?.SetOrigin(spawn);
@@ -313,6 +326,7 @@ namespace NPC
         /// <see cref="LogDamage"/> is enabled.</param>
         public void ClearDamageContributors(string reason = null)
         {
+            knockbackReceiver?.CancelKnockback();
             ResetDamageCounters();
             if (logDamage)
             {

--- a/Assets/Scripts/NPC/Combat/NpcKnockbackReceiver.cs
+++ b/Assets/Scripts/NPC/Combat/NpcKnockbackReceiver.cs
@@ -1,0 +1,98 @@
+using UnityEngine;
+
+namespace NPC
+{
+    /// <summary>
+    /// Handles directional knockback impulses for NPCs by forwarding displacement
+    /// requests to the <see cref="NpcWanderer"/> movement controller.
+    /// </summary>
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(NpcWanderer))]
+    public sealed class NpcKnockbackReceiver : MonoBehaviour
+    {
+        [Header("Knockback")]
+        [SerializeField, Tooltip("Global toggle so designers can disable knockback without removing the component.")]
+        private bool enableKnockback = true;
+        [SerializeField, Tooltip("Base displacement applied when a hit lands. This is expressed in world units.")]
+        private float baseDistance = 0.75f;
+        [SerializeField, Tooltip("Time in seconds for the knockback interpolation to complete.")]
+        private float knockbackDuration = 0.3f;
+        [SerializeField, Tooltip("When enabled the knockback distance scales with incoming damage to emphasise heavy hits.")]
+        private bool scaleWithDamage = true;
+        [SerializeField, Tooltip("Additional distance added for each point of damage when scaling is enabled.")]
+        private float distancePerDamagePoint = 0.02f;
+        [SerializeField, Tooltip("Maximum displacement allowed after scaling so extreme hits do not launch NPCs excessively far.")]
+        private float maxScaledDistance = 2.5f;
+        [SerializeField, Tooltip("Clamp the resolved knockback position to the wanderer's configured movement bounds.")]
+        private bool clampToMovementBounds = true;
+        [SerializeField, Tooltip("Curve used to ease the knockback interpolation over time.")]
+        private AnimationCurve knockbackCurve = AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
+
+        private NpcWanderer wanderer;
+        private NpcCombatant combatant;
+        private Rigidbody2D body;
+
+        private void Awake()
+        {
+            wanderer = GetComponent<NpcWanderer>();
+            combatant = GetComponent<NpcCombatant>();
+            body = GetComponent<Rigidbody2D>();
+        }
+
+        /// <summary>
+        /// Applies a knockback impulse away from the provided <paramref name="source"/> transform.
+        /// Damage is used to scale the displacement when <see cref="scaleWithDamage"/> is enabled.
+        /// </summary>
+        /// <param name="source">Transform representing the origin of the hit.</param>
+        /// <param name="damage">The final damage amount applied by the attack.</param>
+        public void ApplyKnockbackFrom(Transform source, int damage)
+        {
+            if (!enableKnockback || source == null || wanderer == null)
+                return;
+
+            if (combatant != null && !combatant.IsAlive)
+                return;
+
+            if (wanderer.IsFrozen)
+                return;
+
+            Vector2 currentPosition = body != null ? body.position : (Vector2)transform.position;
+            Vector2 direction = currentPosition - (Vector2)source.position;
+            if (direction.sqrMagnitude <= Mathf.Epsilon)
+            {
+                // Default to pushing right when the attacker is exactly overlapping the NPC.
+                direction = Vector2.right;
+            }
+
+            direction.Normalize();
+            float distance = Mathf.Max(0f, baseDistance);
+            if (scaleWithDamage && damage > 0)
+            {
+                float scaled = baseDistance + distancePerDamagePoint * damage;
+                distance = Mathf.Clamp(scaled, 0f, maxScaledDistance);
+            }
+
+            float duration = Mathf.Max(0.01f, knockbackDuration);
+            AnimationCurve curveToUse = knockbackCurve != null && knockbackCurve.length > 0
+                ? knockbackCurve
+                : AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
+
+            Vector2 desiredEnd = currentPosition + direction * distance;
+            if (clampToMovementBounds)
+                desiredEnd = wanderer.ClampToMovementBounds(desiredEnd);
+
+            wanderer.ApplyKnockback(direction, Vector2.Distance(currentPosition, desiredEnd), duration, clampToMovementBounds, curveToUse);
+        }
+
+        /// <summary>
+        /// Immediately cancels any active knockback interpolation.
+        /// </summary>
+        public void CancelKnockback()
+        {
+            if (wanderer == null)
+                return;
+
+            wanderer.CancelKnockback();
+        }
+    }
+}

--- a/Assets/Scripts/NPC/Combat/NpcKnockbackReceiver.cs.meta
+++ b/Assets/Scripts/NPC/Combat/NpcKnockbackReceiver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2a6a9b1d4474b0f41b7f62e6a86fba13
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/NPC/Movement/NpcWanderer.cs
+++ b/Assets/Scripts/NPC/Movement/NpcWanderer.cs
@@ -52,6 +52,15 @@ namespace NPC
         private float _lerpTime;
         private bool _frozen;
 
+        // Knockback state
+        private bool _knockbackActive;
+        private float _knockbackTimer;
+        private float _knockbackDuration;
+        private Vector2 _knockbackStart;
+        private Vector2 _knockbackEnd;
+        private AnimationCurve _knockbackCurve = AnimationCurve.Linear(0f, 0f, 1f, 1f);
+        private bool _knockbackClamp;
+
         // Ticker subscription management
         private Coroutine _tickerSubscriptionRoutine;
         private bool _tickerSubscribed;
@@ -105,6 +114,7 @@ namespace NPC
 
         public void SetOrigin(Vector2 origin)
         {
+            CancelKnockback();
             _origin = origin;
             _lastPos = origin;
             _from = _to = origin;
@@ -118,11 +128,13 @@ namespace NPC
 
         private void OnDisable()
         {
+            CancelKnockback();
             ReleaseTickerSubscription();
         }
 
         private void BeginIdle()
         {
+            CancelKnockback();
             _waiting = true;
             _waitTimer = Random.Range(minIdleTime, maxIdleTime);
             spriteAnimator?.UpdateVisuals(Vector2.zero);
@@ -148,6 +160,7 @@ namespace NPC
 
         public void EnterCombat(Transform target)
         {
+            CancelKnockback();
             if (!_combatTargets.Contains(target))
                 _combatTargets.Add(target);
             _target = _rb != null ? _rb.position : (Vector2)transform.position;
@@ -169,8 +182,64 @@ namespace NPC
 
         public void ForceReturnToOrigin()
         {
+            CancelKnockback();
             _target = _origin;
             _waiting = false;
+        }
+
+        /// <summary>
+        /// Applies a knockback impulse handled by this wanderer. The NPC will interpolate
+        /// between the current position and the resolved destination using the supplied curve.
+        /// </summary>
+        public void ApplyKnockback(Vector2 direction, float distance, float duration, bool clamp, AnimationCurve curve)
+        {
+            if (direction.sqrMagnitude <= Mathf.Epsilon || distance <= 0f)
+                return;
+
+            Vector2 current = _rb != null ? _rb.position : (Vector2)transform.position;
+            CancelKnockback();
+
+            Vector2 normalisedDirection = direction.normalized;
+            Vector2 destination = current + normalisedDirection * distance;
+            if (clamp)
+                destination = ClampToMovementBounds(destination);
+
+            if (Vector2.Distance(current, destination) <= Mathf.Epsilon)
+                return;
+
+            _knockbackStart = current;
+            _knockbackEnd = destination;
+            _knockbackDuration = Mathf.Max(0.01f, duration);
+            _knockbackTimer = 0f;
+            _knockbackCurve = curve != null && curve.length > 0 ? curve : AnimationCurve.EaseInOut(0f, 0f, 1f, 1f);
+            _knockbackClamp = clamp;
+            _knockbackActive = true;
+            _waiting = false;
+            _from = current;
+            _to = current;
+            _lerpTime = Ticker.TickDuration;
+        }
+
+        /// <summary>
+        /// Aborts any active knockback motion and locks the NPC to its current position.
+        /// </summary>
+        public void CancelKnockback()
+        {
+            bool wasActive = _knockbackActive;
+            _knockbackActive = false;
+            _knockbackTimer = 0f;
+
+            if (!wasActive)
+                return;
+
+            Vector2 current = _rb != null ? _rb.position : (Vector2)transform.position;
+            _knockbackStart = current;
+            _knockbackEnd = current;
+            _from = current;
+            _to = current;
+            _lerpTime = Ticker.TickDuration;
+            _lastPos = current;
+            spriteAnimator?.UpdateVisuals(Vector2.zero);
         }
 
         /// <summary>True when a freeze effect is preventing the NPC from moving.</summary>
@@ -285,6 +354,12 @@ namespace NPC
             float delta = Ticker.TickDuration;
             const float DISTANCE_EPSILON = 0.05f;
 
+            if (_knockbackActive)
+            {
+                _lerpTime = Ticker.TickDuration;
+                return;
+            }
+
             if (_frozen)
             {
                 _from = _rb != null ? _rb.position : (Vector2)transform.position;
@@ -375,6 +450,32 @@ namespace NPC
 
         private void Update()
         {
+            if (_knockbackActive)
+            {
+                _knockbackTimer += Time.deltaTime;
+                float progress = _knockbackDuration > 0f ? Mathf.Clamp01(_knockbackTimer / _knockbackDuration) : 1f;
+                float eased = _knockbackCurve != null && _knockbackCurve.length > 0 ? _knockbackCurve.Evaluate(progress) : progress;
+                Vector2 target = Vector2.LerpUnclamped(_knockbackStart, _knockbackEnd, eased);
+                if (_knockbackClamp)
+                    target = ClampToMovementBounds(target);
+
+                if (_rb != null) _rb.MovePosition(target);
+                else transform.position = target;
+
+                Vector2 knockbackVelocity = (target - _lastPos) / Mathf.Max(Time.deltaTime, 0.0001f);
+                spriteAnimator?.UpdateVisuals(knockbackVelocity);
+                _lastPos = target;
+
+                if (_knockbackTimer >= _knockbackDuration)
+                {
+                    _knockbackActive = false;
+                    _from = target;
+                    _to = target;
+                    _lerpTime = Ticker.TickDuration;
+                }
+                return;
+            }
+
             if (_frozen)
             {
                 // Maintain the frozen position without reusing the interpolated movement variable name below.

--- a/README.md
+++ b/README.md
@@ -72,3 +72,7 @@ This project currently targets **Unity 6000.2.3f1**.
 3. Run existing tests through the Unity Test Runner before submitting.
 4. Open a pull request with a clear description of your changes.
 
+## NPC Setup Notes
+- Add `NpcKnockbackReceiver` alongside `NpcWanderer` on light NPC prefabs to enable damage-driven knockback. The receiver defaults to easing the displacement over a short duration while clamping to wander bounds so goblins stay near their spawn tile.
+- Heavy or raid-class NPCs can omit the receiver (or disable the `enableKnockback` toggle) to stay rooted. Leaving the component absent on `NPC_GOBLIN_WARCHIEF` keeps the boss-style goblin stationary.
+- Designers can tune knockback by adjusting the base distance, duration, and damage scaling curve directly on the component. The wanderer now exposes `ApplyKnockback`/`CancelKnockback` helpers should scripted events need to fire custom impulses.


### PR DESCRIPTION
## Summary
- add an `NpcKnockbackReceiver` component that scales impulses from player damage and clamps to wander bounds
- extend `NpcWanderer` with knockback interpolation, cancellation hooks, and ensure reset paths halt active impulses
- integrate the receiver into `NpcCombatant`, update goblin prefabs with tuned settings, and document setup expectations

## Testing
- not run (Unity editor unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68da8a100488832ea410a28d4bba8ff0