### PR TITLE
Add personal ore node prefab and data-driven definitions

### DIFF
--- a/Assets/Item/MiningDatabase/PersonalNodes.meta
+++ b/Assets/Item/MiningDatabase/PersonalNodes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dc248fd1185b47f5819321934caaa003
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Item/MiningDatabase/PersonalNodes/Personal Adamantite Node.asset
+++ b/Assets/Item/MiningDatabase/PersonalNodes/Personal Adamantite Node.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 478a3efbdba08cb42910fd0005addf6d, type: 3}
+  m_Name: Personal Adamantite Node
+  m_EditorClassIdentifier:
+  id: Personal Adamantite Node
+  ore: {fileID: 11400000, guid: 3027fbd7818b9a6448613444b53c9ca3, type: 2}
+  depletionRoll: 0
+  depleteAfterNOres: 0
+  respawnTimeSecondsMin: 90
+  respawnTimeSecondsMax: 180
+  requiresToolTier: 4

--- a/Assets/Item/MiningDatabase/PersonalNodes/Personal Adamantite Node.asset.meta
+++ b/Assets/Item/MiningDatabase/PersonalNodes/Personal Adamantite Node.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b915dff922d04fdca34f29c6915b5be7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Item/MiningDatabase/PersonalNodes/Personal Coal Node.asset
+++ b/Assets/Item/MiningDatabase/PersonalNodes/Personal Coal Node.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 478a3efbdba08cb42910fd0005addf6d, type: 3}
+  m_Name: Personal Coal Node
+  m_EditorClassIdentifier:
+  id: Personal Coal Node
+  ore: {fileID: 11400000, guid: d6216817fc6a570448ad73e0e6a901e7, type: 2}
+  depletionRoll: 0
+  depleteAfterNOres: 0
+  respawnTimeSecondsMin: 15
+  respawnTimeSecondsMax: 30
+  requiresToolTier: 2

--- a/Assets/Item/MiningDatabase/PersonalNodes/Personal Coal Node.asset.meta
+++ b/Assets/Item/MiningDatabase/PersonalNodes/Personal Coal Node.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 271071a82b1140f8b543a7b5196bf06d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Item/MiningDatabase/PersonalNodes/Personal Copper Node.asset
+++ b/Assets/Item/MiningDatabase/PersonalNodes/Personal Copper Node.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 478a3efbdba08cb42910fd0005addf6d, type: 3}
+  m_Name: Personal Copper Node
+  m_EditorClassIdentifier:
+  id: Personal Copper Node
+  ore: {fileID: 11400000, guid: 02ae12462e8dee5448c7d8b225c3b2dd, type: 2}
+  depletionRoll: 0
+  depleteAfterNOres: 0
+  respawnTimeSecondsMin: 2
+  respawnTimeSecondsMax: 4
+  requiresToolTier: 1

--- a/Assets/Item/MiningDatabase/PersonalNodes/Personal Copper Node.asset.meta
+++ b/Assets/Item/MiningDatabase/PersonalNodes/Personal Copper Node.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 056a87e9c43f4ac2808203fa84cacef0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Item/MiningDatabase/PersonalNodes/Personal Iron Node.asset
+++ b/Assets/Item/MiningDatabase/PersonalNodes/Personal Iron Node.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 478a3efbdba08cb42910fd0005addf6d, type: 3}
+  m_Name: Personal Iron Node
+  m_EditorClassIdentifier:
+  id: Personal Iron Node
+  ore: {fileID: 11400000, guid: 0c99a27b936219b4d997f8625c9b5b22, type: 2}
+  depletionRoll: 0
+  depleteAfterNOres: 0
+  respawnTimeSecondsMin: 4
+  respawnTimeSecondsMax: 7
+  requiresToolTier: 1

--- a/Assets/Item/MiningDatabase/PersonalNodes/Personal Iron Node.asset.meta
+++ b/Assets/Item/MiningDatabase/PersonalNodes/Personal Iron Node.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cd5c81cbac9f43f08eb733b3448aa70e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Item/MiningDatabase/PersonalNodes/Personal Mithril Node.asset
+++ b/Assets/Item/MiningDatabase/PersonalNodes/Personal Mithril Node.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 478a3efbdba08cb42910fd0005addf6d, type: 3}
+  m_Name: Personal Mithril Node
+  m_EditorClassIdentifier:
+  id: Personal Mithril Node
+  ore: {fileID: 11400000, guid: c0b1be63ffe600542a574d35fb81d71f, type: 2}
+  depletionRoll: 0
+  depleteAfterNOres: 0
+  respawnTimeSecondsMin: 60
+  respawnTimeSecondsMax: 120
+  requiresToolTier: 3

--- a/Assets/Item/MiningDatabase/PersonalNodes/Personal Mithril Node.asset.meta
+++ b/Assets/Item/MiningDatabase/PersonalNodes/Personal Mithril Node.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ec9d44a520cd49419d4956399650692b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Item/MiningDatabase/PersonalNodes/Personal Orichalcum Node.asset
+++ b/Assets/Item/MiningDatabase/PersonalNodes/Personal Orichalcum Node.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 478a3efbdba08cb42910fd0005addf6d, type: 3}
+  m_Name: Personal Orichalcum Node
+  m_EditorClassIdentifier:
+  id: Personal Orichalcum Node
+  ore: {fileID: 11400000, guid: 7097c8d545f7f3b48ac58dfeb5ab65b0, type: 2}
+  depletionRoll: 0
+  depleteAfterNOres: 0
+  respawnTimeSecondsMin: 75
+  respawnTimeSecondsMax: 150
+  requiresToolTier: 4

--- a/Assets/Item/MiningDatabase/PersonalNodes/Personal Orichalcum Node.asset.meta
+++ b/Assets/Item/MiningDatabase/PersonalNodes/Personal Orichalcum Node.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c936d105476f4fad8373547154cfea79
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Item/MiningDatabase/PersonalNodes/Personal Runite Node.asset
+++ b/Assets/Item/MiningDatabase/PersonalNodes/Personal Runite Node.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 478a3efbdba08cb42910fd0005addf6d, type: 3}
+  m_Name: Personal Runite Node
+  m_EditorClassIdentifier:
+  id: Personal Runite Node
+  ore: {fileID: 11400000, guid: fff76b79758966842adfe61ba8746c3c, type: 2}
+  depletionRoll: 0
+  depleteAfterNOres: 0
+  respawnTimeSecondsMin: 900
+  respawnTimeSecondsMax: 1200
+  requiresToolTier: 5

--- a/Assets/Item/MiningDatabase/PersonalNodes/Personal Runite Node.asset.meta
+++ b/Assets/Item/MiningDatabase/PersonalNodes/Personal Runite Node.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f797c6b2d7c745d89e2d3754cbfbf4fc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Item/MiningDatabase/PersonalNodes/Personal Tin Node.asset
+++ b/Assets/Item/MiningDatabase/PersonalNodes/Personal Tin Node.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 478a3efbdba08cb42910fd0005addf6d, type: 3}
+  m_Name: Personal Tin Node
+  m_EditorClassIdentifier:
+  id: Personal Tin Node
+  ore: {fileID: 11400000, guid: 4f6b27442e147384cbf0fa012fe8e824, type: 2}
+  depletionRoll: 0
+  depleteAfterNOres: 0
+  respawnTimeSecondsMin: 2
+  respawnTimeSecondsMax: 4
+  requiresToolTier: 1

--- a/Assets/Item/MiningDatabase/PersonalNodes/Personal Tin Node.asset.meta
+++ b/Assets/Item/MiningDatabase/PersonalNodes/Personal Tin Node.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a15e519114c7412eb4c5ce566f4c4bf0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Prefabs/GFX/OreNodeDespawnVFX.prefab
+++ b/Assets/Prefabs/GFX/OreNodeDespawnVFX.prefab
@@ -1,0 +1,107 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3189570348857454560
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3384619786070310697}
+  - component: {fileID: 690970882536941450}
+  - component: {fileID: 4193562506874003632}
+  m_Layer: 7
+  m_Name: OreNodeDespawnVFX
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3384619786070310697
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3189570348857454560}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &690970882536941450
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3189570348857454560}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: -160616933
+  m_SortingLayer: 4
+  m_SortingOrder: 250
+  m_Sprite: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.7}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 0
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &4193562506874003632
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3189570348857454560}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d9ab714939f54876a8e77f5f80902f9b, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  targetRenderer: {fileID: 690970882536941450}
+  applyOnEnable: 1

--- a/Assets/Prefabs/GFX/OreNodeDespawnVFX.prefab.meta
+++ b/Assets/Prefabs/GFX/OreNodeDespawnVFX.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 41879afac747405d8f1850c91af12234
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Prefabs/Ore Rocks/PersonalOreNode.prefab
+++ b/Assets/Prefabs/Ore Rocks/PersonalOreNode.prefab
@@ -1,0 +1,512 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1953538185238979234
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7205172019341862210}
+  - component: {fileID: 7445129156621080460}
+  - component: {fileID: 1649910375163350527}
+  - component: {fileID: 4389721864341208886}
+  - component: {fileID: 2934156379953286805}
+  - component: {fileID: 5567743148573218289}
+  m_Layer: 7
+  m_Name: PersonalOreNode
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7205172019341862210
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1953538185238979234}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 784643508996635948}
+  - {fileID: 1901990182990518628}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &7445129156621080460
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1953538185238979234}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: -160616933
+  m_SortingLayer: 4
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 4717179716814709447, guid: 015f3f22b8d356945bb1376d1c2c3dbf, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &1649910375163350527
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1953538185238979234}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eaeca4ebf1961d646be160b9b0493572, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  rockDef: {fileID: 11400000, guid: 056a87e9c43f4ac2808203fa84cacef0, type: 2}
+  spriteRenderer: {fileID: 7445129156621080460}
+  fullSprite: {fileID: 4717179716814709447, guid: 015f3f22b8d356945bb1376d1c2c3dbf, type: 3}
+  depletedSprite: {fileID: 4125299660649565555, guid: 760efa6975d83c24ba0ecd4d9d8e949a, type: 3}
+--- !u!114 &4389721864341208886
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1953538185238979234}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76cd1b72de0d4b218ac17b592277af94, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  offset: -1
+  directionOffset: 0
+--- !u!58 &2934156379953286805
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1953538185238979234}
+  m_Enabled: 0
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_Radius: 0.35
+--- !u!114 &5567743148573218289
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1953538185238979234}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f9a7df36187b4e6bad67feb51e58d435, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  interactionCollider: {fileID: 2934156379953286805}
+  despawnVfxPrefab: {fileID: 100000, guid: 41879afac747405d8f1850c91af12234, type: 3}
+  ownerOnlyCanvas: {fileID: 8658737499160987752}
+  ownerOnlyText: {fileID: 5929134930105094452}
+  ownerOnlyIcon: {fileID: 8826503063245502298}
+  ownerOnlySpriteRenderers:
+  - {fileID: 3800447266406252256}
+--- !u!1 &7794538126340125048
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 784643508996635948}
+  - component: {fileID: 3800447266406252256}
+  m_Layer: 7
+  m_Name: OwnerSoloSprite
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &784643508996635948
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7794538126340125048}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.85, z: 0}
+  m_LocalScale: {x: 0.6, y: 0.6, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7205172019341862210}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &3800447266406252256
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7794538126340125048}
+  m_Enabled: 0
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: -160616933
+  m_SortingLayer: 4
+  m_SortingOrder: 10
+  m_Sprite: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.85}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 0
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &6012164185261679023
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1901990182990518628}
+  - component: {fileID: 8658737499160987752}
+  - component: {fileID: 5439480130709723231}
+  - component: {fileID: 2217402029238500130}
+  m_Layer: 5
+  m_Name: OwnerCanvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1901990182990518628
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6012164185261679023}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.25, z: 0}
+  m_LocalScale: {x: 0.015625, y: 0.015625, z: 0.015625}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1549421098497485823}
+  - {fileID: 826932642213942235}
+  m_Father: {fileID: 7205172019341862210}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 64, y: 64}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!223 &8658737499160987752
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6012164185261679023}
+  m_Enabled: 0
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 0
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 300
+  m_TargetDisplay: 0
+--- !u!114 &5439480130709723231
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6012164185261679023}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 64, y: 64}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 1
+--- !u!114 &2217402029238500130
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6012164185261679023}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!1 &237704528153428884
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1549421098497485823}
+  - component: {fileID: 5929134930105094452}
+  m_Layer: 5
+  m_Name: TimerText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1549421098497485823
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 237704528153428884}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1901990182990518628}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: 10}
+  m_SizeDelta: {x: 64, y: 20}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!114 &5929134930105094452
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 237704528153428884}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 18
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 300
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 1
+    m_LineSpacing: 1
+  m_Text: 00:00
+--- !u!1 &7353942185382184586
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 826932642213942235}
+  - component: {fileID: 8826503063245502298}
+  m_Layer: 5
+  m_Name: SoloIcon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &826932642213942235
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7353942185382184586}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1901990182990518628}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.3}
+  m_AnchorMax: {x: 0.5, y: 0.3}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 28, y: 28}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &8826503063245502298
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7353942185382184586}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0c0e9d3a8e4e8f96bba6c5d2bf1, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.9}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Assets/Prefabs/Ore Rocks/PersonalOreNode.prefab.meta
+++ b/Assets/Prefabs/Ore Rocks/PersonalOreNode.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b517a91277d2435e8530e04eb6679bfd
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Mining.meta
+++ b/Assets/Resources/Mining.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f452f36f01e7462f80bc660b2293d83e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Mining/OreMonsterNodes.meta
+++ b/Assets/Resources/Mining/OreMonsterNodes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0d61510eafcd4f40ab6f2dc0d93a33d0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Mining/OreMonsterNodes/Adamantite Ore Monster Node.asset
+++ b/Assets/Resources/Mining/OreMonsterNodes/Adamantite Ore Monster Node.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3a6b363ec0e84e199fc8b1461b1cf6c9, type: 3}
+  m_Name: Adamantite Ore Monster Node
+  m_EditorClassIdentifier:
+  monsterCombatProfile: {fileID: 11400000, guid: a2f9345330f24e74da31849069a079ad, type: 2}
+  personalOreNodePrefab: {fileID: 100000, guid: b517a91277d2435e8530e04eb6679bfd, type: 3}
+  personalRockDefinition: {fileID: 11400000, guid: b915dff922d04fdca34f29c6915b5be7, type: 2}
+  baseLifetimeSeconds: 300
+  charmLifetimeSeconds: 480
+  charmItemId: personal_adamantite_charm
+  requiresCombatLevel: 1
+  requiredCombatLevel: 65
+  soloLockSprite: {fileID: 0}
+  spawnOffset: {x: 0, y: 0.25, z: 0}

--- a/Assets/Resources/Mining/OreMonsterNodes/Adamantite Ore Monster Node.asset.meta
+++ b/Assets/Resources/Mining/OreMonsterNodes/Adamantite Ore Monster Node.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ef8f18b59bfa4303adb597870adf27f7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Mining/OreMonsterNodes/Coal Ore Monster Node.asset
+++ b/Assets/Resources/Mining/OreMonsterNodes/Coal Ore Monster Node.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3a6b363ec0e84e199fc8b1461b1cf6c9, type: 3}
+  m_Name: Coal Ore Monster Node
+  m_EditorClassIdentifier:
+  monsterCombatProfile: {fileID: 11400000, guid: a2f9345330f24e74da31849069a079ad, type: 2}
+  personalOreNodePrefab: {fileID: 100000, guid: b517a91277d2435e8530e04eb6679bfd, type: 3}
+  personalRockDefinition: {fileID: 11400000, guid: 271071a82b1140f8b543a7b5196bf06d, type: 2}
+  baseLifetimeSeconds: 240
+  charmLifetimeSeconds: 420
+  charmItemId: personal_coal_charm
+  requiresCombatLevel: 1
+  requiredCombatLevel: 35
+  soloLockSprite: {fileID: 0}
+  spawnOffset: {x: 0, y: 0.25, z: 0}

--- a/Assets/Resources/Mining/OreMonsterNodes/Coal Ore Monster Node.asset.meta
+++ b/Assets/Resources/Mining/OreMonsterNodes/Coal Ore Monster Node.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7b4bbed46f924e468560da655e21d3a6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Mining/OreMonsterNodes/Copper Ore Monster Node.asset
+++ b/Assets/Resources/Mining/OreMonsterNodes/Copper Ore Monster Node.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3a6b363ec0e84e199fc8b1461b1cf6c9, type: 3}
+  m_Name: Copper Ore Monster Node
+  m_EditorClassIdentifier:
+  monsterCombatProfile: {fileID: 11400000, guid: 99be5545587046b409a3d4e9f2a85c70, type: 2}
+  personalOreNodePrefab: {fileID: 100000, guid: b517a91277d2435e8530e04eb6679bfd, type: 3}
+  personalRockDefinition: {fileID: 11400000, guid: 056a87e9c43f4ac2808203fa84cacef0, type: 2}
+  baseLifetimeSeconds: 180
+  charmLifetimeSeconds: 300
+  charmItemId: personal_copper_charm
+  requiresCombatLevel: 0
+  requiredCombatLevel: 1
+  soloLockSprite: {fileID: 0}
+  spawnOffset: {x: 0, y: 0.25, z: 0}

--- a/Assets/Resources/Mining/OreMonsterNodes/Copper Ore Monster Node.asset.meta
+++ b/Assets/Resources/Mining/OreMonsterNodes/Copper Ore Monster Node.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3e914c8850a440bfbd9eb305a597d565
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Mining/OreMonsterNodes/Iron Ore Monster Node.asset
+++ b/Assets/Resources/Mining/OreMonsterNodes/Iron Ore Monster Node.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3a6b363ec0e84e199fc8b1461b1cf6c9, type: 3}
+  m_Name: Iron Ore Monster Node
+  m_EditorClassIdentifier:
+  monsterCombatProfile: {fileID: 11400000, guid: 99be5545587046b409a3d4e9f2a85c70, type: 2}
+  personalOreNodePrefab: {fileID: 100000, guid: b517a91277d2435e8530e04eb6679bfd, type: 3}
+  personalRockDefinition: {fileID: 11400000, guid: cd5c81cbac9f43f08eb733b3448aa70e, type: 2}
+  baseLifetimeSeconds: 210
+  charmLifetimeSeconds: 360
+  charmItemId: personal_iron_charm
+  requiresCombatLevel: 1
+  requiredCombatLevel: 20
+  soloLockSprite: {fileID: 0}
+  spawnOffset: {x: 0, y: 0.25, z: 0}

--- a/Assets/Resources/Mining/OreMonsterNodes/Iron Ore Monster Node.asset.meta
+++ b/Assets/Resources/Mining/OreMonsterNodes/Iron Ore Monster Node.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 609a84fd69df496a8665131092329307
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Mining/OreMonsterNodes/Mithril Ore Monster Node.asset
+++ b/Assets/Resources/Mining/OreMonsterNodes/Mithril Ore Monster Node.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3a6b363ec0e84e199fc8b1461b1cf6c9, type: 3}
+  m_Name: Mithril Ore Monster Node
+  m_EditorClassIdentifier:
+  monsterCombatProfile: {fileID: 11400000, guid: a2f9345330f24e74da31849069a079ad, type: 2}
+  personalOreNodePrefab: {fileID: 100000, guid: b517a91277d2435e8530e04eb6679bfd, type: 3}
+  personalRockDefinition: {fileID: 11400000, guid: ec9d44a520cd49419d4956399650692b, type: 2}
+  baseLifetimeSeconds: 270
+  charmLifetimeSeconds: 450
+  charmItemId: personal_mithril_charm
+  requiresCombatLevel: 1
+  requiredCombatLevel: 50
+  soloLockSprite: {fileID: 0}
+  spawnOffset: {x: 0, y: 0.25, z: 0}

--- a/Assets/Resources/Mining/OreMonsterNodes/Mithril Ore Monster Node.asset.meta
+++ b/Assets/Resources/Mining/OreMonsterNodes/Mithril Ore Monster Node.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d9455b3a88d84390941fcd7fd0184175
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Mining/OreMonsterNodes/Orichalcum Ore Monster Node.asset
+++ b/Assets/Resources/Mining/OreMonsterNodes/Orichalcum Ore Monster Node.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3a6b363ec0e84e199fc8b1461b1cf6c9, type: 3}
+  m_Name: Orichalcum Ore Monster Node
+  m_EditorClassIdentifier:
+  monsterCombatProfile: {fileID: 11400000, guid: a2f9345330f24e74da31849069a079ad, type: 2}
+  personalOreNodePrefab: {fileID: 100000, guid: b517a91277d2435e8530e04eb6679bfd, type: 3}
+  personalRockDefinition: {fileID: 11400000, guid: c936d105476f4fad8373547154cfea79, type: 2}
+  baseLifetimeSeconds: 360
+  charmLifetimeSeconds: 600
+  charmItemId: personal_orichalcum_charm
+  requiresCombatLevel: 1
+  requiredCombatLevel: 90
+  soloLockSprite: {fileID: 0}
+  spawnOffset: {x: 0, y: 0.25, z: 0}

--- a/Assets/Resources/Mining/OreMonsterNodes/Orichalcum Ore Monster Node.asset.meta
+++ b/Assets/Resources/Mining/OreMonsterNodes/Orichalcum Ore Monster Node.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 480f5c43100f4b4a956ea3d00d603827
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Mining/OreMonsterNodes/Runite Ore Monster Node.asset
+++ b/Assets/Resources/Mining/OreMonsterNodes/Runite Ore Monster Node.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3a6b363ec0e84e199fc8b1461b1cf6c9, type: 3}
+  m_Name: Runite Ore Monster Node
+  m_EditorClassIdentifier:
+  monsterCombatProfile: {fileID: 11400000, guid: a2f9345330f24e74da31849069a079ad, type: 2}
+  personalOreNodePrefab: {fileID: 100000, guid: b517a91277d2435e8530e04eb6679bfd, type: 3}
+  personalRockDefinition: {fileID: 11400000, guid: f797c6b2d7c745d89e2d3754cbfbf4fc, type: 2}
+  baseLifetimeSeconds: 330
+  charmLifetimeSeconds: 540
+  charmItemId: personal_runite_charm
+  requiresCombatLevel: 1
+  requiredCombatLevel: 80
+  soloLockSprite: {fileID: 0}
+  spawnOffset: {x: 0, y: 0.25, z: 0}

--- a/Assets/Resources/Mining/OreMonsterNodes/Runite Ore Monster Node.asset.meta
+++ b/Assets/Resources/Mining/OreMonsterNodes/Runite Ore Monster Node.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e8ebfa3a45a8463f886c9552d1ebcfc6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Mining/OreMonsterNodes/Tin Ore Monster Node.asset
+++ b/Assets/Resources/Mining/OreMonsterNodes/Tin Ore Monster Node.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3a6b363ec0e84e199fc8b1461b1cf6c9, type: 3}
+  m_Name: Tin Ore Monster Node
+  m_EditorClassIdentifier:
+  monsterCombatProfile: {fileID: 11400000, guid: 99be5545587046b409a3d4e9f2a85c70, type: 2}
+  personalOreNodePrefab: {fileID: 100000, guid: b517a91277d2435e8530e04eb6679bfd, type: 3}
+  personalRockDefinition: {fileID: 11400000, guid: a15e519114c7412eb4c5ce566f4c4bf0, type: 2}
+  baseLifetimeSeconds: 180
+  charmLifetimeSeconds: 300
+  charmItemId: personal_tin_charm
+  requiresCombatLevel: 0
+  requiredCombatLevel: 1
+  soloLockSprite: {fileID: 0}
+  spawnOffset: {x: 0, y: 0.25, z: 0}

--- a/Assets/Resources/Mining/OreMonsterNodes/Tin Ore Monster Node.asset.meta
+++ b/Assets/Resources/Mining/OreMonsterNodes/Tin Ore Monster Node.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6d877db96a1048418d9d2de4ed80e051
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Skills/Mining/Core/PersonalOreNode.cs
+++ b/Assets/Scripts/Skills/Mining/Core/PersonalOreNode.cs
@@ -35,6 +35,7 @@ namespace Skills.Mining
         [SerializeField] private SpriteRenderer[] ownerOnlySpriteRenderers;
 
         private MiningPersonalNodeController ownerController;
+        private MineableRock mineableRock;
         private OreMonsterNodeDefinition sourceDefinition;
         private string ownerProfileId = string.Empty;
         private float totalLifetimeSeconds;
@@ -97,7 +98,7 @@ namespace Skills.Mining
         private void Awake()
         {
             // Ensure the required mineable rock component exists so the prefab remains valid.
-            GetComponent<MineableRock>();
+            mineableRock = GetComponent<MineableRock>();
 
             // Fall back to the attached collider when no explicit interaction collider has been
             // assigned via the inspector. This keeps prefabs flexible while enforcing safe mining.
@@ -124,6 +125,12 @@ namespace Skills.Mining
             totalLifetimeSeconds = Mathf.Max(0f, lifetimeSeconds);
             remainingLifetimeSeconds = totalLifetimeSeconds;
             isExpired = false;
+
+            if (mineableRock == null)
+                mineableRock = GetComponent<MineableRock>();
+
+            if (mineableRock != null && definition != null && definition.PersonalRockDefinition != null)
+                mineableRock.rockDef = definition.PersonalRockDefinition;
 
             LegacyFontProvider.ApplyTo(ownerOnlyText);
 

--- a/Assets/Scripts/Skills/Mining/Core/PersonalOreNode.cs.meta
+++ b/Assets/Scripts/Skills/Mining/Core/PersonalOreNode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f9a7df36187b4e6bad67feb51e58d435
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Skills/Mining/Core/SoloLockSpriteApplier.cs
+++ b/Assets/Scripts/Skills/Mining/Core/SoloLockSpriteApplier.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+
+namespace Skills.Mining
+{
+    /// <summary>
+    ///     Utility behaviour that ensures a target sprite renderer displays the generated solo-lock sprite. This keeps
+    ///     VFX and world indicators in sync with the runtime-generated texture without requiring binary art assets.
+    /// </summary>
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(SpriteRenderer))]
+    public sealed class SoloLockSpriteApplier : MonoBehaviour
+    {
+        [Tooltip("Renderer that should display the solo-lock sprite. Defaults to the component on this GameObject.")]
+        [SerializeField] private SpriteRenderer targetRenderer;
+
+        [Tooltip("When enabled the sprite will be applied during OnEnable. Disable to only apply once during Awake.")]
+        [SerializeField] private bool applyOnEnable = true;
+
+        private void Awake()
+        {
+            if (targetRenderer == null)
+                targetRenderer = GetComponent<SpriteRenderer>();
+
+            if (!applyOnEnable)
+                ApplySprite();
+        }
+
+        private void OnEnable()
+        {
+            if (applyOnEnable)
+                ApplySprite();
+        }
+
+        private void ApplySprite()
+        {
+            if (targetRenderer == null)
+                return;
+
+            var sprite = SoloLockSpriteLibrary.DefaultSprite;
+            targetRenderer.sprite = sprite;
+            targetRenderer.enabled = sprite != null;
+        }
+    }
+}

--- a/Assets/Scripts/Skills/Mining/Core/SoloLockSpriteApplier.cs.meta
+++ b/Assets/Scripts/Skills/Mining/Core/SoloLockSpriteApplier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d9ab714939f54876a8e77f5f80902f9b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Skills/Mining/Data/OreMonsterNodeDefinition.cs
+++ b/Assets/Scripts/Skills/Mining/Data/OreMonsterNodeDefinition.cs
@@ -18,6 +18,10 @@ namespace Skills.Mining
         [Tooltip("Prefab for the personal ore node that becomes available after defeating the monster.")]
         [SerializeField] private PersonalOreNode personalOreNodePrefab;
 
+        [Header("Personal Node Data")]
+        [Tooltip("Rock definition applied to the spawned personal node so ore rewards remain data-driven.")]
+        [SerializeField] private RockDefinition personalRockDefinition;
+
         [Header("Lifetime (Seconds)")]
         [Tooltip("Default lifetime for the personal ore node before it despawns.")]
         [Min(0f)]
@@ -56,6 +60,11 @@ namespace Skills.Mining
         public PersonalOreNode PersonalOreNodePrefab => personalOreNodePrefab;
 
         /// <summary>
+        /// Rock definition assigned to the personal node so it yields the correct ore rewards.
+        /// </summary>
+        public RockDefinition PersonalRockDefinition => personalRockDefinition;
+
+        /// <summary>
         /// Lifetime applied when no charm bonus is active.
         /// </summary>
         public float BaseLifetimeSeconds => baseLifetimeSeconds;
@@ -83,7 +92,7 @@ namespace Skills.Mining
         /// <summary>
         /// Solo-lock indicator sprite shown when the node is reserved for the defeating player.
         /// </summary>
-        public Sprite SoloLockSprite => soloLockSprite;
+        public Sprite SoloLockSprite => soloLockSprite != null ? soloLockSprite : SoloLockSpriteLibrary.DefaultSprite;
 
         /// <summary>
         /// World-space offset used when spawning the monster relative to its target rock.

--- a/Assets/Scripts/Skills/Mining/Data/OreMonsterNodeDefinition.cs.meta
+++ b/Assets/Scripts/Skills/Mining/Data/OreMonsterNodeDefinition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3a6b363ec0e84e199fc8b1461b1cf6c9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Skills/Mining/Data/SoloLockSpriteLibrary.cs
+++ b/Assets/Scripts/Skills/Mining/Data/SoloLockSpriteLibrary.cs
@@ -1,0 +1,62 @@
+using System;
+using UnityEngine;
+
+namespace Skills.Mining
+{
+    /// <summary>
+    ///     Provides runtime access to the solo-lock sprite used by personal ore nodes. The sprite is generated from an
+    ///     embedded 64x64 PNG so we can avoid committing binary art assets while still supplying a consistent icon.
+    /// </summary>
+    public static class SoloLockSpriteLibrary
+    {
+        private static Sprite cachedSprite;
+
+        /// <summary>
+        ///     Shared solo-lock sprite instance. The texture is generated on demand and cached for reuse by all nodes.
+        /// </summary>
+        public static Sprite DefaultSprite
+        {
+            get
+            {
+                if (cachedSprite == null)
+                    cachedSprite = CreateSprite();
+
+                return cachedSprite;
+            }
+        }
+
+        private static Sprite CreateSprite()
+        {
+            var texture = new Texture2D(2, 2, TextureFormat.RGBA32, false)
+            {
+                name = "SoloLockTexture"
+            };
+
+            var imageData = Convert.FromBase64String(EncodedSpriteData);
+            ImageConversion.LoadImage(texture, imageData, markNonReadable: false);
+
+            texture.filterMode = FilterMode.Point;
+            texture.wrapMode = TextureWrapMode.Clamp;
+
+            var sprite = Sprite.Create(
+                texture,
+                new Rect(0f, 0f, texture.width, texture.height),
+                new Vector2(0.5f, 0.5f),
+                64f);
+            sprite.name = "SoloLockSprite";
+
+            return sprite;
+        }
+
+        /// <summary>
+        ///     Base64 encoded PNG representing a 64x64 transparent lock icon.
+        /// </summary>
+        private const string EncodedSpriteData =
+            "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAABvklEQVR4nO2ZvXHDMAyFwVyGUKtalVR6ghQawkOkTZU2Q2iIFJrAZVKldpstlMo5HU1SP3wEctH7Kp9p"
+            + "E8AjAJKSCCGEEEIIOSbOwujH+9MUG+v6UdUnNWOpoGNoiFHcwJ7AfUoK8VBqYhFM8Mh5QhRRdsnhtqmiY59f38m50dkAFyAWfNePbrqeV6+kqweXmmuvfz5FS+BG21Sy"
+            + "JXgRkel6nlKZggIqQGjFcoMI/R/ZE2CptDV4Vw93tlNZEuoNiFJ4zJ0gRiz4UOD+WEiItqkWG+QeICXgr35oZVw9uFTwa37rz4soBYgAvmNbG95a5vN2/egQJVDkHOAL"
+            + "sHblS89lQm42lMomQggRKbALaDQt5E4AvQtodWykHZgA2tsVyh5EAKu9GmE3WwDrg0qufZUHIn+ZrG7q38Y0nuDM8a/Hey5Hh8+AYg9E1vD8cvn9/PZ6MvHBRIB54P53"
+            + "2kIcvgTUBQit/pZxNMwAawesURdgqclpN8GsXWDr+z40t4NXzvXYpARiq2xxFmAPsHbAGgpg7YA1FMDaAWuyBbB+WZlrH5IBViIg7EId1zwVokSH9gCtTLAuO0IIIYSQ"
+            + "f8EPIEGtB8PKbaAAAAAASUVORK5CYII=";
+    }
+}

--- a/Assets/Scripts/Skills/Mining/Data/SoloLockSpriteLibrary.cs.meta
+++ b/Assets/Scripts/Skills/Mining/Data/SoloLockSpriteLibrary.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8584b39c473340059e8b5af842a5eb24
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sprites/UI.meta
+++ b/Assets/Sprites/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: eabd7569b3dc46b9a228f7ece1341036
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sprites/UI/solo_lock.png
+++ b/Assets/Sprites/UI/solo_lock.png
@@ -1,0 +1,1 @@
+Solo lock sprite is generated at runtime by SoloLockSpriteLibrary to satisfy the no-binary-assets workflow constraint.

--- a/Assets/Sprites/UI/solo_lock.png.meta
+++ b/Assets/Sprites/UI/solo_lock.png.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 780c5aeb121543fe82ad511c3fff3dce
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- create a PersonalOreNode prefab that wires owner-only UI, collider gating, and despawn VFX for personal ore spawns
- add infinite personal rock definitions plus OreMonsterNodeDefinition assets that point at the new prefab and charm/lifetime data
- introduce SoloLockSpriteLibrary and SoloLockSpriteApplier so the solo-lock icon is generated at runtime without committing binary art

## Testing
- not run (Unity editor not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd0f7beed0832e81d47f5e34680fdf