### PR TITLE
Align pets and mining overlays with project layers

### DIFF
--- a/Assets/Scripts/Pets/PetSpawner.cs
+++ b/Assets/Scripts/Pets/PetSpawner.cs
@@ -24,6 +24,14 @@ namespace Pets
             var go = new GameObject($"Pet_{def.id}");
             go.transform.position = position;
 
+            // Ensure the spawned pet uses the dedicated physics layer so collision filters,
+            // targeting, and raycasts that operate on layer masks treat the familiar correctly.
+            // The live project names the layer "Pets" (layer index 9) but we honour a couple of
+            // legacy names in case older data still relies on a different capitalisation.
+            int petLayer = ResolveLayerIndex("Pets", "Pet", "PET");
+            if (petLayer >= 0)
+                go.layer = petLayer;
+
             var sr = go.AddComponent<SpriteRenderer>();
             sr.sortingLayerName = "Characters";
             if (player != null)
@@ -178,6 +186,29 @@ namespace Pets
             floatingTextController.RefreshAnchorPosition();
 
             return go;
+        }
+
+        /// <summary>
+        ///     Attempts to resolve the first valid physics layer index from the supplied list of
+        ///     potential names. Returns -1 when none of the names map to a configured layer.
+        /// </summary>
+        private static int ResolveLayerIndex(params string[] layerNames)
+        {
+            if (layerNames == null || layerNames.Length == 0)
+                return -1;
+
+            for (int i = 0; i < layerNames.Length; i++)
+            {
+                string layerName = layerNames[i];
+                if (string.IsNullOrEmpty(layerName))
+                    continue;
+
+                int layer = LayerMask.NameToLayer(layerName);
+                if (layer >= 0)
+                    return layer;
+            }
+
+            return -1;
         }
     }
 }

--- a/Assets/Scripts/Skills/Mining/Core/PersonalOreNode.cs
+++ b/Assets/Scripts/Skills/Mining/Core/PersonalOreNode.cs
@@ -38,6 +38,11 @@ namespace Skills.Mining
         [Tooltip("Maximum distance (in tiles) the owner can move away before the node despawns.")]
         [SerializeField] private float ownerDespawnDistanceTiles = 12f;
 
+        private static readonly string[] OwnerOverlayPreferredSortingLayerNames = { "UI", "Characters" };
+        private const string OwnerOverlayLayerName = "UI";
+        private const int OwnerOverlaySortingOrderOffset = 50;
+        private const int OwnerOverlayMinimumSortingOrder = 1000;
+
         private MiningPersonalNodeController ownerController;
         private MineableRock mineableRock;
         private OreMonsterNodeDefinition sourceDefinition;
@@ -99,6 +104,23 @@ namespace Skills.Mining
         /// </summary>
         public bool IsExpired => isExpired;
 
+        /// <summary>
+        ///     Canvas that renders the solo-lock icon and lifetime timer for the owning player.
+        /// </summary>
+        public Canvas OwnerOnlyCanvas => ownerOnlyCanvas;
+
+        /// <summary>
+        ///     Sorting layer identifier applied to the ownership canvas so other systems can align
+        ///     world-space UI (such as the mining progress bar) without guessing priorities.
+        /// </summary>
+        public int OwnerOverlaySortingLayerId => ownerOnlyCanvas != null ? ownerOnlyCanvas.sortingLayerID : 0;
+
+        /// <summary>
+        ///     Sorting order assigned to the ownership canvas. Returns <see cref="int.MinValue"/>
+        ///     when no canvas is configured so callers can detect the absence of overlay data.
+        /// </summary>
+        public int OwnerOverlaySortingOrder => ownerOnlyCanvas != null ? ownerOnlyCanvas.sortingOrder : int.MinValue;
+
         private void Awake()
         {
             // Ensure the required mineable rock component exists so the prefab remains valid.
@@ -139,6 +161,7 @@ namespace Skills.Mining
             LegacyFontProvider.ApplyTo(ownerOnlyText);
 
             ApplyDefinitionVisuals();
+            ConfigureOwnerOverlaySorting();
             ConfigureOwnershipVisibility();
             RaiseLifetimeChanged();
 
@@ -323,6 +346,162 @@ namespace Skills.Mining
                 var renderer = ownerOnlySpriteRenderers[i];
                 if (renderer != null && sourceDefinition.SoloLockSprite != null)
                     renderer.sprite = sourceDefinition.SoloLockSprite;
+            }
+        }
+
+        /// <summary>
+        ///     Ensures the ownership overlay (solo-lock icon and timer) renders above the rock and
+        ///     other character layers so the player can always see their reservation details.
+        /// </summary>
+        private void ConfigureOwnerOverlaySorting()
+        {
+            if (ownerOnlyCanvas == null)
+                return;
+
+            ApplyOwnerOverlayLayer();
+            ownerOnlyCanvas.overrideSorting = true;
+
+            var referenceRenderer = ResolveReferenceRenderer();
+
+            string overlaySortingLayerName = ResolveOwnerOverlaySortingLayerName();
+
+            if (!string.IsNullOrEmpty(overlaySortingLayerName))
+            {
+                ownerOnlyCanvas.sortingLayerName = overlaySortingLayerName;
+            }
+            else if (referenceRenderer != null)
+            {
+                ownerOnlyCanvas.sortingLayerID = referenceRenderer.sortingLayerID;
+            }
+
+            int desiredOrder = OwnerOverlayMinimumSortingOrder;
+            if (referenceRenderer != null)
+            {
+                desiredOrder = Mathf.Max(
+                    desiredOrder,
+                    referenceRenderer.sortingOrder + OwnerOverlaySortingOrderOffset);
+            }
+
+            ownerOnlyCanvas.sortingOrder = desiredOrder;
+
+            if (ownerOnlySpriteRenderers == null)
+                return;
+
+            for (int i = 0; i < ownerOnlySpriteRenderers.Length; i++)
+            {
+                var renderer = ownerOnlySpriteRenderers[i];
+                if (renderer == null)
+                    continue;
+
+                if (!string.IsNullOrEmpty(overlaySortingLayerName))
+                    renderer.sortingLayerName = overlaySortingLayerName;
+                else if (referenceRenderer != null)
+                    renderer.sortingLayerID = referenceRenderer.sortingLayerID;
+
+                renderer.sortingOrder = desiredOrder;
+            }
+        }
+
+        /// <summary>
+        ///     Determines the most appropriate sorting layer for the owner overlay.
+        /// </summary>
+        private static string ResolveOwnerOverlaySortingLayerName()
+        {
+            for (int i = 0; i < OwnerOverlayPreferredSortingLayerNames.Length; i++)
+            {
+                string candidate = OwnerOverlayPreferredSortingLayerNames[i];
+                if (SortingLayerExists(candidate))
+                    return candidate;
+            }
+
+            return string.Empty;
+        }
+
+        /// <summary>
+        ///     Applies the UI physics layer to the ownership overlay so it renders above characters
+        ///     and participates in layer-based filtering correctly.
+        /// </summary>
+        private void ApplyOwnerOverlayLayer()
+        {
+            if (ownerOnlyCanvas == null)
+                return;
+
+            ApplyOwnerOverlayLayer(ownerOnlyCanvas.gameObject);
+
+            if (ownerOnlySpriteRenderers == null)
+                return;
+
+            for (int i = 0; i < ownerOnlySpriteRenderers.Length; i++)
+            {
+                var renderer = ownerOnlySpriteRenderers[i];
+                if (renderer != null)
+                    ApplyOwnerOverlayLayer(renderer.gameObject);
+            }
+        }
+
+        /// <summary>
+        ///     Applies the configured overlay layer to the provided game object and its children.
+        /// </summary>
+        private void ApplyOwnerOverlayLayer(GameObject target)
+        {
+            if (target == null)
+                return;
+
+            int overlayLayer = LayerMask.NameToLayer(OwnerOverlayLayerName);
+            if (overlayLayer < 0)
+                return;
+
+            SetLayerRecursively(target.transform, overlayLayer);
+        }
+
+        /// <summary>
+        ///     Attempts to locate the sprite renderer responsible for visualising the rock so the
+        ///     overlay can inherit sensible sorting priorities.
+        /// </summary>
+        private SpriteRenderer ResolveReferenceRenderer()
+        {
+            if (mineableRock != null)
+            {
+                var renderer = mineableRock.GetComponent<SpriteRenderer>();
+                if (renderer != null)
+                    return renderer;
+            }
+
+            return GetComponent<SpriteRenderer>();
+        }
+
+        /// <summary>
+        ///     Determines whether a sorting layer with the supplied name exists in the project.
+        /// </summary>
+        private static bool SortingLayerExists(string layerName)
+        {
+            if (string.IsNullOrEmpty(layerName))
+                return false;
+
+            var layers = SortingLayer.layers;
+            for (int i = 0; i < layers.Length; i++)
+            {
+                if (string.Equals(layers[i].name, layerName, StringComparison.Ordinal))
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        ///     Recursively assigns the provided layer index to the transform and all of its children.
+        /// </summary>
+        private static void SetLayerRecursively(Transform target, int layer)
+        {
+            if (target == null)
+                return;
+
+            target.gameObject.layer = layer;
+            for (int i = 0; i < target.childCount; i++)
+            {
+                var child = target.GetChild(i);
+                if (child != null)
+                    SetLayerRecursively(child, layer);
             }
         }
 

--- a/Assets/Scripts/Skills/Mining/UI/MiningUI.cs
+++ b/Assets/Scripts/Skills/Mining/UI/MiningUI.cs
@@ -28,6 +28,7 @@ namespace Skills.Mining
         private GameObject pickaxeRoot;
         private SpriteRenderer pickaxeRenderer;
         private Canvas progressCanvas;
+        private const string ProgressLayerName = "UI";
         // Offset from the targeted rock's position where the progress bar will appear.
         // Reduced the vertical component to half of its previous value so the bar sits closer to the object.
         private readonly Vector3 offset = new Vector3(0f, 0.75f, 0f);
@@ -170,6 +171,7 @@ namespace Skills.Mining
 
             progressRoot = new GameObject("MiningProgress");
             progressRoot.transform.SetParent(transform);
+            ApplyProgressLayer(progressRoot);
 
             progressCanvas = progressRoot.AddComponent<Canvas>();
             progressCanvas.renderMode = RenderMode.WorldSpace;
@@ -180,6 +182,7 @@ namespace Skills.Mining
 
             var bg = new GameObject("Background");
             bg.transform.SetParent(progressRoot.transform, false);
+            ApplyProgressLayer(bg);
             var bgImage = bg.AddComponent<Image>();
             bgImage.color = new Color(0f, 0f, 0f, 0.5f);
             var bgSprite = Sprite.Create(Texture2D.whiteTexture, new Rect(0, 0, 1, 1), new Vector2(0.5f, 0.5f));
@@ -189,6 +192,7 @@ namespace Skills.Mining
 
             var fill = new GameObject("Fill");
             fill.transform.SetParent(bg.transform, false);
+            ApplyProgressLayer(fill);
             progressImage = fill.AddComponent<Image>();
             progressImage.color = SkillingProgressColorGradient.Evaluate(0f);
             progressImage.sprite = bgSprite;
@@ -211,9 +215,43 @@ namespace Skills.Mining
 
             pickaxeRoot = new GameObject("MiningPickaxe");
             pickaxeRoot.transform.SetParent(transform);
+            ApplyProgressLayer(pickaxeRoot);
             pickaxeRenderer = pickaxeRoot.AddComponent<SpriteRenderer>();
             pickaxeRenderer.sortingOrder = 100;
             pickaxeRoot.SetActive(false);
+        }
+
+        /// <summary>
+        ///     Applies the configured UI physics layer to the provided game object so the HUD
+        ///     participates in layer-based filtering correctly.
+        /// </summary>
+        private void ApplyProgressLayer(GameObject target)
+        {
+            if (target == null)
+                return;
+
+            int uiLayer = LayerMask.NameToLayer(ProgressLayerName);
+            if (uiLayer < 0)
+                return;
+
+            SetLayerRecursively(target.transform, uiLayer);
+        }
+
+        /// <summary>
+        ///     Recursively applies the given layer index to the provided transform and all children.
+        /// </summary>
+        private static void SetLayerRecursively(Transform root, int layer)
+        {
+            if (root == null)
+                return;
+
+            root.gameObject.layer = layer;
+            for (int i = 0; i < root.childCount; i++)
+            {
+                var child = root.GetChild(i);
+                if (child != null)
+                    SetLayerRecursively(child, layer);
+            }
         }
 
         private void HandleStart(MineableRock rock)
@@ -238,20 +276,78 @@ namespace Skills.Mining
                     pickaxeRoot.SetActive(true);
                 }
             }
+
             var targetRenderer = rock.GetComponent<SpriteRenderer>();
-            if (targetRenderer != null)
+            var personalNode = rock.GetComponent<PersonalOreNode>();
+            if (personalNode == null)
+                personalNode = rock.GetComponentInParent<PersonalOreNode>();
+
+            if (targetRenderer != null && pickaxeRenderer != null)
             {
-                if (progressCanvas != null)
-                {
-                    progressCanvas.sortingLayerID = targetRenderer.sortingLayerID;
-                    progressCanvas.sortingOrder = targetRenderer.sortingOrder + 1;
-                }
-                if (pickaxeRenderer != null)
-                {
-                    pickaxeRenderer.sortingLayerID = targetRenderer.sortingLayerID;
-                    pickaxeRenderer.sortingOrder = targetRenderer.sortingOrder + 2;
-                }
+                pickaxeRenderer.sortingLayerID = targetRenderer.sortingLayerID;
+                pickaxeRenderer.sortingOrder = targetRenderer.sortingOrder + 2;
             }
+
+            if (progressCanvas != null)
+            {
+                int progressLayerId = progressCanvas.sortingLayerID;
+                int progressOrder = progressCanvas.sortingOrder;
+                int minimumOrder = int.MinValue;
+
+                if (targetRenderer != null)
+                {
+                    progressLayerId = targetRenderer.sortingLayerID;
+                    minimumOrder = targetRenderer.sortingOrder + 1;
+                    progressOrder = minimumOrder;
+                }
+
+                if (personalNode != null)
+                {
+                    var overlayCanvas = personalNode.OwnerOnlyCanvas;
+                    if (overlayCanvas != null)
+                    {
+                        int overlayLayerId = personalNode.OwnerOverlaySortingLayerId;
+                        if (overlayLayerId != 0)
+                        {
+                            progressLayerId = overlayLayerId;
+                        }
+                        else if (!string.IsNullOrEmpty(overlayCanvas.sortingLayerName))
+                        {
+                            progressCanvas.sortingLayerName = overlayCanvas.sortingLayerName;
+                            progressLayerId = progressCanvas.sortingLayerID;
+                        }
+
+                        int overlayOrder = personalNode.OwnerOverlaySortingOrder;
+                        if (overlayOrder > int.MinValue + 1)
+                        {
+                            int maxOrder = overlayOrder - 1;
+                            if (minimumOrder == int.MinValue)
+                            {
+                                progressOrder = maxOrder;
+                            }
+                            else if (maxOrder >= minimumOrder)
+                            {
+                                progressOrder = Mathf.Clamp(progressOrder, minimumOrder, maxOrder);
+                            }
+                            else
+                            {
+                                progressOrder = minimumOrder;
+                            }
+                        }
+                    }
+                }
+                else if (minimumOrder != int.MinValue)
+                {
+                    progressOrder = minimumOrder;
+                }
+
+                if (minimumOrder != int.MinValue)
+                    progressOrder = Mathf.Max(progressOrder, minimumOrder);
+
+                progressCanvas.sortingLayerID = progressLayerId;
+                progressCanvas.sortingOrder = progressOrder;
+            }
+
             if (Ticker.Instance != null)
                 Ticker.Instance.Subscribe(this);
         }


### PR DESCRIPTION
## Summary
- ensure runtime-spawned pets use the dedicated Pets layer via resilient lookup
- force personal ore ownership overlays onto the UI layer and preferred sorting so the solo timer/icon render above characters and pets
- assign the mining progress HUD to the UI layer to keep the bar beneath the overlay while respecting layer-based filters

## Testing
- Not Run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de4f2f6578832e9405286cab2c2eca