### PR TITLE
Adjust NPC path mover rigidbody handling

### DIFF
--- a/Assets/Scripts/NPC/Movement/NpcPathMover.cs
+++ b/Assets/Scripts/NPC/Movement/NpcPathMover.cs
@@ -448,14 +448,21 @@ namespace NPC
         {
             Vector2 clampedPosition = ClampWithWanderer(position);
 
-            if (body != null)
-            {
-                body.MovePosition(clampedPosition);
-            }
-            else
+            if (body == null)
             {
                 transform.position = new Vector3(clampedPosition.x, clampedPosition.y, transform.position.z);
+                return;
             }
+
+            if (body.bodyType == RigidbodyType2D.Dynamic)
+            {
+                // Dynamic bodies are advanced during FixedUpdate, so defer to MovePosition to keep physics contacts stable.
+                body.MovePosition(clampedPosition);
+                return;
+            }
+
+            // Kinematic (and other non-dynamic) bodies expect direct position assignment so they respect the Update-driven lerp.
+            body.position = clampedPosition;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- ensure kinematic NPC path movers write positions directly to the Rigidbody so Update-driven lerps persist
- reserve MovePosition for dynamic bodies while keeping the existing interpolation flow

## Testing
- not run (Unity editor required)


------
https://chatgpt.com/codex/tasks/task_e_68daff566408832ebee761bd96b85dd3