### PR TITLE
Fix combat obstruction mask initialization

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -91,8 +91,10 @@ namespace Combat
         private float hitsplatFallbackOffset = 1.1f;
 
         [Header("Line of Sight")]
+        private static readonly string[] DefaultObstructionLayers = { "Obstacles", "Physical Objects" };
+
         [SerializeField, Tooltip("Layers considered solid when checking whether swings or spells have a clear path to the target.")]
-        private LayerMask obstructionMask = LayerMask.GetMask("Obstacles", "Physical Objects");
+        private LayerMask obstructionMask;
 
         private Sprite damageHitsplat;
         private Sprite zeroHitsplat;
@@ -102,6 +104,8 @@ namespace Combat
 
         private void Awake()
         {
+            EnsureObstructionMaskConfigured();
+
             // Grab required components from this object, falling back to parent/children so the
             // controller still works if supporting components live elsewhere in the hierarchy.
             skills = GetComponent<SkillManager>() ?? GetComponentInParent<SkillManager>() ?? GetComponentInChildren<SkillManager>();
@@ -131,6 +135,22 @@ namespace Combat
                 maxHitHitsplat = hitSplatLibrary.MaxHitHitsplat;
                 elementHitsplats = hitSplatLibrary.ElementHitsplats;
             }
+        }
+
+        private void OnValidate()
+        {
+            EnsureObstructionMaskConfigured();
+        }
+
+        /// <summary>
+        /// Ensures the obstruction mask contains the expected default layers when unset.
+        /// </summary>
+        private void EnsureObstructionMaskConfigured()
+        {
+            if (obstructionMask.value != 0)
+                return;
+
+            obstructionMask = LayerMask.GetMask(DefaultObstructionLayers);
         }
 
         /// <summary>

--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -35,9 +35,11 @@ namespace NPC
         /// </summary>
         protected float nextAttackTimestamp;
 
+        private static readonly string[] DefaultObstructionLayers = { "Obstacles", "Physical Objects" };
+
         [Header("Line of Sight")]
         [SerializeField, Tooltip("Layers treated as solid when determining whether attacks can reach a target.")]
-        protected LayerMask obstructionMask = LayerMask.GetMask("Obstacles", "Physical Objects");
+        protected LayerMask obstructionMask;
 
         private bool inCombat;
         public bool InCombat => inCombat;
@@ -53,12 +55,29 @@ namespace NPC
 
         protected virtual void Awake()
         {
+            EnsureObstructionMaskConfigured();
             combatant = GetComponent<NpcCombatant>();
             wanderer = GetComponent<NpcWanderer>();
             playerTarget = FindObjectOfType<PlayerCombatTarget>();
             spawnPosition = transform.position;
             npcFacing = GetComponent<NpcFacing>();
             nextAttackTimestamp = Time.time;
+        }
+
+        protected virtual void OnValidate()
+        {
+            EnsureObstructionMaskConfigured();
+        }
+
+        /// <summary>
+        /// Ensures the obstruction mask defaults to the expected obstacle layers when unset.
+        /// </summary>
+        private void EnsureObstructionMaskConfigured()
+        {
+            if (obstructionMask.value != 0)
+                return;
+
+            obstructionMask = LayerMask.GetMask(DefaultObstructionLayers);
         }
 
         public virtual void ResetCombatState(bool resetSpawnPosition = false)


### PR DESCRIPTION
## Summary
- ensure NPC and player combat controllers lazily configure obstruction layer masks during Awake instead of constructors
- add editor-time validation so default obstacle layers are reapplied when unset

## Testing
- not run (Unity environment unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dab9835430832e855c2d4aea5e2bc3