### PR TITLE
Fix sprite renderer visibility check

### DIFF
--- a/Assets/Scripts/Skills/Mining/Core/PersonalOreNode.cs
+++ b/Assets/Scripts/Skills/Mining/Core/PersonalOreNode.cs
@@ -440,7 +440,13 @@ namespace Skills.Mining
             for (int i = 0; i < renderers.Length; i++)
             {
                 var renderer = renderers[i];
-                if (renderer == null || !renderer.isActiveAndEnabled)
+                if (renderer == null)
+                    continue;
+
+                // SpriteRenderers do not inherit from Behaviour, so they do not expose
+                // isActiveAndEnabled. Instead, validate both the GameObject hierarchy
+                // state and the renderer's enabled flag to ensure the sprite is visible.
+                if (!renderer.gameObject.activeInHierarchy || !renderer.enabled)
                     continue;
 
                 if (!IsCharacterLayer(renderer.gameObject.layer))


### PR DESCRIPTION
## Summary
- replace the SpriteRenderer visibility guard in PersonalOreNode with active hierarchy and enabled checks
- add inline documentation clarifying why Behaviour.isActiveAndEnabled is unavailable on SpriteRenderer

## Testing
- not run (editor-only change)


------
https://chatgpt.com/codex/tasks/task_e_68de6f3495d4832e8446fc8ed28b4c09