### PR TITLE
Fix player resolution for pet followers in NPC combat

### DIFF
--- a/Assets/Scripts/NPC/Combat/NpcCombatant.cs
+++ b/Assets/Scripts/NPC/Combat/NpcCombatant.cs
@@ -442,7 +442,7 @@ namespace NPC
 
             var follower = component.GetComponentInParent<PetFollower>();
             if (follower != null && follower.Player != null && follower.Player.TryGetComponent<PlayerCombatTarget>(out _))
-                return follower.Player;
+                return follower.Player.gameObject;
 
             return null;
         }


### PR DESCRIPTION
## Summary
- resolve the NPC combatant player lookup to return the owning GameObject when sourced from a pet follower

## Testing
- not run (editor-only change)

------
https://chatgpt.com/codex/tasks/task_e_68dd0b468124832e846e4c5a285b432b