### PR TITLE
Add line-of-sight bypass component for combat checks

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -549,8 +549,24 @@ namespace Combat
 
             Vector2 origin = transform.position;
             Vector2 destination = targetTransform.position;
+            DamageType damageType = DetermineActiveDamageType();
 
-            return LineOfSightUtility.HasLineOfSight(origin, destination, obstructionMask, transform, targetTransform);
+            bool ShouldIgnoreCollider(Collider2D collider)
+            {
+                if (collider == null)
+                    return false;
+
+                var bypass = collider.GetComponentInParent<CombatLineOfSightBypass>();
+                return bypass != null && bypass.AllowsDamageType(damageType);
+            }
+
+            return LineOfSightUtility.HasLineOfSight(
+                origin,
+                destination,
+                obstructionMask,
+                transform,
+                targetTransform,
+                ShouldIgnoreCollider);
         }
 
         protected virtual void ResolveAttack(CombatTarget target)

--- a/Assets/Scripts/Combat/LineOfSight/CombatLineOfSightBypass.cs
+++ b/Assets/Scripts/Combat/LineOfSight/CombatLineOfSightBypass.cs
@@ -1,0 +1,42 @@
+using UnityEngine;
+
+namespace Combat
+{
+    /// <summary>
+    /// Designer-friendly toggle that lets specific colliders permit certain damage types to
+    /// bypass line-of-sight checks. Useful for mining rocks or interactables that should block
+    /// melee swings while still allowing spells or ranged projectiles to pass through.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public sealed class CombatLineOfSightBypass : MonoBehaviour
+    {
+        [SerializeField, Tooltip("When enabled melee attacks treat this collider as transparent, allowing players and NPCs to strike through it. Ideal for rocks that should only be broken with ranged or magic damage.")]
+        private bool allowMelee = false;
+
+        [SerializeField, Tooltip("When enabled ranged attacks (arrows, thrown weapons) ignore this collider during line of sight checks. Use this to let ranged combat reach targets behind harvesting nodes without repositioning.")]
+        private bool allowRanged = true;
+
+        [SerializeField, Tooltip("When enabled magic spells can pass through this collider. Combine with disabled melee to recreate OSRS-style obstacles that force players to use spells.")]
+        private bool allowMagic = true;
+
+        /// <summary>
+        /// Returns true when the supplied damage type is allowed to pass through this collider.
+        /// </summary>
+        public bool AllowsDamageType(DamageType type)
+        {
+            switch (type)
+            {
+                case DamageType.Melee:
+                    return allowMelee;
+                case DamageType.Ranged:
+                    return allowRanged;
+                case DamageType.Magic:
+                    return allowMagic;
+                default:
+                    // Non-standard damage types (poison, dragonfire, etc.) do not interact with
+                    // harvesting obstacles, so treat them as unblocked by default.
+                    return true;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -684,6 +684,26 @@ namespace NPC
                     return true;
             }
 
+            DamageType attackType = DamageType.Melee;
+            if (combatant != null)
+            {
+                var profile = combatant.Profile;
+                if (profile != null)
+                {
+                    attackType = profile.AttackType;
+                }
+                else
+                {
+                    var stats = combatant.GetCombatantStats();
+                    if (stats != null)
+                        attackType = stats.DamageType;
+                }
+            }
+
+            var bypass = hitTransform.GetComponentInParent<CombatLineOfSightBypass>();
+            if (bypass != null && bypass.AllowsDamageType(attackType))
+                return true;
+
             // Allow pets and friendly NPCs to stand between combatants without blocking attacks.
             var pet = hitTransform.GetComponentInParent<PetCombatController>();
             if (pet != null)


### PR DESCRIPTION
## Summary
- add a CombatLineOfSightBypass component so designers can flag colliders that only allow certain damage types through
- update player and NPC line-of-sight checks to respect the bypass component based on their active damage type

## Testing
- not run (not applicable in container environment)


------
https://chatgpt.com/codex/tasks/task_e_68de72724840832e83fb6d7dc0117890