### PR TITLE
Handle personal ore node access during mining validation

### DIFF
--- a/Assets/Scripts/Skills/Mining/Core/MinerController.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MinerController.cs
@@ -66,6 +66,12 @@ namespace Skills.Mining
                 return false;
             }
 
+            var personalNode = node.GetComponent<PersonalOreNode>();
+            if (personalNode != null && !personalNode.CanMine(MiningSkill, out failureMessage))
+            {
+                return false;
+            }
+
             cachedPickaxe = pickaxeSelector != null ? pickaxeSelector.GetBestPickaxe() : null;
             if (cachedPickaxe == null)
             {


### PR DESCRIPTION
## Summary
- ensure miner validation respects personal ore node ownership and combat requirements before other checks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcfd17e278832e8bc09707bcbc56e5