### PR TITLE
Add tile-aligned NPC pathfinding support

### DIFF
--- a/Assets/Scripts/NPC/Combat/NpcAttackController.cs
+++ b/Assets/Scripts/NPC/Combat/NpcAttackController.cs
@@ -1,11 +1,105 @@
+using Combat;
 using UnityEngine;
 
 namespace NPC
 {
     /// <summary>
     /// Handles standard NPC melee attacks using BaseNpcCombat functionality.
+    /// Falls back to the shared <see cref="PathfindingService"/> whenever line-of-sight is obstructed so the NPC can re-path around obstacles.
     /// </summary>
+    [RequireComponent(typeof(NpcPathMover))]
     public class NpcAttackController : BaseNpcCombat
     {
+        [Header("Pathfinding")]
+        [Tooltip("Minimum time between successive path requests when chasing a target without line-of-sight.")]
+        [SerializeField] private float replanCooldownSeconds = 0.6f;
+
+        [Tooltip("Optional logging that highlights when the controller triggers a replan.")]
+        [SerializeField] private bool enablePathDebugLogging;
+
+        private NpcPathMover pathMover;
+        private float nextAllowedPathRequestTime;
+
+        /// <inheritdoc />
+        protected override void Awake()
+        {
+            base.Awake();
+            pathMover = GetComponent<NpcPathMover>();
+        }
+
+        private void OnEnable()
+        {
+            if (pathMover != null)
+            {
+                pathMover.DestinationReached += HandleDestinationReached;
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (pathMover != null)
+            {
+                pathMover.DestinationReached -= HandleDestinationReached;
+                pathMover.CancelPath();
+            }
+        }
+
+        /// <inheritdoc />
+        protected override bool HasLineOfSight(CombatTarget target, Transform targetTransform)
+        {
+            bool hasLine = base.HasLineOfSight(target, targetTransform);
+            if (hasLine)
+            {
+                if (pathMover != null && pathMover.IsFollowingPath)
+                {
+                    pathMover.CancelPath();
+                }
+                return true;
+            }
+
+            if (target == null || targetTransform == null)
+            {
+                return false;
+            }
+
+            TryRequestPath(targetTransform);
+            return false;
+        }
+
+        /// <summary>
+        /// Requests a fresh path to the supplied target transform when line-of-sight is obstructed.
+        /// </summary>
+        private void TryRequestPath(Transform targetTransform)
+        {
+            if (pathMover == null)
+            {
+                return;
+            }
+
+            if (Time.time < nextAllowedPathRequestTime)
+            {
+                return;
+            }
+
+            float preferredRange = combatant != null && combatant.Profile != null
+                ? combatant.Profile.GetPreferredAttackRange()
+                : CombatMath.MELEE_RANGE;
+
+            pathMover.RequestPathTo(targetTransform.position, Mathf.Max(preferredRange, CombatMath.MELEE_RANGE));
+            nextAllowedPathRequestTime = Time.time + replanCooldownSeconds;
+
+            if (enablePathDebugLogging)
+            {
+                Debug.Log($"{name} requesting navigation path towards {targetTransform.name}.", this);
+            }
+        }
+
+        /// <summary>
+        /// Resets the replan timer once the mover reports it has reached its destination.
+        /// </summary>
+        private void HandleDestinationReached(NpcPathMover mover)
+        {
+            nextAllowedPathRequestTime = Time.time + replanCooldownSeconds;
+        }
     }
 }

--- a/Assets/Scripts/NPC/Combat/NpcFacing.cs
+++ b/Assets/Scripts/NPC/Combat/NpcFacing.cs
@@ -39,11 +39,24 @@ namespace NPC
         {
             if (target == null)
                 return;
+
             Vector2 diff = target.position - transform.position;
-            if (Mathf.Abs(diff.x) > Mathf.Abs(diff.y))
-                FacingDirection = diff.x < 0f ? 1 : 2;
+            FaceDirection(diff);
+        }
+
+        /// <summary>
+        /// Faces the supplied direction vector, updating any linked sprite animator or renderer.
+        /// </summary>
+        /// <param name="direction">Direction the NPC should face.</param>
+        public void FaceDirection(Vector2 direction)
+        {
+            if (direction.sqrMagnitude <= Mathf.Epsilon)
+                return;
+
+            if (Mathf.Abs(direction.x) > Mathf.Abs(direction.y))
+                FacingDirection = direction.x < 0f ? 1 : 2;
             else
-                FacingDirection = diff.y < 0f ? 0 : 3;
+                FacingDirection = direction.y < 0f ? 0 : 3;
 
             if (spriteAnimator != null)
                 spriteAnimator.SetFacing(FacingDirection);

--- a/Assets/Scripts/NPC/Movement/NpcPathMover.cs
+++ b/Assets/Scripts/NPC/Movement/NpcPathMover.cs
@@ -1,0 +1,579 @@
+using System.Collections.Generic;
+using UnityEngine;
+using Util;
+
+namespace NPC
+{
+    /// <summary>
+    /// Tick-driven movement helper that consumes waypoint queues from <see cref="PathfindingService"/>
+    /// and walks NPCs tile-to-tile. The mover requests replans whenever the active route becomes invalid
+    /// so NPCs can steer around newly placed fences or blockers.
+    /// </summary>
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(Rigidbody2D))]
+    public sealed class NpcPathMover : MonoBehaviour, ITickable
+    {
+        [Header("Movement")]
+        [Tooltip("Seconds spent traversing a single tile. Defaults to the OSRS tick length for grid-accurate pacing.")]
+        [SerializeField] private float tileTraverseDuration = Ticker.TickDuration;
+
+        [Tooltip("Distance considered ""close enough"" to consume a waypoint.")]
+        [SerializeField] private float waypointTolerance = 0.05f;
+
+        [Tooltip("Desired stand-off distance from the destination. Updated by combat controllers when chasing targets.")]
+        [SerializeField] private float stopDistance = 1f;
+
+        [Header("Repathing")]
+        [Tooltip("Minimum time between automatic replans.")]
+        [SerializeField] private float repathCooldownSeconds = 0.6f;
+
+        [Tooltip("If progress stalls for longer than this value the mover forces a replan.")]
+        [SerializeField] private float stuckTimeoutSeconds = 3f;
+
+        [Tooltip("Destination drift (in world units) that triggers a replan when the goal moves.")]
+        [SerializeField] private float destinationRepathThreshold = 0.75f;
+
+        [Header("Debug")]
+        [SerializeField] private bool enableDebugLogging;
+        [SerializeField] private bool drawDebugPath = true;
+        [SerializeField] private Color debugPathColor = new Color(1f, 0.75f, 0f, 0.9f);
+
+        private readonly Queue<Vector2> waypointQueue = new Queue<Vector2>();
+        private readonly List<Vector2> debugPath = new List<Vector2>();
+
+        private Rigidbody2D body;
+        private NpcWanderer wanderer;
+        private NpcFacing facing;
+        private PathfindingService pathService;
+
+        private bool subscribedToTicker;
+        private Coroutine tickerSubscriptionRoutine;
+
+        private bool awaitingPath;
+        private bool stepping;
+        private Vector2 currentStepStart;
+        private Vector2 currentStepTarget;
+        private float stepTimer;
+        private float lastProgressTimestamp;
+        private float nextAllowedRepathTime;
+        private float lastDestinationUpdate;
+
+        private Vector2 desiredDestination;
+        private Vector2 lastRequestedDestination;
+        private bool hasDestination;
+        private int activeRequestId = -1;
+        private bool wandererSuspended;
+
+        /// <summary>
+        /// Raised whenever the mover reaches its destination within the configured stop distance.
+        /// </summary>
+        public event System.Action<NpcPathMover> DestinationReached;
+
+        /// <summary>
+        /// Current stop distance applied when approaching the destination.
+        /// </summary>
+        public float StopDistance => stopDistance;
+
+        /// <summary>
+        /// Returns true while the mover is waiting on or following a path.
+        /// </summary>
+        public bool IsFollowingPath => awaitingPath || stepping || waypointQueue.Count > 0;
+
+        private void Awake()
+        {
+            body = GetComponent<Rigidbody2D>();
+            if (body != null)
+            {
+                body.bodyType = RigidbodyType2D.Kinematic;
+            }
+
+            wanderer = GetComponent<NpcWanderer>();
+            facing = GetComponent<NpcFacing>();
+            pathService = PathfindingService.Instance;
+        }
+
+        private void OnEnable()
+        {
+            SubscribeToTicker();
+        }
+
+        private void Start()
+        {
+            SubscribeToTicker();
+            EnsureServiceReference();
+        }
+
+        private void OnDisable()
+        {
+            UnsubscribeFromTicker();
+            CancelPath();
+        }
+
+        private void OnDestroy()
+        {
+            UnsubscribeFromTicker();
+        }
+
+        private void Update()
+        {
+            if (!stepping)
+            {
+                return;
+            }
+
+            stepTimer += Time.deltaTime;
+            float duration = Mathf.Max(0.01f, tileTraverseDuration);
+            float progress = Mathf.Clamp01(stepTimer / duration);
+            Vector2 interpolated = Vector2.Lerp(currentStepStart, currentStepTarget, progress);
+            ApplyPosition(interpolated);
+
+            if (progress >= 1f - Mathf.Epsilon)
+            {
+                ApplyPosition(currentStepTarget);
+                stepping = false;
+                lastProgressTimestamp = Time.time;
+                if (waypointQueue.Count == 0)
+                {
+                    ResumeWandererIfNeeded();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Configures the preferred stop distance (usually the NPC's preferred attack range).
+        /// </summary>
+        public void SetPreferredStopDistance(float distance)
+        {
+            stopDistance = Mathf.Max(0.05f, distance);
+        }
+
+        /// <summary>
+        /// Queues a path request to the supplied destination. Existing paths are cancelled.
+        /// </summary>
+        public void RequestPathTo(Vector2 destination)
+        {
+            hasDestination = true;
+            desiredDestination = destination;
+            RequestPathInternal(destination, false);
+        }
+
+        /// <summary>
+        /// Convenience overload that updates the preferred stop distance before requesting a path.
+        /// </summary>
+        public void RequestPathTo(Vector2 destination, float desiredStopDistance)
+        {
+            SetPreferredStopDistance(desiredStopDistance);
+            RequestPathTo(destination);
+        }
+
+        /// <summary>
+        /// Cancels any active path request and clears outstanding waypoints.
+        /// </summary>
+        public void CancelPath()
+        {
+            awaitingPath = false;
+            waypointQueue.Clear();
+            debugPath.Clear();
+            stepping = false;
+            activeRequestId = -1;
+            hasDestination = false;
+            ResumeWandererIfNeeded();
+        }
+
+        /// <inheritdoc />
+        public void OnTick()
+        {
+            if (hasDestination)
+            {
+                EnsureServiceReference();
+                EvaluateDestinationDrift();
+            }
+
+            if (!stepping && waypointQueue.Count > 0)
+            {
+                Vector2 next = waypointQueue.Peek();
+                if (!IsWaypointWalkable(next))
+                {
+                    ForceReplan();
+                    return;
+                }
+
+                waypointQueue.Dequeue();
+                BeginStep(next);
+            }
+
+            if (stepping)
+            {
+                if (!IsWaypointWalkable(currentStepTarget))
+                {
+                    ForceReplan();
+                    return;
+                }
+
+                if (Time.time - lastProgressTimestamp >= stuckTimeoutSeconds)
+                {
+                    ForceReplan(true);
+                    return;
+                }
+            }
+            else if (hasDestination && !awaitingPath && waypointQueue.Count == 0)
+            {
+                EvaluateArrival();
+            }
+        }
+
+        /// <summary>
+        /// Consumes the outcome of a path request issued through <see cref="PathfindingService"/>.
+        /// </summary>
+        internal void HandlePathResult(int requestId, PathfindingService.PathStatus status, List<Vector2> worldPath, Vector2 goalWorld)
+        {
+            if (requestId != activeRequestId)
+            {
+                return;
+            }
+
+            awaitingPath = false;
+            activeRequestId = -1;
+            desiredDestination = goalWorld;
+
+            if (status != PathfindingService.PathStatus.Success || worldPath == null)
+            {
+                if (enableDebugLogging)
+                {
+                    Debug.LogWarning($"NPC {name} path request {requestId} failed: {status}.", this);
+                }
+
+                ScheduleRetry();
+                return;
+            }
+
+            waypointQueue.Clear();
+            debugPath.Clear();
+
+            for (int i = 0; i < worldPath.Count; i++)
+            {
+                Vector2 waypoint = worldPath[i];
+                waypointQueue.Enqueue(waypoint);
+                debugPath.Add(waypoint);
+            }
+
+            if (enableDebugLogging)
+            {
+                Debug.Log($"NPC {name} received path {requestId} with {debugPath.Count} waypoints.", this);
+            }
+
+            if (waypointQueue.Count == 0)
+            {
+                EvaluateArrival();
+                return;
+            }
+
+            BeginStep(waypointQueue.Dequeue());
+        }
+
+        /// <summary>
+        /// Starts interpolating toward the supplied waypoint, suspending any wanderer behaviour.
+        /// </summary>
+        private void BeginStep(Vector2 destination)
+        {
+            SuspendWanderer();
+            currentStepStart = GetCurrentPosition();
+            currentStepTarget = destination;
+            stepTimer = 0f;
+            stepping = true;
+            lastProgressTimestamp = Time.time;
+
+            Vector2 direction = currentStepTarget - currentStepStart;
+            if (direction.sqrMagnitude > Mathf.Epsilon)
+            {
+                facing?.FaceDirection(direction);
+            }
+        }
+
+        /// <summary>
+        /// Checks whether the destination has moved sufficiently to warrant a fresh path request.
+        /// </summary>
+        private void EvaluateDestinationDrift()
+        {
+            if (awaitingPath)
+            {
+                return;
+            }
+
+            if (Time.time < lastDestinationUpdate + repathCooldownSeconds)
+            {
+                return;
+            }
+
+            float drift = Vector2.Distance(desiredDestination, lastRequestedDestination);
+            if (drift >= destinationRepathThreshold)
+            {
+                RequestPathInternal(desiredDestination, true);
+            }
+        }
+
+        /// <summary>
+        /// Validates whether the NPC is close enough to its destination or if another replan is required.
+        /// </summary>
+        private void EvaluateArrival()
+        {
+            Vector2 current = GetCurrentPosition();
+            if (Vector2.Distance(current, desiredDestination) <= stopDistance + waypointTolerance)
+            {
+                DestinationReached?.Invoke(this);
+                hasDestination = false;
+                ResumeWandererIfNeeded();
+            }
+            else if (Time.time >= nextAllowedRepathTime)
+            {
+                RequestPathInternal(desiredDestination, true);
+            }
+        }
+
+        /// <summary>
+        /// Forces the mover to re-request a path, optionally bypassing the standard cooldown.
+        /// </summary>
+        private void ForceReplan(bool ignoreCooldown = false)
+        {
+            if (!hasDestination)
+            {
+                return;
+            }
+
+            if (!ignoreCooldown && Time.time < nextAllowedRepathTime)
+            {
+                return;
+            }
+
+            if (enableDebugLogging)
+            {
+                Debug.Log($"NPC {name} forcing path replan.", this);
+            }
+
+            RequestPathInternal(desiredDestination, ignoreCooldown);
+        }
+
+        /// <summary>
+        /// Internal helper that queues a path request with the shared service and tracks cooldowns.
+        /// </summary>
+        private void RequestPathInternal(Vector2 destination, bool force)
+        {
+            EnsureServiceReference();
+            if (pathService == null)
+            {
+                if (enableDebugLogging)
+                {
+                    Debug.LogWarning($"NPC {name} cannot request path: service missing.", this);
+                }
+                return;
+            }
+
+            if (!force && Time.time < nextAllowedRepathTime)
+            {
+                return;
+            }
+
+            SuspendWanderer();
+            awaitingPath = true;
+            stepping = false;
+            waypointQueue.Clear();
+            debugPath.Clear();
+            desiredDestination = destination;
+            lastRequestedDestination = destination;
+            nextAllowedRepathTime = Time.time + repathCooldownSeconds;
+            lastDestinationUpdate = Time.time;
+
+            Vector2 start = GetCurrentPosition();
+            activeRequestId = pathService.RequestPath(this, start, destination);
+
+            if (activeRequestId < 0)
+            {
+                awaitingPath = false;
+                ScheduleRetry();
+                if (enableDebugLogging)
+                {
+                    Debug.LogWarning($"NPC {name} failed to queue a path request.", this);
+                }
+                return;
+            }
+
+            if (enableDebugLogging)
+            {
+                Debug.Log($"NPC {name} requested path {activeRequestId} -> {destination}.", this);
+            }
+        }
+
+        /// <summary>
+        /// Bumps the replan timer so the mover can retry once any transient issue clears.
+        /// </summary>
+        private void ScheduleRetry()
+        {
+            nextAllowedRepathTime = Time.time + repathCooldownSeconds;
+        }
+
+        /// <summary>
+        /// Verifies that a waypoint remains walkable according to the active navigation grid.
+        /// </summary>
+        private bool IsWaypointWalkable(Vector2 waypoint)
+        {
+            var grid = pathService != null ? pathService.ActiveGrid : PathfindingService.Instance?.ActiveGrid;
+            if (grid == null)
+            {
+                return true;
+            }
+
+            return grid.IsWorldPositionWalkable(waypoint);
+        }
+
+        /// <summary>
+        /// Moves the NPC to the supplied position, using the rigidbody when available.
+        /// </summary>
+        private void ApplyPosition(Vector2 position)
+        {
+            if (body != null)
+            {
+                body.MovePosition(position);
+            }
+            else
+            {
+                transform.position = new Vector3(position.x, position.y, transform.position.z);
+            }
+        }
+
+        /// <summary>
+        /// Returns the NPC's current 2D position.
+        /// </summary>
+        private Vector2 GetCurrentPosition()
+        {
+            return body != null ? body.position : (Vector2)transform.position;
+        }
+
+        /// <summary>
+        /// Temporarily disables the wanderer so tick-driven roaming does not fight manual pathing.
+        /// </summary>
+        private void SuspendWanderer()
+        {
+            if (wanderer != null && wanderer.enabled)
+            {
+                wanderer.enabled = false;
+                wandererSuspended = true;
+            }
+        }
+
+        /// <summary>
+        /// Restores wanderer behaviour after manual movement completes.
+        /// </summary>
+        private void ResumeWandererIfNeeded()
+        {
+            if (wanderer != null && wandererSuspended)
+            {
+                wanderer.enabled = true;
+                wandererSuspended = false;
+            }
+        }
+
+        /// <summary>
+        /// Caches the shared pathfinding service, bootstrapping it if necessary.
+        /// </summary>
+        private void EnsureServiceReference()
+        {
+            if (pathService == null)
+            {
+                pathService = PathfindingService.Instance;
+            }
+        }
+
+        /// <summary>
+        /// Subscribes the mover to the global ticker so it receives OSRS tick callbacks.
+        /// </summary>
+        private void SubscribeToTicker()
+        {
+            if (subscribedToTicker)
+            {
+                return;
+            }
+
+            if (Ticker.Instance == null)
+            {
+                if (tickerSubscriptionRoutine == null && isActiveAndEnabled)
+                {
+                    tickerSubscriptionRoutine = StartCoroutine(WaitForTicker());
+                }
+                return;
+            }
+
+            Ticker.Instance.Subscribe(this);
+            subscribedToTicker = true;
+        }
+
+        /// <summary>
+        /// Removes the mover from the global ticker subscription list.
+        /// </summary>
+        private void UnsubscribeFromTicker()
+        {
+            if (tickerSubscriptionRoutine != null)
+            {
+                StopCoroutine(tickerSubscriptionRoutine);
+                tickerSubscriptionRoutine = null;
+            }
+
+            if (!subscribedToTicker)
+            {
+                return;
+            }
+
+            if (Ticker.Instance != null)
+            {
+                Ticker.Instance.Unsubscribe(this);
+            }
+
+            subscribedToTicker = false;
+        }
+
+        /// <summary>
+        /// Waits for the ticker singleton to become available before registering.
+        /// </summary>
+        private System.Collections.IEnumerator WaitForTicker()
+        {
+            while (Ticker.Instance == null)
+            {
+                yield return null;
+            }
+
+            tickerSubscriptionRoutine = null;
+
+            if (!isActiveAndEnabled)
+            {
+                yield break;
+            }
+
+            Ticker.Instance.Subscribe(this);
+            subscribedToTicker = true;
+        }
+
+#if UNITY_EDITOR
+        private void OnDrawGizmos()
+        {
+            if (!drawDebugPath)
+            {
+                return;
+            }
+
+            if (debugPath == null || debugPath.Count == 0)
+            {
+                return;
+            }
+
+            Gizmos.color = debugPathColor;
+            Vector3 previous = transform.position;
+            for (int i = 0; i < debugPath.Count; i++)
+            {
+                Vector3 target = new Vector3(debugPath[i].x, debugPath[i].y, previous.z);
+                Gizmos.DrawLine(previous, target);
+                Gizmos.DrawSphere(target, 0.1f);
+                previous = target;
+            }
+        }
+#endif
+    }
+}

--- a/Assets/Scripts/NPC/Navigation/NavGridBuilder.cs
+++ b/Assets/Scripts/NPC/Navigation/NavGridBuilder.cs
@@ -1,0 +1,445 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace NPC
+{
+    /// <summary>
+    /// Builds a 2D navigation grid by sampling colliders in the scene and marking tiles as walkable or blocked.
+    /// Grids align to the 64×64 OSRS tile spacing so NPC path requests can be resolved deterministically.
+    /// </summary>
+    [ExecuteAlways]
+    [DisallowMultipleComponent]
+    public sealed class NavGridBuilder : MonoBehaviour
+    {
+        /// <summary>
+        /// Event raised whenever the grid is rebuilt.
+        /// </summary>
+        public event Action<NavGridBuilder> GridRebuilt;
+
+        [Header("Grid Dimensions")]
+        [Tooltip("World-space size of the grid. The component centres the grid on this transform.")]
+        [SerializeField] private Vector2 areaSize = new Vector2(32f, 32f);
+
+        [Tooltip("World-space size of an individual tile. 1 unit corresponds to a 64×64px OSRS tile by convention.")]
+        [SerializeField] private float tileSize = 1f;
+
+        [Tooltip("Automatically rebuild the grid when entering play mode or when the component awakes.")]
+        [SerializeField] private bool autoBuildOnEnable = true;
+
+        [Tooltip("When enabled the grid origin is snapped to the tile size so cells align to the shared OSRS tile lattice.")]
+        [SerializeField] private bool snapOriginToTile = true;
+
+        [Header("Obstacle Detection")]
+        [Tooltip("Layers treated as solid when baking the navigation grid.")]
+        [SerializeField] private LayerMask blockingLayers = 0;
+
+        [Tooltip("Optional tags that should mark colliders as blocking even when they sit outside the layer mask.")]
+        [SerializeField] private List<string> blockingTags = new List<string> { "Obstacle", "Blocking", "Wall" };
+
+        [Tooltip("Treat trigger colliders as solid when building the grid.")]
+        [SerializeField] private bool includeTriggerColliders;
+
+        [Tooltip("Sample colliders on inactive GameObjects. Disable to ignore temporarily disabled props during baking.")]
+        [SerializeField] private bool includeInactiveObjects;
+
+        [Tooltip("Padding applied to the overlap box when sampling blockers. Values below 1 shrink the sampling region slightly.")]
+        [SerializeField, Range(0.1f, 1.2f)] private float samplingPadding = 0.92f;
+
+        [Header("Validation & Debug")]
+        [Tooltip("Logs summary information whenever the grid is rebuilt.")]
+        [SerializeField] private bool enableDebugLogging;
+
+        [Tooltip("Draws the walkable grid overlay in the editor and play mode.")]
+        [SerializeField] private bool drawDebugGizmos = true;
+
+        [Tooltip("Color used for walkable cells when drawing gizmos.")]
+        [SerializeField] private Color walkableColor = new Color(0f, 0.75f, 0.2f, 0.12f);
+
+        [Tooltip("Color used for blocked cells when drawing gizmos.")]
+        [SerializeField] private Color blockedColor = new Color(0.75f, 0f, 0.1f, 0.3f);
+
+        [Tooltip("Elevates gizmos slightly so they do not z-fight with sprites in the scene.")]
+        [SerializeField] private float gizmoHeightOffset = 0.05f;
+
+        private bool[,] walkableGrid;
+        private Vector2Int gridSize;
+        private Vector2 gridOrigin;
+        private Vector2 gridWorldSize;
+        private bool gridDirty = true;
+        private int blockedCellCount;
+        private int revision;
+
+        private Vector3 lastRecordedPosition;
+        private Vector3 lastRecordedScale;
+
+        /// <summary>
+        /// Size of a single tile in world units.
+        /// </summary>
+        public float TileSize => tileSize;
+
+        /// <summary>
+        /// Number of tiles along the X/Y axes.
+        /// </summary>
+        public Vector2Int GridSize => gridSize;
+
+        /// <summary>
+        /// World-space origin of the grid (bottom-left corner).
+        /// </summary>
+        public Vector2 GridOrigin => gridOrigin;
+
+        /// <summary>
+        /// Total world-space dimensions of the baked grid.
+        /// </summary>
+        public Vector2 GridWorldSize => gridWorldSize;
+
+        /// <summary>
+        /// Indicates whether a valid grid is currently cached.
+        /// </summary>
+        public bool HasGrid => walkableGrid != null && gridSize.x > 0 && gridSize.y > 0;
+
+        /// <summary>
+        /// True when the grid should be rebuilt before being used.
+        /// </summary>
+        public bool NeedsRebuild => gridDirty || !HasGrid;
+
+        /// <summary>
+        /// Tracks how many times the grid has been rebuilt. Consumers can cache this value and detect changes.
+        /// </summary>
+        public int Revision => revision;
+
+        private void Reset()
+        {
+            lastRecordedPosition = transform.position;
+            lastRecordedScale = transform.lossyScale;
+        }
+
+        private void Awake()
+        {
+            lastRecordedPosition = transform.position;
+            lastRecordedScale = transform.lossyScale;
+            if (autoBuildOnEnable)
+            {
+                BuildGrid();
+            }
+        }
+
+        private void OnEnable()
+        {
+            if (autoBuildOnEnable && NeedsRebuild)
+            {
+                BuildGrid();
+            }
+            if (Application.isPlaying)
+            {
+                PathfindingService.Instance?.RegisterNavGrid(this);
+            }
+        }
+
+        private void OnValidate()
+        {
+            tileSize = Mathf.Max(0.01f, tileSize);
+            areaSize.x = Mathf.Max(tileSize, Mathf.Abs(areaSize.x));
+            areaSize.y = Mathf.Max(tileSize, Mathf.Abs(areaSize.y));
+            samplingPadding = Mathf.Clamp(samplingPadding, 0.1f, 1.2f);
+            gridDirty = true;
+
+            if (!Application.isPlaying && autoBuildOnEnable)
+            {
+                BuildGrid();
+            }
+        }
+
+        private void LateUpdate()
+        {
+            if (!Application.isPlaying)
+            {
+                if (transform.position != lastRecordedPosition || transform.lossyScale != lastRecordedScale)
+                {
+                    lastRecordedPosition = transform.position;
+                    lastRecordedScale = transform.lossyScale;
+                    gridDirty = true;
+                    if (autoBuildOnEnable)
+                    {
+                        BuildGrid();
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Forces the grid to rebuild immediately.
+        /// </summary>
+        [ContextMenu("Rebuild Navigation Grid")]
+        public void BuildGrid()
+        {
+            if (tileSize <= 0f)
+            {
+                Debug.LogWarning("Tile size must be positive before building the navigation grid.", this);
+                tileSize = 1f;
+            }
+
+            gridSize = new Vector2Int(
+                Mathf.Max(1, Mathf.CeilToInt(areaSize.x / tileSize)),
+                Mathf.Max(1, Mathf.CeilToInt(areaSize.y / tileSize)));
+
+            gridWorldSize = new Vector2(gridSize.x * tileSize, gridSize.y * tileSize);
+            gridOrigin = (Vector2)transform.position - gridWorldSize * 0.5f;
+            if (snapOriginToTile)
+            {
+                gridOrigin.x = Mathf.Floor(gridOrigin.x / tileSize) * tileSize;
+                gridOrigin.y = Mathf.Floor(gridOrigin.y / tileSize) * tileSize;
+            }
+
+            walkableGrid = new bool[gridSize.x, gridSize.y];
+            blockedCellCount = 0;
+
+            float halfTile = tileSize * 0.5f;
+            Vector2 sampleExtents = Vector2.one * halfTile * samplingPadding * 2f;
+            // Because OverlapBox expects size rather than extents we double the extents.
+
+            for (int y = 0; y < gridSize.y; y++)
+            {
+                for (int x = 0; x < gridSize.x; x++)
+                {
+                    Vector2 cellCenter = GetCellCenter(new Vector2Int(x, y));
+                    bool blocked = SampleBlocked(cellCenter, sampleExtents);
+                    walkableGrid[x, y] = !blocked;
+                    if (blocked)
+                    {
+                        blockedCellCount++;
+                    }
+                }
+            }
+
+            gridDirty = false;
+            revision++;
+
+            if (enableDebugLogging)
+            {
+                int totalCells = gridSize.x * gridSize.y;
+                int walkableCells = totalCells - blockedCellCount;
+                Debug.Log($"NavGridBuilder rebuilt {name}: {walkableCells} walkable / {blockedCellCount} blocked (tile size {tileSize:F2}).", this);
+            }
+
+            GridRebuilt?.Invoke(this);
+            if (Application.isPlaying)
+            {
+                PathfindingService.Instance?.RegisterNavGrid(this);
+            }
+        }
+
+        /// <summary>
+        /// Returns whether the supplied cell is inside the cached grid bounds.
+        /// </summary>
+        public bool IsCellWithinBounds(Vector2Int cell)
+        {
+            return cell.x >= 0 && cell.x < gridSize.x && cell.y >= 0 && cell.y < gridSize.y;
+        }
+
+        /// <summary>
+        /// Returns whether a specific cell is considered walkable. Returns <c>false</c> for out-of-bounds cells.
+        /// </summary>
+        public bool IsCellWalkable(Vector2Int cell)
+        {
+            if (!HasGrid || !IsCellWithinBounds(cell))
+            {
+                return false;
+            }
+
+            return walkableGrid[cell.x, cell.y];
+        }
+
+        /// <summary>
+        /// Converts a world-space position to a grid cell. Returns <c>false</c> when the position lies outside the grid.
+        /// </summary>
+        public bool TryGetCell(Vector2 worldPosition, out Vector2Int cell)
+        {
+            if (!HasGrid)
+            {
+                cell = Vector2Int.zero;
+                return false;
+            }
+
+            Vector2 offset = worldPosition - gridOrigin;
+            if (offset.x < 0f || offset.y < 0f)
+            {
+                cell = Vector2Int.zero;
+                return false;
+            }
+
+            int x = Mathf.FloorToInt(offset.x / tileSize);
+            int y = Mathf.FloorToInt(offset.y / tileSize);
+
+            cell = new Vector2Int(x, y);
+            if (!IsCellWithinBounds(cell))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Clamps the supplied cell coordinates to the grid bounds.
+        /// </summary>
+        public Vector2Int ClampToBounds(Vector2Int cell)
+        {
+            if (!HasGrid)
+            {
+                return Vector2Int.zero;
+            }
+
+            int x = Mathf.Clamp(cell.x, 0, gridSize.x - 1);
+            int y = Mathf.Clamp(cell.y, 0, gridSize.y - 1);
+            return new Vector2Int(x, y);
+        }
+
+        /// <summary>
+        /// Converts a cell coordinate back to a world-space tile centre.
+        /// </summary>
+        public Vector2 GetCellCenter(Vector2Int cell)
+        {
+            Vector2 clamped = ClampToBounds(cell);
+            return new Vector2(
+                gridOrigin.x + (clamped.x + 0.5f) * tileSize,
+                gridOrigin.y + (clamped.y + 0.5f) * tileSize);
+        }
+
+        /// <summary>
+        /// Converts a world position into the nearest cell, clamped to the grid bounds.
+        /// </summary>
+        public Vector2Int WorldToCellClamped(Vector2 worldPosition)
+        {
+            if (!HasGrid)
+            {
+                return Vector2Int.zero;
+            }
+
+            Vector2 offset = worldPosition - gridOrigin;
+            int x = Mathf.FloorToInt(offset.x / tileSize);
+            int y = Mathf.FloorToInt(offset.y / tileSize);
+            return ClampToBounds(new Vector2Int(x, y));
+        }
+
+        /// <summary>
+        /// Returns true if the world position maps to a walkable cell.
+        /// </summary>
+        public bool IsWorldPositionWalkable(Vector2 worldPosition)
+        {
+            return TryGetCell(worldPosition, out var cell) && IsCellWalkable(cell);
+        }
+
+        private bool SampleBlocked(Vector2 centre, Vector2 size)
+        {
+            bool blocked = false;
+
+            Collider2D[] hits2D = Physics2D.OverlapBoxAll(centre, size, 0f);
+            for (int i = 0; i < hits2D.Length; i++)
+            {
+                var hit = hits2D[i];
+                if (hit == null)
+                {
+                    continue;
+                }
+
+                if (!includeTriggerColliders && hit.isTrigger)
+                {
+                    continue;
+                }
+
+                if (!includeInactiveObjects && !hit.gameObject.activeInHierarchy)
+                {
+                    continue;
+                }
+
+                if (IsColliderBlocking(hit.gameObject))
+                {
+                    blocked = true;
+                    break;
+                }
+            }
+
+            if (!blocked)
+            {
+                Collider[] hits3D = Physics.OverlapBox(new Vector3(centre.x, centre.y, transform.position.z), new Vector3(size.x, size.y, tileSize) * 0.5f, Quaternion.identity);
+                for (int i = 0; i < hits3D.Length; i++)
+                {
+                    var hit = hits3D[i];
+                    if (hit == null)
+                    {
+                        continue;
+                    }
+
+                    if (!includeTriggerColliders && hit.isTrigger)
+                    {
+                        continue;
+                    }
+
+                    if (!includeInactiveObjects && !hit.gameObject.activeInHierarchy)
+                    {
+                        continue;
+                    }
+
+                    if (IsColliderBlocking(hit.gameObject))
+                    {
+                        blocked = true;
+                        break;
+                    }
+                }
+            }
+
+            return blocked;
+        }
+
+        private bool IsColliderBlocking(GameObject obj)
+        {
+            if (obj == null)
+            {
+                return false;
+            }
+
+            int layerMask = 1 << obj.layer;
+            if ((blockingLayers.value & layerMask) != 0)
+            {
+                return true;
+            }
+
+            if (blockingTags != null)
+            {
+                for (int i = 0; i < blockingTags.Count; i++)
+                {
+                    string tag = blockingTags[i];
+                    if (!string.IsNullOrEmpty(tag) && obj.CompareTag(tag))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+#if UNITY_EDITOR
+        private void OnDrawGizmos()
+        {
+            if (!drawDebugGizmos || !HasGrid)
+            {
+                return;
+            }
+
+            float z = transform.position.z + gizmoHeightOffset;
+            Vector3 size = new Vector3(tileSize, tileSize, 0f);
+            for (int y = 0; y < gridSize.y; y++)
+            {
+                for (int x = 0; x < gridSize.x; x++)
+                {
+                    Vector3 centre = new Vector3(gridOrigin.x + (x + 0.5f) * tileSize, gridOrigin.y + (y + 0.5f) * tileSize, z);
+                    Gizmos.color = walkableGrid[x, y] ? walkableColor : blockedColor;
+                    Gizmos.DrawCube(centre, size);
+                }
+            }
+        }
+#endif
+    }
+}

--- a/Assets/Scripts/NPC/Navigation/PathfindingService.cs
+++ b/Assets/Scripts/NPC/Navigation/PathfindingService.cs
@@ -1,0 +1,698 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using Util;
+using World;
+
+namespace NPC
+{
+    /// <summary>
+    /// Centralised pathfinding service that owns the baked navigation grid, processes queued path requests,
+    /// and steps an A* search incrementally each OSRS tick so NPC navigation integrates with the global ticker cadence.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public sealed class PathfindingService : ScenePersistentObject, ITickable
+    {
+        /// <summary>
+        /// Result of a path query.
+        /// </summary>
+        public enum PathStatus
+        {
+            Success,
+            GridUnavailable,
+            GoalUnreachable
+        }
+
+        private sealed class PathRequest
+        {
+            public readonly int Id;
+            public readonly WeakReference<NpcPathMover> MoverReference;
+            public readonly Vector2 StartWorld;
+            public readonly Vector2 GoalWorld;
+
+            public AStarSearch Search;
+            public Vector2Int StartCell;
+            public Vector2Int GoalCell;
+            public bool Prepared;
+
+            public PathRequest(int id, NpcPathMover mover, Vector2 start, Vector2 goal)
+            {
+                Id = id;
+                MoverReference = new WeakReference<NpcPathMover>(mover);
+                StartWorld = start;
+                GoalWorld = goal;
+                Search = new AStarSearch();
+            }
+        }
+
+        private sealed class AStarSearch
+        {
+            public readonly List<Vector2Int> OpenSet = new List<Vector2Int>();
+            public readonly HashSet<Vector2Int> ClosedSet = new HashSet<Vector2Int>();
+            public readonly Dictionary<Vector2Int, NodeRecord> Records = new Dictionary<Vector2Int, NodeRecord>();
+            public Vector2Int Start;
+            public Vector2Int Goal;
+        }
+
+        private struct NodeRecord
+        {
+            public float GCost;
+            public float HCost;
+            public Vector2Int Parent;
+            public bool HasParent;
+
+            public float FCost => GCost + HCost;
+        }
+
+        private static PathfindingService instance;
+
+        [Header("Grid Source")]
+        [Tooltip("Reference grid used for pathfinding. When unset the service will search the scene for a NavGridBuilder.")]
+        [SerializeField] private NavGridBuilder navGrid;
+
+        [Tooltip("Maximum number of nodes expanded per tick. Lower values spread work across more ticks at the cost of latency.")]
+        [SerializeField, Range(4, 512)] private int maxNodesPerTick = 128;
+
+        [Header("Debug")]
+        [Tooltip("Writes verbose logging for path requests and failures.")]
+        [SerializeField] private bool enableDebugLogging;
+
+        private readonly Queue<PathRequest> pendingRequests = new Queue<PathRequest>();
+        private PathRequest activeRequest;
+        private int nextRequestId = 1;
+        private bool subscribedToTicker;
+        private Coroutine tickerSubscriptionRoutine;
+        private int cachedGridRevision;
+
+        /// <summary>
+        /// Active singleton instance.
+        /// </summary>
+        public static PathfindingService Instance => instance != null || !Application.isPlaying
+            ? instance
+            : BootstrapImmediate();
+
+        /// <summary>
+        /// Current grid assigned to the service.
+        /// </summary>
+        public NavGridBuilder ActiveGrid => navGrid;
+
+        /// <summary>
+        /// Revision counter for the active grid, incremented every time it is rebuilt.
+        /// </summary>
+        public int GridRevision => navGrid != null ? navGrid.Revision : 0;
+
+        protected override void Awake()
+        {
+            if (instance != null && instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            base.Awake();
+            instance = this;
+            EnsureGridReference();
+        }
+
+        private void Start()
+        {
+            SubscribeToTicker();
+        }
+
+        private void OnEnable()
+        {
+            if (instance == null)
+            {
+                instance = this;
+            }
+
+            SubscribeToTicker();
+            EnsureGridReference();
+        }
+
+        private void OnDisable()
+        {
+            UnsubscribeFromTicker();
+        }
+
+        private void OnDestroy()
+        {
+            if (instance == this)
+            {
+                UnsubscribeFromTicker();
+                if (navGrid != null)
+                {
+                    navGrid.GridRebuilt -= HandleGridRebuilt;
+                }
+                instance = null;
+            }
+        }
+
+        /// <summary>
+        /// Registers a navigation grid with the service.
+        /// </summary>
+        public void RegisterNavGrid(NavGridBuilder builder)
+        {
+            if (builder == null)
+            {
+                return;
+            }
+
+            if (navGrid == builder)
+            {
+                return;
+            }
+
+            if (navGrid != null)
+            {
+                navGrid.GridRebuilt -= HandleGridRebuilt;
+            }
+
+            navGrid = builder;
+            cachedGridRevision = navGrid != null ? navGrid.Revision : 0;
+            if (navGrid != null)
+            {
+                navGrid.GridRebuilt += HandleGridRebuilt;
+                if (navGrid.NeedsRebuild)
+                {
+                    navGrid.BuildGrid();
+                }
+            }
+
+            if (enableDebugLogging && navGrid != null)
+            {
+                Debug.Log($"PathfindingService registered grid '{navGrid.name}'.", this);
+            }
+        }
+
+        /// <summary>
+        /// Queues a path request. The service will deliver the result asynchronously via the supplied mover.
+        /// </summary>
+        public int RequestPath(NpcPathMover mover, Vector2 start, Vector2 goal)
+        {
+            if (mover == null)
+            {
+                return -1;
+            }
+
+            int id = nextRequestId++;
+            var request = new PathRequest(id, mover, start, goal);
+            pendingRequests.Enqueue(request);
+
+            if (enableDebugLogging)
+            {
+                Debug.Log($"Queued path request {id} for {mover.name} -> {goal}.", this);
+            }
+
+            return id;
+        }
+
+        /// <inheritdoc />
+        public void OnTick()
+        {
+            if (!EnsureGridReference())
+            {
+                if (activeRequest != null)
+                {
+                    CompleteRequest(activeRequest, PathStatus.GridUnavailable, null);
+                    activeRequest = null;
+                }
+                return;
+            }
+
+            if (activeRequest == null)
+            {
+                TryBeginNextRequest();
+            }
+
+            if (activeRequest == null)
+            {
+                return;
+            }
+
+            if (cachedGridRevision != navGrid.Revision)
+            {
+                if (enableDebugLogging)
+                {
+                    Debug.Log("Nav grid changed while processing a request. Restarting search.", this);
+                }
+
+                // Re-queue the request so it can restart with the new grid data.
+                RequeueActiveRequest();
+                TryBeginNextRequest();
+                return;
+            }
+
+            StepActiveRequest();
+        }
+
+        /// <summary>
+        /// Advances the active A* search, expanding up to <see cref="maxNodesPerTick"/> nodes.
+        /// </summary>
+        private void StepActiveRequest()
+        {
+            var search = activeRequest.Search;
+            var grid = navGrid;
+            if (search.OpenSet.Count == 0)
+            {
+                CompleteRequest(activeRequest, PathStatus.GoalUnreachable, null);
+                activeRequest = null;
+                TryBeginNextRequest();
+                return;
+            }
+
+            for (int i = 0; i < maxNodesPerTick; i++)
+            {
+                if (search.OpenSet.Count == 0)
+                {
+                    CompleteRequest(activeRequest, PathStatus.GoalUnreachable, null);
+                    activeRequest = null;
+                    TryBeginNextRequest();
+                    return;
+                }
+
+                Vector2Int current = PopLowestCostNode(search.OpenSet, search.Records);
+                if (current == search.Goal)
+                {
+                    var pathCells = ReconstructPath(search, current);
+                    var worldPath = ConvertCellsToWorld(pathCells, activeRequest.StartCell);
+                    CompleteRequest(activeRequest, PathStatus.Success, worldPath);
+                    activeRequest = null;
+                    TryBeginNextRequest();
+                    return;
+                }
+
+                search.ClosedSet.Add(current);
+
+                var currentRecord = search.Records[current];
+                foreach (var neighbour in EnumerateNeighbours(current))
+                {
+                    if (!grid.IsCellWithinBounds(neighbour))
+                    {
+                        continue;
+                    }
+
+                    if (!grid.IsCellWalkable(neighbour) && neighbour != search.Goal)
+                    {
+                        continue;
+                    }
+
+                    if (search.ClosedSet.Contains(neighbour))
+                    {
+                        continue;
+                    }
+
+                    float tentativeG = currentRecord.GCost + 1f;
+                    if (!search.Records.TryGetValue(neighbour, out var neighbourRecord) || tentativeG < neighbourRecord.GCost)
+                    {
+                        neighbourRecord.GCost = tentativeG;
+                        neighbourRecord.HCost = Heuristic(neighbour, search.Goal);
+                        neighbourRecord.Parent = current;
+                        neighbourRecord.HasParent = true;
+                        search.Records[neighbour] = neighbourRecord;
+
+                        if (!search.OpenSet.Contains(neighbour))
+                        {
+                            search.OpenSet.Add(neighbour);
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Pulls the next queued request and prepares it for execution.
+        /// </summary>
+        private void TryBeginNextRequest()
+        {
+            while (pendingRequests.Count > 0)
+            {
+                var request = pendingRequests.Dequeue();
+                if (!request.MoverReference.TryGetTarget(out var mover) || mover == null)
+                {
+                    continue;
+                }
+
+                if (!PrepareRequest(request))
+                {
+                    CompleteRequest(request, PathStatus.GridUnavailable, null);
+                    continue;
+                }
+
+                activeRequest = request;
+                cachedGridRevision = navGrid != null ? navGrid.Revision : 0;
+                return;
+            }
+        }
+
+        /// <summary>
+        /// Converts world positions into grid coordinates and seeds the search structures.
+        /// </summary>
+        private bool PrepareRequest(PathRequest request)
+        {
+            if (!EnsureGridReference())
+            {
+                return false;
+            }
+
+            var grid = navGrid;
+            Vector2Int startCell = grid.TryGetCell(request.StartWorld, out var tempStart)
+                ? tempStart
+                : grid.WorldToCellClamped(request.StartWorld);
+
+            Vector2Int goalCell = grid.TryGetCell(request.GoalWorld, out var tempGoal)
+                ? tempGoal
+                : grid.WorldToCellClamped(request.GoalWorld);
+
+            Vector2Int resolvedGoal = ResolveNearestWalkable(goalCell, startCell);
+            if (resolvedGoal == startCell && !grid.IsCellWalkable(resolvedGoal))
+            {
+                return false;
+            }
+
+            request.StartCell = startCell;
+            request.GoalCell = resolvedGoal;
+            request.Search.OpenSet.Clear();
+            request.Search.ClosedSet.Clear();
+            request.Search.Records.Clear();
+            request.Search.Start = startCell;
+            request.Search.Goal = resolvedGoal;
+
+            var startRecord = new NodeRecord
+            {
+                GCost = 0f,
+                HCost = Heuristic(startCell, resolvedGoal),
+                Parent = startCell,
+                HasParent = false
+            };
+            request.Search.Records[startCell] = startRecord;
+            request.Search.OpenSet.Add(startCell);
+            request.Prepared = true;
+            return true;
+        }
+
+        /// <summary>
+        /// Finds the closest walkable cell to the desired goal, falling back toward the start when necessary.
+        /// </summary>
+        private Vector2Int ResolveNearestWalkable(Vector2Int desired, Vector2Int start)
+        {
+            var grid = navGrid;
+            if (grid.IsCellWalkable(desired))
+            {
+                return desired;
+            }
+
+            Queue<Vector2Int> frontier = new Queue<Vector2Int>();
+            HashSet<Vector2Int> visited = new HashSet<Vector2Int>();
+            frontier.Enqueue(desired);
+            visited.Add(desired);
+
+            while (frontier.Count > 0)
+            {
+                Vector2Int current = frontier.Dequeue();
+                foreach (var neighbour in EnumerateNeighbours(current))
+                {
+                    if (!grid.IsCellWithinBounds(neighbour))
+                    {
+                        continue;
+                    }
+
+                    if (!visited.Add(neighbour))
+                    {
+                        continue;
+                    }
+
+                    if (grid.IsCellWalkable(neighbour) || neighbour == start)
+                    {
+                        return neighbour;
+                    }
+
+                    frontier.Enqueue(neighbour);
+                }
+            }
+
+            return start;
+        }
+
+        /// <summary>
+        /// Dispatches the resolved path back to the requesting mover.
+        /// </summary>
+        private void CompleteRequest(PathRequest request, PathStatus status, List<Vector2> worldPath)
+        {
+            if (!request.MoverReference.TryGetTarget(out var mover) || mover == null)
+            {
+                return;
+            }
+
+            mover.HandlePathResult(request.Id, status, worldPath, request.GoalWorld);
+        }
+
+        /// <summary>
+        /// Re-enqueues the active request so it can be retried after the grid changes.
+        /// </summary>
+        private void RequeueActiveRequest()
+        {
+            if (activeRequest == null)
+            {
+                return;
+            }
+
+            activeRequest.Search.OpenSet.Clear();
+            activeRequest.Search.ClosedSet.Clear();
+            activeRequest.Search.Records.Clear();
+            activeRequest.Prepared = false;
+            pendingRequests.Enqueue(activeRequest);
+            activeRequest = null;
+        }
+
+        /// <summary>
+        /// Maps a list of grid cells back into world-space positions.
+        /// </summary>
+        private static List<Vector2> ConvertCellsToWorld(List<Vector2Int> cells, Vector2Int startCell)
+        {
+            var grid = instance?.navGrid;
+            var path = new List<Vector2>();
+            if (grid == null)
+            {
+                return path;
+            }
+
+            for (int i = 0; i < cells.Count; i++)
+            {
+                Vector2Int cell = cells[i];
+                if (cell == startCell)
+                {
+                    continue;
+                }
+
+                path.Add(grid.GetCellCenter(cell));
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Extracts the node with the lowest f-cost from the open set.
+        /// </summary>
+        private static Vector2Int PopLowestCostNode(List<Vector2Int> openSet, Dictionary<Vector2Int, NodeRecord> records)
+        {
+            int bestIndex = 0;
+            float bestCost = float.PositiveInfinity;
+            float bestHeuristic = float.PositiveInfinity;
+
+            for (int i = 0; i < openSet.Count; i++)
+            {
+                Vector2Int cell = openSet[i];
+                var record = records[cell];
+                float fCost = record.FCost;
+                if (fCost < bestCost || (Mathf.Approximately(fCost, bestCost) && record.HCost < bestHeuristic))
+                {
+                    bestCost = fCost;
+                    bestHeuristic = record.HCost;
+                    bestIndex = i;
+                }
+            }
+
+            Vector2Int result = openSet[bestIndex];
+            openSet.RemoveAt(bestIndex);
+            return result;
+        }
+
+        /// <summary>
+        /// Manhattan distance heuristic for the 4-way grid.
+        /// </summary>
+        private static float Heuristic(Vector2Int a, Vector2Int b)
+        {
+            return Mathf.Abs(a.x - b.x) + Mathf.Abs(a.y - b.y);
+        }
+
+        /// <summary>
+        /// Enumerates the four orthogonal neighbours of a grid cell.
+        /// </summary>
+        private static IEnumerable<Vector2Int> EnumerateNeighbours(Vector2Int cell)
+        {
+            yield return new Vector2Int(cell.x + 1, cell.y);
+            yield return new Vector2Int(cell.x - 1, cell.y);
+            yield return new Vector2Int(cell.x, cell.y + 1);
+            yield return new Vector2Int(cell.x, cell.y - 1);
+        }
+
+        /// <summary>
+        /// Builds the final path by walking parent pointers back from the goal node.
+        /// </summary>
+        private static List<Vector2Int> ReconstructPath(AStarSearch search, Vector2Int goal)
+        {
+            List<Vector2Int> path = new List<Vector2Int>();
+            Vector2Int current = goal;
+            path.Add(current);
+
+            while (search.Records.TryGetValue(current, out var record) && record.HasParent && record.Parent != current)
+            {
+                current = record.Parent;
+                path.Add(current);
+            }
+
+            path.Reverse();
+            return path;
+        }
+
+        /// <summary>
+        /// Resolves and validates the navigation grid used by the service.
+        /// </summary>
+        private bool EnsureGridReference()
+        {
+            if (navGrid != null && navGrid.HasGrid)
+            {
+                return true;
+            }
+
+            if (navGrid == null)
+            {
+                navGrid = FindObjectOfType<NavGridBuilder>();
+                if (navGrid != null)
+                {
+                    navGrid.GridRebuilt += HandleGridRebuilt;
+                }
+            }
+
+            if (navGrid == null)
+            {
+                return false;
+            }
+
+            if (navGrid.NeedsRebuild)
+            {
+                navGrid.BuildGrid();
+            }
+
+            cachedGridRevision = navGrid.Revision;
+            return navGrid.HasGrid;
+        }
+
+        /// <summary>
+        /// Handles grid rebuild notifications so outstanding requests can restart against the new data.
+        /// </summary>
+        private void HandleGridRebuilt(NavGridBuilder builder)
+        {
+            if (builder != navGrid)
+            {
+                return;
+            }
+
+            cachedGridRevision = builder.Revision;
+            if (enableDebugLogging)
+            {
+                Debug.Log($"Nav grid rebuilt (revision {cachedGridRevision}).", this);
+            }
+
+            if (activeRequest != null)
+            {
+                RequeueActiveRequest();
+            }
+        }
+
+        /// <summary>
+        /// Registers the service with the global ticker to process queued requests each game tick.
+        /// </summary>
+        private void SubscribeToTicker()
+        {
+            if (subscribedToTicker)
+            {
+                return;
+            }
+
+            if (Ticker.Instance == null)
+            {
+                if (tickerSubscriptionRoutine == null && isActiveAndEnabled)
+                {
+                    tickerSubscriptionRoutine = StartCoroutine(WaitForTicker());
+                }
+                return;
+            }
+
+            Ticker.Instance.Subscribe(this);
+            subscribedToTicker = true;
+        }
+
+        /// <summary>
+        /// Removes the ticker subscription when the service is disabled or destroyed.
+        /// </summary>
+        private void UnsubscribeFromTicker()
+        {
+            if (tickerSubscriptionRoutine != null)
+            {
+                StopCoroutine(tickerSubscriptionRoutine);
+                tickerSubscriptionRoutine = null;
+            }
+
+            if (!subscribedToTicker)
+            {
+                return;
+            }
+
+            if (Ticker.Instance != null)
+            {
+                Ticker.Instance.Unsubscribe(this);
+            }
+
+            subscribedToTicker = false;
+        }
+
+        /// <summary>
+        /// Defers ticker registration until the singleton instance becomes available.
+        /// </summary>
+        private System.Collections.IEnumerator WaitForTicker()
+        {
+            while (Ticker.Instance == null)
+            {
+                yield return null;
+            }
+
+            tickerSubscriptionRoutine = null;
+
+            if (!isActiveAndEnabled)
+            {
+                yield break;
+            }
+
+            Ticker.Instance.Subscribe(this);
+            subscribedToTicker = true;
+        }
+
+        /// <summary>
+        /// Ensures a service instance exists when requested before the scene bootstrap completes.
+        /// </summary>
+        private static PathfindingService BootstrapImmediate()
+        {
+            var existing = FindObjectOfType<PathfindingService>();
+            if (existing != null)
+            {
+                return existing;
+            }
+
+            var go = new GameObject(nameof(PathfindingService));
+            var service = go.AddComponent<PathfindingService>();
+            return service;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a NavGridBuilder component that scans scene colliders, bakes a 64×64-aligned grid, and draws debug gizmos
- introduce a persistent PathfindingService that shares the baked grid and resolves queued A* path requests each OSRS tick
- implement an NpcPathMover that walks NPCs along returned waypoints and extend NpcAttackController to request paths when line-of-sight is blocked
- expose a FaceDirection helper on NpcFacing so movement systems can update sprite orientation

## Testing
- Not run (Unity editor only)


------
https://chatgpt.com/codex/tasks/task_e_68dad506e770832e843d5e3393da342d