### PR TITLE
Align NPC path destinations with resolved grid goal

### DIFF
--- a/Assets/Scripts/NPC/Movement/NpcPathMover.cs
+++ b/Assets/Scripts/NPC/Movement/NpcPathMover.cs
@@ -252,7 +252,7 @@ namespace NPC
         /// <summary>
         /// Consumes the outcome of a path request issued through <see cref="PathfindingService"/>.
         /// </summary>
-        internal void HandlePathResult(int requestId, PathfindingService.PathStatus status, List<Vector2> worldPath, Vector2 goalWorld)
+        internal void HandlePathResult(int requestId, PathfindingService.PathStatus status, List<Vector2> worldPath, Vector2 resolvedGoalWorld)
         {
             if (requestId != activeRequestId)
             {
@@ -261,7 +261,8 @@ namespace NPC
 
             awaitingPath = false;
             activeRequestId = -1;
-            desiredDestination = goalWorld;
+            desiredDestination = resolvedGoalWorld;
+            lastRequestedDestination = resolvedGoalWorld;
 
             if (status == PathfindingService.PathStatus.GoalUnreachable)
             {

--- a/Assets/Scripts/NPC/Navigation/PathfindingService.cs
+++ b/Assets/Scripts/NPC/Navigation/PathfindingService.cs
@@ -31,6 +31,13 @@ namespace NPC
             public readonly Vector2 StartWorld;
             public readonly Vector2 GoalWorld;
 
+            /// <summary>
+            /// Resolved world position that the navigation grid determined was reachable.
+            /// Cached so the mover can align its destination with the actual walkable cell even if the
+            /// goal had to be clamped or redirected during preparation.
+            /// </summary>
+            public Vector2 ResolvedGoalWorld;
+
             public AStarSearch Search;
             public Vector2Int StartCell;
             public Vector2Int GoalCell;
@@ -764,6 +771,7 @@ namespace NPC
             request.StartCell = startCell;
             request.GoalCell = resolvedGoal;
             request.DesiredGoalCell = goalCell;
+            request.ResolvedGoalWorld = grid.GetCellCenter(resolvedGoal);
             request.UsedStartFallback = usedStartFallback;
             request.Search.OpenSet.Clear();
             request.Search.ClosedSet.Clear();
@@ -856,8 +864,20 @@ namespace NPC
                 return;
             }
 
+            Vector2 resolvedGoalWorld = request.ResolvedGoalWorld;
+            if (navGrid != null && navGrid.HasGrid)
+            {
+                resolvedGoalWorld = navGrid.GetCellCenter(request.GoalCell);
+            }
+            else if (!request.Prepared)
+            {
+                // If preparation never succeeded we cannot reliably compute a resolved goal, so fall back to
+                // the originally requested world-space target.
+                resolvedGoalWorld = request.GoalWorld;
+            }
+
             RemoveMoverTracking(request, onlyWhenIdMatches: true);
-            mover.HandlePathResult(request.Id, status, worldPath, request.GoalWorld);
+            mover.HandlePathResult(request.Id, status, worldPath, resolvedGoalWorld);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- cache the resolved walkable goal position when preparing pathfinding requests
- return the resolved goal to movers so they align arrival checks with the reachable cell

## Testing
- not run (Unity editor required)


------
https://chatgpt.com/codex/tasks/task_e_68dbf2cab7cc832ea7ec99a06dcdd378