### PR TITLE
Ensure default obstruction layers persist for combat masks

### DIFF
--- a/Assets/Prefabs/MainScriptObjects/Player.prefab
+++ b/Assets/Prefabs/MainScriptObjects/Player.prefab
@@ -609,8 +609,11 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d02d43035d14f0f44b973eec23f7e118, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
+  obstructionMask:
+    serializedVersion: 2
+    m_Bits: 64
   hitSplatLibrary: {fileID: 11400000, guid: 3bdb17896f374e8bb098d628ca4ba2f4, type: 2}
 --- !u!114 &2480528448797343508
 MonoBehaviour:

--- a/Assets/Prefabs/NPCS/NPC_GOBLIN_WARCHIEF.prefab
+++ b/Assets/Prefabs/NPCS/NPC_GOBLIN_WARCHIEF.prefab
@@ -376,7 +376,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   obstructionMask:
     serializedVersion: 2
-    m_Bits: 0
+    m_Bits: 64
   slamInterval: 10
   slamDamage: 10
   slamDustPrefab: {fileID: 6111494187698877684, guid: 6af1b55044c31a34db2173e37299b34e, type: 3}

--- a/Assets/Prefabs/NPCS/NPC_GOBLIN_WARMAGE.prefab
+++ b/Assets/Prefabs/NPCS/NPC_GOBLIN_WARMAGE.prefab
@@ -231,8 +231,11 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: a3499121a43ce7a4c81402d2529f06e0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
+  obstructionMask:
+    serializedVersion: 2
+    m_Bits: 64
 --- !u!114 &1276688815178828107
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -147,10 +147,12 @@ namespace Combat
         /// </summary>
         private void EnsureObstructionMaskConfigured()
         {
-            if (obstructionMask.value != 0)
-                return;
+            int defaultMask = LayerMask.GetMask(DefaultObstructionLayers);
 
-            obstructionMask = LayerMask.GetMask(DefaultObstructionLayers);
+            // Always merge in the default layers so inspector overrides can't accidentally drop
+            // physical blockers like AntiMeleeObstacle colliders from the mask.
+            int combinedMask = obstructionMask.value | defaultMask;
+            obstructionMask = combinedMask;
         }
 
         /// <summary>

--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -74,10 +74,12 @@ namespace NPC
         /// </summary>
         private void EnsureObstructionMaskConfigured()
         {
-            if (obstructionMask.value != 0)
-                return;
+            int defaultMask = LayerMask.GetMask(DefaultObstructionLayers);
 
-            obstructionMask = LayerMask.GetMask(DefaultObstructionLayers);
+            // Keep the NPC obstruction mask aligned with the shared defaults while preserving
+            // any bespoke overrides applied in prefabs or instances.
+            int combinedMask = obstructionMask.value | defaultMask;
+            obstructionMask = combinedMask;
         }
 
         public virtual void ResetCombatState(bool resetSpawnPosition = false)


### PR DESCRIPTION
## Summary
- Always merge the default obstruction layers into player and NPC combat controllers so inspector overrides cannot drop AntiMeleeObstacle coverage.
- Reserialized the player and goblin combat prefabs so the updated mask defaults persist across saves.

## Testing
- Not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68dace9c22c0832ebac58f22c63ca465