### PR TITLE
Fix ambiguous Object reference in PersonalOreNode

### DIFF
--- a/Assets/Scripts/Skills/Mining/Core/PersonalOreNode.cs
+++ b/Assets/Scripts/Skills/Mining/Core/PersonalOreNode.cs
@@ -429,11 +429,11 @@ namespace Skills.Mining
             EnsureCharacterLayerCache();
 
 #if UNITY_2023_1_OR_NEWER
-            var renderers = Object.FindObjectsByType<SpriteRenderer>(
+            var renderers = UnityEngine.Object.FindObjectsByType<SpriteRenderer>(
                 FindObjectsInactive.Exclude,
                 FindObjectsSortMode.None);
 #else
-            var renderers = Object.FindObjectsOfType<SpriteRenderer>();
+            var renderers = UnityEngine.Object.FindObjectsOfType<SpriteRenderer>();
 #endif
 
             int maximumOrder = int.MinValue;


### PR DESCRIPTION
## Summary
- qualify calls to Unity's Object API in PersonalOreNode to avoid ambiguity with System.Object

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de6e9af4a4832eb523cea83f3ed6cb