### PR TITLE
Delay ore monster respawns until personal nodes expire

### DIFF
--- a/Assets/Scripts/NPC/Combat/NpcCombatant.cs
+++ b/Assets/Scripts/NPC/Combat/NpcCombatant.cs
@@ -55,6 +55,11 @@ namespace NPC
         private Sprite poisonHitsplat;
         private FloatingTextAnchorUtility.AnchorCache hitsplatAnchorCache;
         private bool isRegisteredWithRegistry;
+        [SerializeField, Tooltip("Cached respawn delay used when scheduling or resuming respawns after suppression.")]
+        private float pendingRespawnDelaySeconds;
+        [SerializeField, Tooltip("Tracks whether respawning is temporarily suppressed by external systems (e.g. personal nodes).")]
+        private bool respawnSuppressed;
+        private Coroutine respawnCoroutine;
 
         /// <summary>
         /// Tracks whether the global NPC combat damage logging override is enabled. When true all
@@ -283,7 +288,7 @@ namespace NPC
                 if (collider2D) collider2D.enabled = false;
                 if (spriteRenderer) spriteRenderer.enabled = false;
                 if (profile != null && profile.RespawnSeconds > 0f)
-                    StartCoroutine(RespawnRoutine());
+                    ScheduleRespawn(profile.RespawnSeconds);
             }
 
             return damageToApply;
@@ -295,9 +300,29 @@ namespace NPC
             return CombatantStats.ForNpc(profile);
         }
 
-        private IEnumerator RespawnRoutine()
+        private void ScheduleRespawn(float delaySeconds)
         {
-            yield return new WaitForSeconds(profile.RespawnSeconds);
+            pendingRespawnDelaySeconds = Mathf.Max(0f, delaySeconds);
+
+            if (respawnCoroutine != null)
+            {
+                StopCoroutine(respawnCoroutine);
+                respawnCoroutine = null;
+            }
+
+            if (respawnSuppressed)
+                return;
+
+            respawnCoroutine = StartCoroutine(RespawnRoutine(pendingRespawnDelaySeconds));
+        }
+
+        private IEnumerator RespawnRoutine(float delaySeconds)
+        {
+            if (delaySeconds > 0f)
+                yield return new WaitForSeconds(delaySeconds);
+            else
+                yield return null;
+
             currentHp = profile != null ? profile.HitpointsLevel : 1;
             if (collider2D) collider2D.enabled = true;
             if (spriteRenderer) spriteRenderer.enabled = true;
@@ -310,6 +335,37 @@ namespace NPC
             combat?.ResetCombatState(true);
             ClearDamageContributors("Respawned");
             OnHealthChanged?.Invoke(currentHp, MaxHP);
+            respawnCoroutine = null;
+            pendingRespawnDelaySeconds = 0f;
+        }
+
+        /// <summary>
+        ///     Prevents the NPC from scheduling or running a respawn routine. Any active
+        ///     respawn coroutine is cancelled so external systems can control the lifecycle.
+        /// </summary>
+        public void SuppressRespawn()
+        {
+            respawnSuppressed = true;
+            if (respawnCoroutine != null)
+            {
+                StopCoroutine(respawnCoroutine);
+                respawnCoroutine = null;
+            }
+        }
+
+        /// <summary>
+        ///     Re-enables respawning after a suppression period. The respawn routine will be
+        ///     scheduled using the supplied delay override or the cached pending delay if no
+        ///     override is provided.
+        /// </summary>
+        /// <param name="delayOverride">
+        ///     Optional delay in seconds that replaces the cached pending delay when provided.
+        /// </param>
+        public void ResumeRespawn(float? delayOverride = null)
+        {
+            respawnSuppressed = false;
+            float delay = delayOverride.HasValue ? delayOverride.Value : pendingRespawnDelaySeconds;
+            ScheduleRespawn(delay);
         }
 
         /// <summary>

--- a/Assets/Scripts/Skills/Mining/Core/OreMonsterRewardController.cs
+++ b/Assets/Scripts/Skills/Mining/Core/OreMonsterRewardController.cs
@@ -20,6 +20,8 @@ namespace Skills.Mining
         private bool enableDebugLogging;
 
         private NpcCombatant npcCombatant;
+        private PersonalOreNode trackedPersonalNode;
+        private float trackedRespawnDelaySeconds;
 
         private void Awake()
         {
@@ -49,6 +51,8 @@ namespace Skills.Mining
         {
             if (npcCombatant != null)
                 npcCombatant.OnKilledByPlayer -= HandleKilledByPlayer;
+
+            DetachTrackedNode(true);
         }
 
         /// <summary>
@@ -59,15 +63,23 @@ namespace Skills.Mining
         /// <param name="killingPlayer">GameObject responsible for the finishing blow.</param>
         private void HandleKilledByPlayer(NpcCombatant combatant, GameObject killingPlayer)
         {
+            float respawnDelay = combatant != null && combatant.Profile != null
+                ? Mathf.Max(0f, combatant.Profile.RespawnSeconds)
+                : 0f;
+
+            npcCombatant?.SuppressRespawn();
+
             if (nodeDefinition == null)
             {
                 LogDebug("No node definition assigned, skipping personal ore node spawn.");
+                npcCombatant?.ResumeRespawn(respawnDelay);
                 return;
             }
 
             if (killingPlayer == null)
             {
                 LogDebug("Killing player reference was null, cannot award personal ore node.");
+                npcCombatant?.ResumeRespawn(respawnDelay);
                 return;
             }
 
@@ -75,11 +87,36 @@ namespace Skills.Mining
             if (personalNodeController == null)
             {
                 LogDebug($"Unable to locate MiningPersonalNodeController on killer '{killingPlayer.name}', skipping spawn.");
+                npcCombatant?.ResumeRespawn(respawnDelay);
+                return;
+            }
+
+            if (!personalNodeController.isActiveAndEnabled)
+            {
+                LogDebug($"MiningPersonalNodeController on '{killingPlayer.name}' is disabled, cannot spawn personal node.");
+                npcCombatant?.ResumeRespawn(respawnDelay);
                 return;
             }
 
             Vector3 spawnPosition = transform.position;
             personalNodeController.SpawnNode(nodeDefinition, spawnPosition);
+
+            var spawnedNode = personalNodeController.ActiveNode;
+            if (spawnedNode == null)
+            {
+                LogDebug("Personal node spawn reported success but no active instance was found. Resuming NPC respawn.");
+                npcCombatant?.ResumeRespawn(respawnDelay);
+                return;
+            }
+
+            if (spawnedNode.IsExpired)
+            {
+                LogDebug("Personal node expired immediately after spawning. Resuming NPC respawn.");
+                npcCombatant?.ResumeRespawn(respawnDelay);
+                return;
+            }
+
+            AttachTrackedNode(spawnedNode, respawnDelay);
 
             LogDebug($"Spawned personal ore node '{nodeDefinition.name}' for '{killingPlayer.name}' at {spawnPosition}.");
         }
@@ -121,6 +158,52 @@ namespace Skills.Mining
                 return;
 
             Debug.Log($"[OreMonsterRewardController] {message}", this);
+        }
+
+        private void AttachTrackedNode(PersonalOreNode node, float respawnDelay)
+        {
+            DetachTrackedNode();
+
+            if (node == null)
+            {
+                npcCombatant?.ResumeRespawn(respawnDelay);
+                return;
+            }
+
+            trackedPersonalNode = node;
+            trackedRespawnDelaySeconds = Mathf.Max(0f, respawnDelay);
+            trackedPersonalNode.Expired += HandleTrackedNodeExpired;
+        }
+
+        private float DetachTrackedNode(bool resumeRespawn = false)
+        {
+            if (trackedPersonalNode == null)
+            {
+                float cachedDelay = trackedRespawnDelaySeconds;
+                trackedRespawnDelaySeconds = 0f;
+                if (resumeRespawn && npcCombatant != null)
+                    npcCombatant.ResumeRespawn(cachedDelay);
+                return cachedDelay;
+            }
+
+            trackedPersonalNode.Expired -= HandleTrackedNodeExpired;
+            trackedPersonalNode = null;
+            float delay = trackedRespawnDelaySeconds;
+            trackedRespawnDelaySeconds = 0f;
+
+            if (resumeRespawn && npcCombatant != null)
+                npcCombatant.ResumeRespawn(delay);
+
+            return delay;
+        }
+
+        private void HandleTrackedNodeExpired(PersonalOreNode node)
+        {
+            if (node != trackedPersonalNode)
+                return;
+
+            float delay = DetachTrackedNode(false);
+            npcCombatant?.ResumeRespawn(delay);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add coroutine tracking and suppression controls to `NpcCombatant` so respawns can be paused and resumed safely
- update `OreMonsterRewardController` to hold NPC respawns until the personal ore node despawns and resume on failure paths
- ensure edge cases like disabled controllers or missing node prefabs immediately restart the configured respawn timer

## Testing
- Not run (Unity play mode not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68de4129b44c832e834ef99d8230d75b