### PR TITLE
Add combat line-of-sight checks for players and NPCs

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -90,6 +90,10 @@ namespace Combat
         [SerializeField, Tooltip("Vertical offset used when no dedicated floating text anchor is found.")]
         private float hitsplatFallbackOffset = 1.1f;
 
+        [Header("Line of Sight")]
+        [SerializeField, Tooltip("Layers considered solid when checking whether swings or spells have a clear path to the target.")]
+        private LayerMask obstructionMask = LayerMask.GetMask("Obstacles", "Physical Objects");
+
         private Sprite damageHitsplat;
         private Sprite zeroHitsplat;
         private Sprite maxHitHitsplat;
@@ -138,6 +142,11 @@ namespace Combat
                 return false;
             if (Vector2.Distance(transform.position, target.transform.position) > GetCurrentAttackRange())
                 return false;
+            if (!HasLineOfSight(target.transform))
+            {
+                nextAttackTime = Mathf.Max(nextAttackTime, Time.time + CombatMath.TICK_SECONDS);
+                return false;
+            }
             if (Time.time < nextAttackTime && attackRoutine == null)
                 return false;
             if (attackRoutine != null)
@@ -333,6 +342,11 @@ namespace Combat
             {
                 if (Vector2.Distance(transform.position, target.transform.position) > GetCurrentAttackRange())
                     break;
+                if (!HasLineOfSight(target.transform))
+                {
+                    yield return new WaitForSeconds(CombatMath.TICK_SECONDS * 0.25f);
+                    continue;
+                }
                 mover?.FaceTarget(target.transform);
                 OnAttackStart?.Invoke();
                 ResolveAttack(target);
@@ -481,7 +495,18 @@ namespace Combat
             return finalDamage;
         }
 
-        private void ResolveAttack(CombatTarget target)
+        protected virtual bool HasLineOfSight(Transform targetTransform)
+        {
+            if (targetTransform == null)
+                return false;
+
+            Vector2 origin = transform.position;
+            Vector2 destination = targetTransform.position;
+
+            return LineOfSightUtility.HasLineOfSight(origin, destination, obstructionMask, transform, targetTransform);
+        }
+
+        protected virtual void ResolveAttack(CombatTarget target)
         {
             CombatantStats attacker;
             if (combatBinder != null)

--- a/Assets/Scripts/Combat/LineOfSightUtility.cs
+++ b/Assets/Scripts/Combat/LineOfSightUtility.cs
@@ -1,0 +1,110 @@
+using System;
+using UnityEngine;
+using Pets;
+using Player;
+
+namespace Combat
+{
+    /// <summary>
+    /// Helper methods for resolving line-of-sight checks between combatants while
+    /// respecting friendly units and designer-configured obstruction masks.
+    /// </summary>
+    public static class LineOfSightUtility
+    {
+        /// <summary>
+        /// Determines whether any collider on the supplied <paramref name="mask"/>
+        /// blocks the sightline between <paramref name="origin"/> and
+        /// <paramref name="destination"/>.
+        /// </summary>
+        /// <param name="origin">World-space starting position for the trace.</param>
+        /// <param name="destination">World-space point the trace should reach.</param>
+        /// <param name="mask">Layer mask describing which colliders can obstruct vision.</param>
+        /// <param name="source">Transform representing the attacker. Used to
+        /// ignore self-collisions.</param>
+        /// <param name="target">Transform representing the intended victim. Used to
+        /// ignore the target's colliders.</param>
+        /// <param name="additionalIgnore">Optional predicate that can skip specific
+        /// colliders (pets, friendlies, etc.). When supplied, colliders returning true
+        /// will not be treated as blockers.</param>
+        /// <returns>True when no blocking collider lies between the two points.</returns>
+        public static bool HasLineOfSight(
+            Vector2 origin,
+            Vector2 destination,
+            LayerMask mask,
+            Transform source,
+            Transform target,
+            Func<Collider2D, bool> additionalIgnore = null)
+        {
+            if (mask == 0)
+                return true;
+
+            Vector2 toTarget = destination - origin;
+            float distance = toTarget.magnitude;
+            if (distance <= Mathf.Epsilon)
+                return true;
+
+            Vector2 direction = toTarget / distance;
+            // Nudge the origin forward slightly so colliders on the attacker do not
+            // immediately trigger the ray.
+            origin += direction * 0.05f;
+
+            var hits = Physics2D.RaycastAll(origin, direction, distance, mask);
+            if (hits == null || hits.Length == 0)
+                return true;
+
+            Array.Sort(hits, static (a, b) => a.distance.CompareTo(b.distance));
+
+            for (int i = 0; i < hits.Length; i++)
+            {
+                var hit = hits[i];
+                var collider = hit.collider;
+                if (collider == null)
+                    continue;
+
+                if (collider.isTrigger)
+                    continue;
+
+                var hitTransform = collider.transform;
+                if (source != null && (hitTransform == source || hitTransform.IsChildOf(source)))
+                    continue;
+                if (target != null && (hitTransform == target || hitTransform.IsChildOf(target)))
+                    continue;
+
+                if (additionalIgnore != null && additionalIgnore(collider))
+                    continue;
+
+                // Ignore colliders belonging to combatants so follower pets or party
+                // members do not block melee swings or projectiles.
+                if (IsFriendlyCollider(collider))
+                    continue;
+
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Determines whether the supplied collider belongs to a combatant that should
+        /// not obstruct the line-of-sight tests (players, pets, allies).
+        /// </summary>
+        private static bool IsFriendlyCollider(Collider2D collider)
+        {
+            if (collider == null)
+                return false;
+
+            var transform = collider.transform;
+            if (transform == null)
+                return false;
+
+            // Pets and player combat targets are treated as friendlies so they do not
+            // block their owner's attacks.
+            if (transform.GetComponentInParent<PetCombatController>() != null)
+                return true;
+            if (transform.GetComponentInParent<PlayerCombatTarget>() != null)
+                return true;
+
+            return false;
+        }
+    }
+}

--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -35,6 +35,10 @@ namespace NPC
         /// </summary>
         protected float nextAttackTimestamp;
 
+        [Header("Line of Sight")]
+        [SerializeField, Tooltip("Layers treated as solid when determining whether attacks can reach a target.")]
+        protected LayerMask obstructionMask = LayerMask.GetMask("Obstacles", "Physical Objects");
+
         private bool inCombat;
         public bool InCombat => inCombat;
         public event System.Action<bool> OnCombatStateChanged;
@@ -459,6 +463,12 @@ namespace NPC
                     if (lostTargetDuringCooldown)
                         break;
 
+                    if (!HasLineOfSight(target, targetTransform))
+                    {
+                        yield return new WaitForSeconds(CombatMath.TICK_SECONDS * 0.25f);
+                        continue;
+                    }
+
                     ResolveAttack(target);
 
                     // Advance the shared timestamp so every active target respects the NPC's
@@ -603,6 +613,61 @@ namespace NPC
 
             if (keyToRemove != null)
                 dictionary.Remove(keyToRemove);
+        }
+
+        protected virtual bool HasLineOfSight(CombatTarget target, Transform targetTransform)
+        {
+            if (targetTransform == null)
+                return false;
+
+            Vector2 origin = transform.position;
+            Vector2 destination = targetTransform.position;
+
+            return LineOfSightUtility.HasLineOfSight(
+                origin,
+                destination,
+                obstructionMask,
+                transform,
+                targetTransform,
+                collider => ShouldIgnoreCollider(collider, target));
+        }
+
+        private bool ShouldIgnoreCollider(Collider2D collider, CombatTarget target)
+        {
+            if (collider == null)
+                return false;
+
+            var hitTransform = collider.transform;
+            if (hitTransform == null)
+                return false;
+
+            // Ignore this NPC's own colliders and those belonging to the intended target.
+            if (combatant != null && hitTransform.GetComponentInParent<NpcCombatant>() == combatant)
+                return true;
+
+            if (target != null)
+            {
+                var targetCombatant = hitTransform.GetComponentInParent<CombatTarget>();
+                if (ReferenceEquals(targetCombatant, target))
+                    return true;
+            }
+
+            // Allow pets and friendly NPCs to stand between combatants without blocking attacks.
+            var pet = hitTransform.GetComponentInParent<PetCombatController>();
+            if (pet != null)
+                return true;
+
+            if (combatant != null)
+            {
+                var otherNpc = hitTransform.GetComponentInParent<NpcCombatant>();
+                if (otherNpc != null && otherNpc != combatant)
+                {
+                    if (!combatant.IsEnemy(otherNpc.Faction))
+                        return true;
+                }
+            }
+
+            return false;
         }
 
         protected virtual void ResolveAttack(CombatTarget target)

--- a/Assets/Tests/CombatLineOfSightTests.cs
+++ b/Assets/Tests/CombatLineOfSightTests.cs
@@ -1,0 +1,222 @@
+using System.Collections;
+using System.Reflection;
+using Combat;
+using NPC;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+/// <summary>
+/// Validates that the new line-of-sight checks prevent combat resolution when
+/// a blocking collider sits between combatants, while still allowing attacks
+/// when the path is clear.
+/// </summary>
+public class CombatLineOfSightTests
+{
+    private class DummyTarget : MonoBehaviour, CombatTarget
+    {
+        public bool alive = true;
+        public bool IsAlive => alive;
+        public DamageType PreferredDefenceType => DamageType.Melee;
+        public int CurrentHP => 10;
+        public int MaxHP => 10;
+        public int ApplyDamage(int amount, DamageType type, SpellElement element, object source) => amount;
+    }
+
+    private class TestCombatController : CombatController
+    {
+        private static readonly FieldInfo ObstructionMaskField = typeof(CombatController)
+            .GetField("obstructionMask", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        public bool AttackAttempted { get; private set; }
+
+        protected new void Awake()
+        {
+            // Skip the base Awake initialisation so the test does not require the
+            // full player combat setup. The tests configure the required state
+            // manually through reflection where necessary.
+        }
+
+        protected override void ResolveAttack(CombatTarget target)
+        {
+            AttackAttempted = true;
+        }
+
+        public void ResetAttackFlag()
+        {
+            AttackAttempted = false;
+        }
+
+        public void SetObstructionMask(LayerMask mask)
+        {
+            ObstructionMaskField.SetValue(this, mask);
+        }
+    }
+
+    private class TestNpcCombat : BaseNpcCombat
+    {
+        public bool AttackAttempted { get; private set; }
+
+        protected override void ResolveAttack(CombatTarget target)
+        {
+            AttackAttempted = true;
+        }
+
+        public void ResetAttackFlag()
+        {
+            AttackAttempted = false;
+        }
+
+        public void SetObstructionMask(LayerMask mask)
+        {
+            obstructionMask = mask;
+        }
+    }
+
+    private static int EnsureLayer(string preferred)
+    {
+        int layer = LayerMask.NameToLayer(preferred);
+        return layer >= 0 ? layer : 0;
+    }
+
+    private static LayerMask BuildMaskForLayer(int layer)
+    {
+        return 1 << layer;
+    }
+
+    private static GameObject CreateWall(int layer, Vector3 position)
+    {
+        var wall = new GameObject("TestWall");
+        wall.layer = layer;
+        var collider = wall.AddComponent<BoxCollider2D>();
+        collider.size = new Vector2(0.25f, 1f);
+        wall.transform.position = position;
+        return wall;
+    }
+
+    private static DummyTarget CreateTarget(Vector3 position)
+    {
+        var targetGo = new GameObject("Target");
+        var target = targetGo.AddComponent<DummyTarget>();
+        targetGo.transform.position = position;
+        return target;
+    }
+
+    private static TestCombatController CreatePlayerController(LayerMask mask)
+    {
+        var go = new GameObject("PlayerCombatController");
+        var controller = go.AddComponent<TestCombatController>();
+        controller.SetObstructionMask(mask);
+        return controller;
+    }
+
+    private static TestNpcCombat CreateNpcController(LayerMask mask, out GameObject spawner)
+    {
+        // Ensure a ground item spawner exists so the NpcDropper dependency
+        // initialised by NpcCombatant can resolve without warnings.
+        spawner = new GameObject("GroundItemSpawner");
+        spawner.AddComponent<MyGame.Drops.GroundItemSpawner>();
+
+        // Provide a shared hitsplat library so NpcCombatant does not log an error
+        // during Awake when it attempts to cache its visual references.
+        var hitsplatLibrary = ScriptableObject.CreateInstance<HitSplatLibrary>();
+        var sharedField = typeof(NpcCombatant).GetField("sharedHitSplatLibrary",
+            BindingFlags.Static | BindingFlags.NonPublic);
+        sharedField.SetValue(null, hitsplatLibrary);
+
+        var npcGo = new GameObject("NpcCombatRoot");
+        var npc = npcGo.AddComponent<TestNpcCombat>();
+        npc.SetObstructionMask(mask);
+        return npc;
+    }
+
+    [UnityTest]
+    public IEnumerator PlayerLineOfSight_AllowsAttackWhenClear()
+    {
+        int obstacleLayer = EnsureLayer("Obstacles");
+        var mask = BuildMaskForLayer(obstacleLayer);
+        var controller = CreatePlayerController(mask);
+        var target = CreateTarget(new Vector3(0f, 1.5f, 0f));
+
+        bool started = controller.TryAttackTarget(target);
+        Assert.IsTrue(started, "Attack should start when nothing blocks the path.");
+
+        // Allow the coroutine a frame to invoke the overridden ResolveAttack.
+        yield return null;
+        Assert.IsTrue(controller.AttackAttempted, "Attack coroutine should resolve when line-of-sight is clear.");
+
+        Object.DestroyImmediate(controller.gameObject);
+        Object.DestroyImmediate(target.gameObject);
+    }
+
+    [UnityTest]
+    public IEnumerator PlayerLineOfSight_BlocksAttackWhenObstructed()
+    {
+        int obstacleLayer = EnsureLayer("Obstacles");
+        var mask = BuildMaskForLayer(obstacleLayer);
+        var controller = CreatePlayerController(mask);
+        var target = CreateTarget(new Vector3(0f, 1.5f, 0f));
+        var wall = CreateWall(obstacleLayer, new Vector3(0f, 0.75f, 0f));
+
+        bool started = controller.TryAttackTarget(target);
+        Assert.IsFalse(started, "Attack should be rejected when geometry blocks line-of-sight.");
+        Assert.IsFalse(controller.AttackAttempted, "ResolveAttack should not run while an obstruction exists.");
+
+        Object.DestroyImmediate(controller.gameObject);
+        Object.DestroyImmediate(target.gameObject);
+        Object.DestroyImmediate(wall);
+    }
+
+    [UnityTest]
+    public IEnumerator NpcLineOfSight_AllowsAttackWhenClear()
+    {
+        int obstacleLayer = EnsureLayer("Obstacles");
+        var mask = BuildMaskForLayer(obstacleLayer);
+        var npc = CreateNpcController(mask, out var spawner);
+        var target = CreateTarget(new Vector3(0f, 1.5f, 0f));
+
+        npc.BeginAttacking(target);
+
+        int frames = 0;
+        const int maxFrames = 120;
+        while (!npc.AttackAttempted && frames < maxFrames)
+        {
+            frames++;
+            yield return null;
+        }
+
+        Assert.IsTrue(npc.AttackAttempted, "NPC should resolve an attack when the path is unobstructed.");
+
+        Object.DestroyImmediate(npc.gameObject);
+        Object.DestroyImmediate(target.gameObject);
+        Object.DestroyImmediate(spawner);
+    }
+
+    [UnityTest]
+    public IEnumerator NpcLineOfSight_BlocksAttackWhenObstructed()
+    {
+        int obstacleLayer = EnsureLayer("Obstacles");
+        var mask = BuildMaskForLayer(obstacleLayer);
+        var npc = CreateNpcController(mask, out var spawner);
+        var target = CreateTarget(new Vector3(0f, 1.5f, 0f));
+        var wall = CreateWall(obstacleLayer, new Vector3(0f, 0.75f, 0f));
+
+        npc.BeginAttacking(target);
+
+        int frames = 0;
+        const int maxFrames = 120;
+        while (frames < maxFrames)
+        {
+            frames++;
+            yield return null;
+            Assert.IsFalse(npc.AttackAttempted, "ResolveAttack should be skipped while the wall blocks the target.");
+        }
+
+        Assert.IsFalse(npc.AttackAttempted, "NPC should not attack a target hidden behind an obstruction.");
+
+        Object.DestroyImmediate(npc.gameObject);
+        Object.DestroyImmediate(target.gameObject);
+        Object.DestroyImmediate(wall);
+        Object.DestroyImmediate(spawner);
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared 2D line-of-sight utility and expose layer-mask controls on player and NPC combat
- gate CombatController and BaseNpcCombat attack routines on clear sightlines and delay when blocked
- create play mode tests verifying walls stop attacks for both players and NPCs while open space remains valid

## Testing
- not run (Unity play mode tests require the editor runtime)

------
https://chatgpt.com/codex/tasks/task_e_68daa660bbc8832ea2fbe6439b68df0e