### PR TITLE
Restrict ore golem combat to pickaxes and auto-expire nodes

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -4,6 +4,8 @@ using UnityEngine;
 using Audio;
 using EquipmentSystem;
 using Skills;
+using Skills.Common;
+using Skills.Mining;
 using Player;
 using NPC;
 using Pets;
@@ -102,6 +104,12 @@ namespace Combat
         private IReadOnlyDictionary<SpellElement, Sprite> elementHitsplats;
         private readonly Dictionary<Transform, FloatingTextAnchorUtility.AnchorCache> hitsplatAnchorCache = new Dictionary<Transform, FloatingTextAnchorUtility.AnchorCache>();
 
+        [Header("Feedback")]
+        [SerializeField, Tooltip("Anchor used when displaying combat restriction feedback popups.")]
+        private Transform floatingTextAnchor;
+
+        private const string PickaxeRequirementMessage = "This golem, can only be harmed with a pickaxe";
+
         private void Awake()
         {
             EnsureObstructionMaskConfigured();
@@ -135,6 +143,13 @@ namespace Combat
                 maxHitHitsplat = hitSplatLibrary.MaxHitHitsplat;
                 elementHitsplats = hitSplatLibrary.ElementHitsplats;
             }
+
+            if (floatingTextAnchor == null)
+            {
+                floatingTextAnchor = transform.Find("FloatingTextAnchor");
+                if (floatingTextAnchor == null)
+                    floatingTextAnchor = transform;
+            }
         }
 
         private void OnValidate()
@@ -162,6 +177,11 @@ namespace Combat
         {
             if (target == null || !target.IsAlive)
                 return false;
+            if (RequiresPickaxeForTarget(target) && !HasPickaxeEquipped())
+            {
+                ShowPickaxeRequirementFeedback();
+                return false;
+            }
             if (Vector2.Distance(transform.position, target.transform.position) > GetCurrentAttackRange())
                 return false;
             if (!HasLineOfSight(target.transform))
@@ -181,7 +201,7 @@ namespace Combat
             if (PetDropSystem.GuardModeEnabled)
             {
                 var pet = PetDropSystem.ActivePetCombat;
-                pet?.CommandAttack(target);
+                pet?.CommandAttack(target, false);
             }
             return true;
         }
@@ -368,6 +388,11 @@ namespace Combat
                 {
                     yield return new WaitForSeconds(CombatMath.TICK_SECONDS * 0.25f);
                     continue;
+                }
+                if (RequiresPickaxeForTarget(target) && !HasPickaxeEquipped())
+                {
+                    ShowPickaxeRequirementFeedback();
+                    break;
                 }
                 mover?.FaceTarget(target.transform);
                 OnAttackStart?.Invoke();
@@ -634,6 +659,44 @@ namespace Combat
             }
 
             FreezeUtility.ApplyFreezeTicks(freezeController.gameObject, spell.freezeDurationTicks, BuffSourceType.Combat, spell.name);
+        }
+
+        private bool RequiresPickaxeForTarget(CombatTarget target)
+        {
+            if (target == null)
+                return false;
+
+            if (target is NpcCombatant npcCombatant)
+                return npcCombatant.GetComponent<OreMonsterRewardController>() != null;
+
+            if (target is MonoBehaviour behaviour)
+            {
+                return behaviour.GetComponent<OreMonsterRewardController>() != null;
+            }
+
+            return false;
+        }
+
+        private bool HasPickaxeEquipped()
+        {
+            if (equipmentComponent == null)
+                return false;
+
+            Inventory.InventoryEntry weaponEntry = equipmentComponent.GetEquipped(Inventory.EquipmentSlot.Weapon);
+            var item = weaponEntry.item;
+            if (item == null)
+                return false;
+
+            return PickaxeUtility.IsPickaxe(item);
+        }
+
+        private void ShowPickaxeRequirementFeedback()
+        {
+            var anchor = floatingTextAnchor != null ? floatingTextAnchor : transform;
+            if (anchor == null)
+                anchor = transform;
+
+            GatheringFloatingTextService.TryShowAtAnchor(PickaxeRequirementMessage, anchor);
         }
 
         private void ApplyHalberdAoe(CombatantStats attacker, CombatTarget primaryTarget, int primaryDamage, int maxHit)

--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -811,7 +811,7 @@ namespace NPC
             if (!hasHitPlayer && playerTarget != null && PetDropSystem.GuardModeEnabled)
             {
                 var pet = PetDropSystem.ActivePetCombat;
-                pet?.CommandAttack(combatant);
+                pet?.CommandAttack(combatant, false);
                 hasHitPlayer = true;
             }
         }

--- a/Assets/Scripts/NPC/Interaction/NpcInteractable.cs
+++ b/Assets/Scripts/NPC/Interaction/NpcInteractable.cs
@@ -84,7 +84,7 @@ namespace NPC
             var combatTarget = GetComponent<CombatTarget>();
             if (!PetDropSystem.GuardModeEnabled && PetDropSystem.ActivePetCombat != null && combatTarget != null)
             {
-                PetDropSystem.ActivePetCombat.CommandAttack(combatTarget);
+                PetDropSystem.ActivePetCombat.CommandAttack(combatTarget, true);
                 return;
             }
 
@@ -205,7 +205,7 @@ namespace NPC
             var pet = PetDropSystem.ActivePetCombat;
             var target = GetComponent<CombatTarget>();
             if (pet != null && target != null)
-                pet.CommandAttack(target);
+                pet.CommandAttack(target, true);
         }
     }
 }

--- a/Assets/Scripts/NPC/Interaction/NpcShopOpener.cs
+++ b/Assets/Scripts/NPC/Interaction/NpcShopOpener.cs
@@ -110,7 +110,7 @@ namespace NPC
             var combatTarget = GetComponent<CombatTarget>();
             if (!PetDropSystem.GuardModeEnabled && PetDropSystem.ActivePetCombat != null && combatTarget != null)
             {
-                PetDropSystem.ActivePetCombat.CommandAttack(combatTarget);
+                PetDropSystem.ActivePetCombat.CommandAttack(combatTarget, true);
                 return;
             }
 

--- a/Assets/Scripts/Pets/PetCombatController.cs
+++ b/Assets/Scripts/Pets/PetCombatController.cs
@@ -5,6 +5,8 @@ using Combat;
 using EquipmentSystem;
 using NPC;
 using Skills;
+using Skills.Common;
+using Skills.Mining;
 using UI;
 using Player;
 
@@ -24,6 +26,9 @@ namespace Pets
 
         [SerializeField, Tooltip("Vertical offset for hitsplats when no floating text anchor exists.")]
         private float hitsplatFallbackOffset = 1f;
+
+        [SerializeField, Tooltip("Controller that maintains the floating text anchor for this pet.")]
+        private PetFloatingTextController floatingTextController;
 
         /// <summary>
         /// Shared cache so pets reuse a single hitsplat library loaded from the Resources
@@ -104,16 +109,27 @@ namespace Pets
                 zeroHitsplat = hitSplatLibrary.ZeroDamageHitsplat;
                 maxHitHitsplat = hitSplatLibrary.MaxHitHitsplat;
             }
+
+            if (floatingTextController == null)
+                floatingTextController = GetComponent<PetFloatingTextController>() ?? GetComponentInChildren<PetFloatingTextController>();
         }
 
         /// <summary>Returns true if this pet has combat capabilities.</summary>
         public bool CanFight => definition != null && definition.canFight;
 
         /// <summary>Order the pet to attack the given combat target.</summary>
-        public void CommandAttack(CombatTarget target)
+        public void CommandAttack(CombatTarget target, bool fromDirectCommand = false)
         {
             if (!CanFight || target == null || !target.IsAlive)
             {
+                CancelAttack();
+                return;
+            }
+
+            if (IsOreGolemTarget(target))
+            {
+                if (fromDirectCommand)
+                    ShowOreGolemBlockedFeedback();
                 CancelAttack();
                 return;
             }
@@ -314,6 +330,33 @@ namespace Pets
                 Vector3 hitsplatPosition = FloatingTextAnchorUtility.ResolveAnchorPosition(target.transform, hitsplatFallbackOffset, hitsplatAnchorCache);
                 FloatingText.Show("0", hitsplatPosition, Color.white, null, zeroHitsplat);
             }
+        }
+
+        private bool IsOreGolemTarget(CombatTarget target)
+        {
+            if (target == null)
+                return false;
+
+            if (target is NpcCombatant npcCombatant)
+                return npcCombatant.GetComponent<OreMonsterRewardController>() != null;
+
+            if (target is MonoBehaviour behaviour)
+                return behaviour.GetComponent<OreMonsterRewardController>() != null;
+
+            return false;
+        }
+
+        private void ShowOreGolemBlockedFeedback()
+        {
+            string petName = definition != null && !string.IsNullOrWhiteSpace(definition.displayName)
+                ? definition.displayName
+                : name;
+            string message = $"\"{petName}\" cannot harm the Golem, due to its magical properties";
+            Transform anchor = floatingTextController != null ? floatingTextController.FloatingTextAnchor : transform;
+            if (anchor == null)
+                anchor = transform;
+
+            GatheringFloatingTextService.TryShowAtAnchor(message, anchor);
         }
 
         /// <summary>

--- a/Assets/Scripts/Skills/Mining/Core/PersonalOreNode.cs
+++ b/Assets/Scripts/Skills/Mining/Core/PersonalOreNode.cs
@@ -34,6 +34,10 @@ namespace Skills.Mining
         [Tooltip("Sprite renderers that should only be visible to the owning player.")]
         [SerializeField] private SpriteRenderer[] ownerOnlySpriteRenderers;
 
+        [Header("Despawn Rules")]
+        [Tooltip("Maximum distance (in tiles) the owner can move away before the node despawns.")]
+        [SerializeField] private float ownerDespawnDistanceTiles = 12f;
+
         private MiningPersonalNodeController ownerController;
         private MineableRock mineableRock;
         private OreMonsterNodeDefinition sourceDefinition;
@@ -214,6 +218,13 @@ namespace Skills.Mining
 
             RefreshOwnershipCacheIfNeeded();
 
+            if (ShouldExpireDueToOwnerDistance())
+            {
+                // Owner moved too far away; silently collapse the node without VFX spam.
+                ForceExpire(false);
+                return;
+            }
+
             remainingLifetimeSeconds = Mathf.Max(0f, remainingLifetimeSeconds - Util.Ticker.TickDuration);
             RaiseLifetimeChanged();
 
@@ -351,6 +362,32 @@ namespace Skills.Mining
 
             UpdateCountdownVisuals();
             LifetimeChanged?.Invoke(this, RemainingLifetimeSeconds, normalized);
+        }
+
+        /// <summary>
+        ///     Determines whether the owning player has exceeded the despawn distance threshold.
+        ///     When the owner leaves the allowed radius the node should immediately expire.
+        /// </summary>
+        private bool ShouldExpireDueToOwnerDistance()
+        {
+            if (ownerController == null)
+                return true;
+
+            var controllerTransform = ownerController.transform;
+            if (controllerTransform == null || !ownerController.isActiveAndEnabled)
+                return true;
+
+            float maxDistanceTiles = Mathf.Max(0f, ownerDespawnDistanceTiles);
+            if (maxDistanceTiles <= 0f)
+                return false;
+
+            Vector2 ownerPosition = controllerTransform.position;
+            Vector2 nodePosition = transform.position;
+            float sqrDistance = (ownerPosition - nodePosition).sqrMagnitude;
+            float maxDistanceWorld = maxDistanceTiles; // Tile size is 1 unit in world space.
+            float maxDistanceSqr = maxDistanceWorld * maxDistanceWorld;
+
+            return sqrDistance > maxDistanceSqr;
         }
     }
 }

--- a/Assets/Scripts/Skills/Mining/Core/PickaxeUtility.cs
+++ b/Assets/Scripts/Skills/Mining/Core/PickaxeUtility.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using Inventory;
+using UnityEngine;
+
+namespace Skills.Mining
+{
+    /// <summary>
+    ///     Shared helper that resolves whether an <see cref="ItemData"/> represents a pickaxe.
+    ///     The lookup prefers dedicated pickaxe definitions when available while falling back
+    ///     to resource heuristics so runtime checks remain resilient.
+    /// </summary>
+    public static class PickaxeUtility
+    {
+        private static readonly StringComparer IdComparer = StringComparer.OrdinalIgnoreCase;
+        private static HashSet<string> cachedPickaxeIds;
+        private static bool cacheInitialised;
+
+        /// <summary>
+        ///     Determines whether the supplied item is classified as a pickaxe.
+        /// </summary>
+        /// <param name="item">Item data to evaluate.</param>
+        /// <returns><c>true</c> when the item is recognised as a pickaxe.</returns>
+        public static bool IsPickaxe(ItemData item)
+        {
+            if (item == null)
+                return false;
+
+            EnsureCache();
+            return cachedPickaxeIds != null && cachedPickaxeIds.Contains(item.id);
+        }
+
+        /// <summary>
+        ///     Determines whether the supplied item identifier is classified as a pickaxe.
+        /// </summary>
+        /// <param name="itemId">Identifier to evaluate.</param>
+        /// <returns><c>true</c> when the identifier maps to a known pickaxe.</returns>
+        public static bool IsPickaxeId(string itemId)
+        {
+            if (string.IsNullOrWhiteSpace(itemId))
+                return false;
+
+            EnsureCache();
+            return cachedPickaxeIds != null && cachedPickaxeIds.Contains(itemId.Trim());
+        }
+
+        /// <summary>
+        ///     Clears the cached pickaxe identifiers. Primarily exposed for editor/testing usage.
+        /// </summary>
+        public static void ClearCache()
+        {
+            cachedPickaxeIds?.Clear();
+            cacheInitialised = false;
+        }
+
+        private static void EnsureCache()
+        {
+            if (cacheInitialised)
+                return;
+
+            cacheInitialised = true;
+            cachedPickaxeIds = new HashSet<string>(IdComparer);
+
+            // Attempt to use explicit pickaxe definitions first so designers can add new picks
+            // without touching code. When no definitions are present we gracefully fall back to
+            // name-based heuristics using the item database under Resources/Item.
+            try
+            {
+                var definitions = Resources.LoadAll<PickaxeDefinition>(string.Empty);
+                for (int i = 0; i < definitions.Length; i++)
+                {
+                    var definition = definitions[i];
+                    if (definition == null)
+                        continue;
+
+                    string id = definition.Id;
+                    if (!string.IsNullOrWhiteSpace(id))
+                        cachedPickaxeIds.Add(id.Trim());
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"[PickaxeUtility] Failed to load pickaxe definitions: {ex.Message}");
+            }
+
+            if (cachedPickaxeIds.Count > 0)
+                return;
+
+            try
+            {
+                var items = Resources.LoadAll<ItemData>("Item");
+                for (int i = 0; i < items.Length; i++)
+                {
+                    var item = items[i];
+                    if (item == null)
+                        continue;
+
+                    if (ContainsPickaxeKeyword(item.id) || ContainsPickaxeKeyword(item.itemName))
+                        cachedPickaxeIds.Add(item.id);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"[PickaxeUtility] Failed to resolve pickaxe items from Resources: {ex.Message}");
+            }
+        }
+
+        private static bool ContainsPickaxeKeyword(string value)
+        {
+            return !string.IsNullOrWhiteSpace(value)
+                   && value.IndexOf("pickaxe", StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- auto-despawn personal ore nodes when their owner travels more than 12 tiles away
- add a mining pickaxe utility and enforce pickaxe-equipped checks in the combat controller for ore golems
- block pets from attacking ore golems, surface player/pet feedback, and ensure guard mode respects the restriction

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de487441b4832e83ef81017af4339f