### PR TITLE
Guard NPC path clearing when stop line is blocked

### DIFF
--- a/Assets/Scripts/NPC/Movement/NpcPathMover.cs
+++ b/Assets/Scripts/NPC/Movement/NpcPathMover.cs
@@ -426,11 +426,16 @@ namespace NPC
             if (hasDestination)
             {
                 Vector2 currentPosition = GetCurrentPosition();
+                bool hasClearStopLine = HasClearStopLine(currentPosition, desiredDestination);
+
                 if (IsWithinStopRange(currentPosition))
                 {
-                    waypointQueue.Clear();
-                    EvaluateArrival();
-                    return false;
+                    if (hasClearStopLine)
+                    {
+                        waypointQueue.Clear();
+                        EvaluateArrival();
+                        return false;
+                    }
                 }
 
                 float distanceToNext = Vector2.Distance(currentPosition, next);
@@ -438,9 +443,12 @@ namespace NPC
                 // current position (common when replans enqueue redundant nodes).
                 if (IsWithinStopRange(next) && distanceToNext <= waypointTolerance * 2f)
                 {
-                    waypointQueue.Clear();
-                    EvaluateArrival(next);
-                    return false;
+                    if (hasClearStopLine)
+                    {
+                        waypointQueue.Clear();
+                        EvaluateArrival(next);
+                        return false;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- ensure NpcPathMover only clears active waypoints when the stop line to the target is unobstructed
- guard peeked waypoint arrival handling with the same line-of-sight check so NPCs commit to queued detours

## Testing
- not run (Unity editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc05976fc0832e92b0d3281880d79a