### PR TITLE
Adjust line of sight for anti melee obstacles

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -91,7 +91,13 @@ namespace Combat
         private float hitsplatFallbackOffset = 1.1f;
 
         [Header("Line of Sight")]
-        private static readonly string[] DefaultObstructionLayers = { "Obstacles", "Obstacle", "Physical Objects" };
+        private static readonly string[] DefaultObstructionLayers =
+        {
+            "Obstacles",
+            "Obstacle",
+            "Physical Objects",
+            LineOfSightUtility.AntiMeleeObstacleLayerName
+        };
 
         [SerializeField, Tooltip("Layers considered solid when checking whether swings or spells have a clear path to the target.")]
         private LayerMask obstructionMask;
@@ -522,8 +528,34 @@ namespace Combat
 
             Vector2 origin = transform.position;
             Vector2 destination = targetTransform.position;
+            DamageType attackType = DetermineActiveDamageType();
 
-            return LineOfSightUtility.HasLineOfSight(origin, destination, obstructionMask, transform, targetTransform);
+            return LineOfSightUtility.HasLineOfSight(
+                origin,
+                destination,
+                obstructionMask,
+                transform,
+                targetTransform,
+                collider => ShouldIgnoreLineOfSightCollider(collider, attackType));
+        }
+
+        /// <summary>
+        /// Determines whether the supplied collider should be ignored for the current
+        /// attack when resolving line-of-sight. Anti-melee obstacles only block melee
+        /// swings while allowing ranged and magic projectiles to pass through.
+        /// </summary>
+        /// <param name="collider">Collider hit by the visibility raycast.</param>
+        /// <param name="attackType">Damage type for the pending attack.</param>
+        /// <returns>True when the collider should be skipped.</returns>
+        protected virtual bool ShouldIgnoreLineOfSightCollider(Collider2D collider, DamageType attackType)
+        {
+            if (collider == null)
+                return false;
+
+            if (attackType != DamageType.Melee && LineOfSightUtility.IsAntiMeleeObstacle(collider))
+                return true;
+
+            return false;
         }
 
         protected virtual void ResolveAttack(CombatTarget target)

--- a/Assets/Scripts/Combat/LineOfSightUtility.cs
+++ b/Assets/Scripts/Combat/LineOfSightUtility.cs
@@ -12,6 +12,32 @@ namespace Combat
     public static class LineOfSightUtility
     {
         /// <summary>
+        /// Name of the physics layer used to flag colliders that should only block
+        /// melee attacks. Magic and ranged projectiles can pass through them.
+        /// </summary>
+        public const string AntiMeleeObstacleLayerName = "AntiMeleeObstacle";
+
+        /// <summary>
+        /// Cached layer index for <see cref="AntiMeleeObstacleLayerName"/>. Unity
+        /// returns -1 when the layer has not been defined in the project.
+        /// </summary>
+        private static int antiMeleeObstacleLayer = -2;
+
+        /// <summary>
+        /// Provides the resolved layer index for
+        /// <see cref="AntiMeleeObstacleLayerName"/> while caching the lookup.
+        /// </summary>
+        private static int AntiMeleeObstacleLayer
+        {
+            get
+            {
+                if (antiMeleeObstacleLayer == -2)
+                    antiMeleeObstacleLayer = LayerMask.NameToLayer(AntiMeleeObstacleLayerName);
+                return antiMeleeObstacleLayer;
+            }
+        }
+
+        /// <summary>
         /// Determines whether any collider on the supplied <paramref name="mask"/>
         /// blocks the sightline between <paramref name="origin"/> and
         /// <paramref name="destination"/>.
@@ -82,6 +108,24 @@ namespace Combat
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Returns true when the supplied collider is configured as an
+        /// anti-melee obstacle layer. Magic and ranged attacks can optionally
+        /// ignore these colliders when computing line-of-sight checks.
+        /// </summary>
+        /// <param name="collider">Collider to inspect.</param>
+        public static bool IsAntiMeleeObstacle(Collider2D collider)
+        {
+            if (collider == null)
+                return false;
+
+            int layerIndex = AntiMeleeObstacleLayer;
+            if (layerIndex < 0)
+                return false;
+
+            return collider.gameObject.layer == layerIndex;
         }
 
         /// <summary>

--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -35,7 +35,13 @@ namespace NPC
         /// </summary>
         protected float nextAttackTimestamp;
 
-        private static readonly string[] DefaultObstructionLayers = { "Obstacles", "Obstacle", "Physical Objects" };
+        private static readonly string[] DefaultObstructionLayers =
+        {
+            "Obstacles",
+            "Obstacle",
+            "Physical Objects",
+            LineOfSightUtility.AntiMeleeObstacleLayerName
+        };
 
         [Header("Line of Sight")]
         [SerializeField, Tooltip("Layers treated as solid when determining whether attacks can reach a target.")]
@@ -641,6 +647,7 @@ namespace NPC
 
             Vector2 origin = transform.position;
             Vector2 destination = targetTransform.position;
+            DamageType attackType = DetermineActiveDamageType();
 
             return LineOfSightUtility.HasLineOfSight(
                 origin,
@@ -648,10 +655,28 @@ namespace NPC
                 obstructionMask,
                 transform,
                 targetTransform,
-                collider => ShouldIgnoreCollider(collider, target));
+                collider => ShouldIgnoreCollider(collider, target, attackType));
         }
 
-        private bool ShouldIgnoreCollider(Collider2D collider, CombatTarget target)
+        /// <summary>
+        /// Resolves the damage type the NPC will use for its current attack cycle.
+        /// Default behaviour inspects the combat profile but can be overridden for
+        /// special-case bosses with dynamic styles.
+        /// </summary>
+        protected virtual DamageType DetermineActiveDamageType()
+        {
+            if (combatant == null)
+                return DamageType.Melee;
+
+            var profile = combatant.Profile;
+            if (profile != null)
+                return profile.AttackType;
+
+            var stats = combatant.GetCombatantStats();
+            return stats != null ? stats.DamageType : DamageType.Melee;
+        }
+
+        private bool ShouldIgnoreCollider(Collider2D collider, CombatTarget target, DamageType attackType)
         {
             if (collider == null)
                 return false;
@@ -659,6 +684,9 @@ namespace NPC
             var hitTransform = collider.transform;
             if (hitTransform == null)
                 return false;
+
+            if (LineOfSightUtility.IsAntiMeleeObstacle(collider))
+                return attackType != DamageType.Melee;
 
             // Ignore this NPC's own colliders and those belonging to the intended target.
             if (combatant != null && hitTransform.GetComponentInParent<NpcCombatant>() == combatant)


### PR DESCRIPTION
## Summary
- allow line-of-sight checks to recognise the AntiMeleeObstacle layer
- permit ranged and magic attacks to ignore anti-melee obstacles while still blocking melee swings
- update NPC combat checks so melee NPCs respect anti-melee blockers

## Testing
- Not run (Unity environment not available)


------
https://chatgpt.com/codex/tasks/task_e_68dabf153344832e856f01c62ca3eade