### PR TITLE
Align NPC obstruction mask with nav grid blockers

### DIFF
--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -79,6 +79,17 @@ namespace NPC
             // Keep the NPC obstruction mask aligned with the shared defaults while preserving
             // any bespoke overrides applied in prefabs or instances.
             int combinedMask = obstructionMask.value | defaultMask;
+
+            // In play mode we also honour the active navigation grid so line-of-sight checks use
+            // the same blockers that pathfinding respects. Guard all lookups to stay editor-safe.
+            if (Application.isPlaying)
+            {
+                var blockingMask = PathfindingService.Instance?.ActiveGrid?.BlockingLayerMask;
+                if (blockingMask.HasValue)
+                {
+                    combinedMask |= blockingMask.Value.value;
+                }
+            }
             obstructionMask = combinedMask;
         }
 

--- a/Assets/Scripts/NPC/Navigation/NavGridBuilder.cs
+++ b/Assets/Scripts/NPC/Navigation/NavGridBuilder.cs
@@ -113,6 +113,12 @@ namespace NPC
         /// </summary>
         public int Revision => revision;
 
+        /// <summary>
+        /// Physics mask used to determine which layers block navigation during grid baking.
+        /// Exposed so other systems (combat, LOS checks) can remain aligned with the baked data.
+        /// </summary>
+        public LayerMask BlockingLayerMask => blockingLayers;
+
         private void Reset()
         {
             SanitizeBlockingTags();


### PR DESCRIPTION
## Summary
- expose NavGridBuilder blocking layer mask through a read-only property so other systems can reuse the baked physics mask
- ensure BaseNpcCombat merges its obstruction mask with the active navigation grid during play mode for consistent LOS checks

## Testing
- not run (requires Unity editor)

------
https://chatgpt.com/codex/tasks/task_e_68daef63290c832ebbe83b02b78b3768