### PR TITLE
Ensure NPC path mover progress timestamps reflect movement

### DIFF
--- a/Assets/Scripts/NPC/Movement/NpcPathMover.cs
+++ b/Assets/Scripts/NPC/Movement/NpcPathMover.cs
@@ -99,6 +99,24 @@ namespace NPC
             pathService = PathfindingService.Instance;
         }
 
+        private void OnValidate()
+        {
+            tileTraverseDuration = Mathf.Max(0.01f, tileTraverseDuration);
+
+            if (stuckTimeoutSeconds <= tileTraverseDuration)
+            {
+                float correctedValue = Mathf.Max(tileTraverseDuration + 0.01f, tileTraverseDuration * 1.1f);
+                if (!Mathf.Approximately(stuckTimeoutSeconds, correctedValue))
+                {
+                    Debug.LogWarning(
+                        $"NpcPathMover '{name}' adjusted stuck timeout from {stuckTimeoutSeconds:F2}s to {correctedValue:F2}s so it exceeds the tile traverse duration.",
+                        this);
+                }
+
+                stuckTimeoutSeconds = correctedValue;
+            }
+        }
+
         private void OnEnable()
         {
             SubscribeToTicker();
@@ -213,7 +231,8 @@ namespace NPC
                     return;
                 }
 
-                if (Time.time - lastProgressTimestamp >= stuckTimeoutSeconds)
+                float timeSinceProgress = Time.time - lastProgressTimestamp;
+                if (lastProgressTimestamp > 0f && timeSinceProgress >= stuckTimeoutSeconds)
                 {
                     ForceReplan(true);
                     return;
@@ -359,6 +378,11 @@ namespace NPC
 
             float deltaTime = Mathf.Max(Time.deltaTime, 0.0001f);
             UpdateMovementVisuals(delta / deltaTime);
+            if (delta.sqrMagnitude > 0.000001f)
+            {
+                // Only treat meaningful deltas as progress so the stuck timer ignores sub-pixel noise.
+                lastProgressTimestamp = Time.time;
+            }
             previousStepPosition = currentPosition;
         }
 


### PR DESCRIPTION
## Summary
- refresh the NPC path mover's progress timestamp whenever a meaningful movement delta occurs and rely on it for the stuck check
- seed and validate timing fields so the first step is covered and the stuck timeout always exceeds the tile traverse duration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbd043a7f8832ea313d31bf2d3c1f0