### PR TITLE
Refine NPC path interpolation clamping

### DIFF
--- a/Assets/Scripts/NPC/Movement/NpcPathMover.cs
+++ b/Assets/Scripts/NPC/Movement/NpcPathMover.cs
@@ -125,11 +125,11 @@ namespace NPC
             float duration = Mathf.Max(0.01f, tileTraverseDuration);
             float progress = Mathf.Clamp01(stepTimer / duration);
             Vector2 interpolated = Vector2.Lerp(currentStepStart, currentStepTarget, progress);
-            ApplyPosition(interpolated);
+            ApplyPosition(interpolated, snapToGrid: false);
 
             if (progress >= 1f - Mathf.Epsilon)
             {
-                ApplyPosition(currentStepTarget);
+                ApplyPosition(currentStepTarget, snapToGrid: true);
                 stepping = false;
                 lastProgressTimestamp = Time.time;
                 TryAdvanceToNextWaypoint();
@@ -462,9 +462,9 @@ namespace NPC
         /// <summary>
         /// Moves the NPC to the supplied position, using the rigidbody when available.
         /// </summary>
-        private void ApplyPosition(Vector2 position)
+        private void ApplyPosition(Vector2 position, bool snapToGrid)
         {
-            Vector2 clampedPosition = ClampWithWanderer(position);
+            Vector2 clampedPosition = ClampWithWanderer(position, snapToGrid);
 
             if (body == null)
             {
@@ -494,9 +494,14 @@ namespace NPC
         /// <summary>
         /// Resolves the provided position against the owning wanderer's bounds when available.
         /// </summary>
-        private Vector2 ClampWithWanderer(Vector2 position)
+        private Vector2 ClampWithWanderer(Vector2 position, bool snapToGrid = true)
         {
-            return wanderer != null ? wanderer.ClampToMovementBounds(position) : position;
+            if (wanderer == null)
+            {
+                return position;
+            }
+
+            return snapToGrid ? wanderer.ClampToMovementBounds(position) : wanderer.ClampToMovementBoundsNoSnap(position);
         }
 
         /// <summary>

--- a/Assets/Scripts/NPC/Movement/NpcWanderer.cs
+++ b/Assets/Scripts/NPC/Movement/NpcWanderer.cs
@@ -548,11 +548,7 @@ namespace NPC
         {
             Vector2 origin = _originInitialized ? _origin : (_rb != null ? _rb.position : (Vector2)transform.position);
 
-            ResolveMovementBounds(origin, out float minX, out float maxX, out float minY, out float maxY);
-
-            float clampedX = Mathf.Clamp(worldPosition.x, minX, maxX);
-            float clampedY = Mathf.Clamp(worldPosition.y, minY, maxY);
-            Vector2 clamped = new Vector2(clampedX, clampedY);
+            Vector2 clamped = ClampWithinConfiguredBounds(origin, worldPosition, out float minX, out float maxX, out float minY, out float maxY);
 
             NavGridBuilder grid = PathfindingService.Instance?.ActiveGrid;
             if (grid == null || !grid.HasGrid)
@@ -609,6 +605,32 @@ namespace NPC
             }
 
             return clamped;
+        }
+
+        /// <summary>
+        /// Clamps the provided world position to the wanderer's configured movement bounds without
+        /// performing any navgrid snapping. This is used when interpolation needs to remain smooth
+        /// between tiles while still respecting the patrol rectangle.
+        /// </summary>
+        /// <param name="worldPosition">Target position in world space.</param>
+        /// <returns>The clamped position limited to the configured patrol bounds.</returns>
+        public Vector2 ClampToMovementBoundsNoSnap(Vector2 worldPosition)
+        {
+            Vector2 origin = _originInitialized ? _origin : (_rb != null ? _rb.position : (Vector2)transform.position);
+            return ClampWithinConfiguredBounds(origin, worldPosition, out _, out _, out _, out _);
+        }
+
+        /// <summary>
+        /// Internal helper that clamps the world position against the configured patrol bounds and
+        /// exposes the resolved min/max values for optional navgrid snapping.
+        /// </summary>
+        private Vector2 ClampWithinConfiguredBounds(Vector2 origin, Vector2 worldPosition, out float minX, out float maxX, out float minY, out float maxY)
+        {
+            ResolveMovementBounds(origin, out minX, out maxX, out minY, out maxY);
+
+            float clampedX = Mathf.Clamp(worldPosition.x, minX, maxX);
+            float clampedY = Mathf.Clamp(worldPosition.y, minY, maxY);
+            return new Vector2(clampedX, clampedY);
         }
 
         private static bool IsWithinBounds(Vector2 position, float minX, float maxX, float minY, float maxY)


### PR DESCRIPTION
## Summary
- add a helper on NpcWanderer to clamp positions to patrol bounds without snapping to the navgrid
- update NpcPathMover so in-flight step interpolation skips snapping while finalising each step still aligns to walkable cells

## Testing
- Not run (Unity editor required)


------
https://chatgpt.com/codex/tasks/task_e_68db03abecbc832ebc6ae2d1f9e746c2