### PR TITLE
Fix tooltip string escaping in NpcPathMover

### DIFF
--- a/Assets/Scripts/NPC/Movement/NpcPathMover.cs
+++ b/Assets/Scripts/NPC/Movement/NpcPathMover.cs
@@ -17,7 +17,7 @@ namespace NPC
         [Tooltip("Seconds spent traversing a single tile. Defaults to the OSRS tick length for grid-accurate pacing.")]
         [SerializeField] private float tileTraverseDuration = Ticker.TickDuration;
 
-        [Tooltip("Distance considered ""close enough"" to consume a waypoint.")]
+        [Tooltip("Distance considered \"close enough\" to consume a waypoint.")]
         [SerializeField] private float waypointTolerance = 0.05f;
 
         [Tooltip("Desired stand-off distance from the destination. Updated by combat controllers when chasing targets.")]


### PR DESCRIPTION
## Summary
- escape the embedded quotation marks in the NpcPathMover waypoint tolerance tooltip so the script compiles again

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dae01351a4832e826a4909806cdd2e