### PR TITLE
Guard combat line of sight tests behind UNITY_INCLUDE_TESTS

### DIFF
--- a/Assets/Tests/CombatLineOfSightTests.cs
+++ b/Assets/Tests/CombatLineOfSightTests.cs
@@ -1,3 +1,8 @@
+// These integration-style tests rely on Unity's play mode test runner. They are wrapped
+// in UNITY_INCLUDE_TESTS so the file is excluded from player builds where the test
+// assemblies are not available, preventing compile errors from missing UnityTest
+// attributes when the Test Runner package is stripped.
+#if UNITY_INCLUDE_TESTS
 using System.Collections;
 using System.Reflection;
 using Combat;
@@ -220,3 +225,4 @@ public class CombatLineOfSightTests
         Object.DestroyImmediate(spawner);
     }
 }
+#endif


### PR DESCRIPTION
## Summary
- wrap the combat line of sight play mode tests in a UNITY_INCLUDE_TESTS guard
- prevent compile errors when the Unity test assemblies are excluded from player builds

## Testing
- not run (tests require Unity environment)


------
https://chatgpt.com/codex/tasks/task_e_68dab6329efc832e8ff7311bdac00a5c