### PR TITLE
Add shared Direction8 helper and refactor facing systems

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -13,6 +13,7 @@ using UI;
 using Magic;
 using Status;
 using Status.Freeze;
+using Util;
 
 namespace Combat
 {
@@ -734,7 +735,8 @@ namespace Combat
                 return;
 
             Vector2 origin = transform.position;
-            Vector2 forward = FacingDirToVector(mover != null ? mover.FacingDir : 0);
+            Direction8 forwardDir = mover != null ? mover.FacingDir : Direction8.Down;
+            Vector2 forward = FacingDirToVector(forwardDir);
             if (forward.sqrMagnitude <= Mathf.Epsilon)
                 forward = Vector2.down;
 
@@ -804,19 +806,9 @@ namespace Combat
             }
         }
 
-        private static Vector2 FacingDirToVector(int facingDir)
+        private static Vector2 FacingDirToVector(Direction8 facingDir)
         {
-            switch (facingDir)
-            {
-                case 1:
-                    return Vector2.left;
-                case 2:
-                    return Vector2.right;
-                case 3:
-                    return Vector2.up;
-                default:
-                    return Vector2.down;
-            }
+            return Direction8Utility.ToVector(facingDir);
         }
 
         private void AwardXp(int damage, CombatStyle style, DamageType type)

--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -6,6 +6,7 @@ using EquipmentSystem;
 using Skills;
 using Player;
 using Pets;
+using Util;
 
 namespace NPC
 {
@@ -802,7 +803,7 @@ namespace NPC
             var animator = npcFacing?.Animator;
             if (animator != null)
             {
-                int facingDir = npcFacing.FacingDirection;
+                int facingDir = Direction8Utility.ToAnimatorIndex(npcFacing.FacingDirection);
                 if (animator.HasAttackAnimation(facingDir))
                 {
                     if (spriteSwapRoutine != null)

--- a/Assets/Scripts/NPC/Combat/NpcFacing.cs
+++ b/Assets/Scripts/NPC/Combat/NpcFacing.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using Util;
 
 namespace NPC
 {
@@ -11,10 +12,9 @@ namespace NPC
         private SpriteRenderer spriteRenderer;
 
         /// <summary>
-        /// Most recent facing direction.
-        /// 0 = down, 1 = left, 2 = right, 3 = up.
+        /// Most recent facing direction resolved through the shared <see cref="Direction8"/> helpers.
         /// </summary>
-        public int FacingDirection { get; private set; }
+        public Direction8 FacingDirection { get; private set; } = Direction8.Down;
 
         /// <summary>
         /// Animator used for sprite swaps and attack animations.
@@ -53,15 +53,12 @@ namespace NPC
             if (direction.sqrMagnitude <= Mathf.Epsilon)
                 return;
 
-            if (Mathf.Abs(direction.x) > Mathf.Abs(direction.y))
-                FacingDirection = direction.x < 0f ? 1 : 2;
-            else
-                FacingDirection = direction.y < 0f ? 0 : 3;
+            FacingDirection = Direction8Utility.FromVector(direction, allowDiagonals: true, fallback: FacingDirection);
 
             if (spriteAnimator != null)
-                spriteAnimator.SetFacing(FacingDirection);
+                spriteAnimator.SetFacing(Direction8Utility.ToAnimatorIndex(FacingDirection));
             else if (spriteRenderer != null)
-                spriteRenderer.flipX = FacingDirection == 2;
+                spriteRenderer.flipX = Direction8Utility.IsFacingRight(FacingDirection);
         }
     }
 }

--- a/Assets/Scripts/Pets/PetCombatController.cs
+++ b/Assets/Scripts/Pets/PetCombatController.cs
@@ -9,6 +9,7 @@ using Skills.Common;
 using Skills.Mining;
 using UI;
 using Player;
+using Util;
 
 namespace Pets
 {
@@ -278,25 +279,22 @@ namespace Pets
             float chance = CombatMath.ChanceToHit(atkRoll, defRoll);
             bool hit = Random.value < chance;
 
-            int facingDir = 0;
             Vector2 diff = target.transform.position - transform.position;
-            if (Mathf.Abs(diff.x) > Mathf.Abs(diff.y))
-                facingDir = diff.x < 0f ? 1 : 2;
-            else
-                facingDir = diff.y < 0f ? 0 : 3;
+            Direction8 facingDir = Direction8Utility.FromVector(diff, allowDiagonals: true, fallback: Direction8.Down);
+            int animatorFacing = Direction8Utility.ToAnimatorIndex(facingDir);
 
             if (spriteAnimator != null)
-                spriteAnimator.SetFacing(facingDir);
+                spriteAnimator.SetFacing(animatorFacing);
             else if (spriteRenderer != null)
-                spriteRenderer.flipX = facingDir == 2;
+                spriteRenderer.flipX = Direction8Utility.IsFacingRight(facingDir);
 
             if (animator != null)
                 animator.SetTrigger("Attack");
-            else if (spriteAnimator != null && spriteAnimator.HasHitAnimation(facingDir))
+            else if (spriteAnimator != null && spriteAnimator.HasHitAnimation(animatorFacing))
             {
                 if (spriteSwapRoutine != null)
                     StopCoroutine(spriteSwapRoutine);
-                spriteSwapRoutine = StartCoroutine(spriteAnimator.PlayHitAnimation(facingDir));
+                spriteSwapRoutine = StartCoroutine(spriteAnimator.PlayHitAnimation(animatorFacing));
             }
             else if (spriteRenderer != null && definition != null && definition.attackSprite != null)
             {

--- a/Assets/Scripts/Pets/PetFollower.cs
+++ b/Assets/Scripts/Pets/PetFollower.cs
@@ -159,13 +159,13 @@ namespace Pets
             if (spriteAnimator != null)
             {
                 if (!playerMoving && playerMover != null)
-                    spriteAnimator.SetFacing(playerMover.FacingDir);
+                    spriteAnimator.SetFacing(Direction8Utility.ToAnimatorIndex(playerMover.FacingDir));
                 spriteAnimator.UpdateVisuals(playerMoving ? velocity : Vector2.zero);
             }
             else if (sprite != null)
             {
                 if (!playerMoving && playerMover != null)
-                    sprite.flipX = playerMover.FacingDir == 1;
+                    sprite.flipX = Direction8Utility.IsFacingLeft(playerMover.FacingDir);
                 else
                     sprite.flipX = newPos.x > player.position.x;
             }

--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -37,10 +37,13 @@ namespace Player
         [Tooltip("If assigned, these sprites will be applied directly each frame based on Dir/IsMoving. Leave null to rely on Animator clips.")]
         public Sprite idleDown, idleLeft, idleRight, idleUp;
         public Sprite walkDown, walkLeft, walkRight, walkUp;
-        [Tooltip("If true, flip right-facing sprites for left-facing movement/idle.")]
-        public bool useFlipXForLeft;
-        [Tooltip("If true, flip left-facing sprites for right-facing movement/idle.")]
-        public bool useFlipXForRight;
+        [Header("Mirroring")]
+        [Tooltip("If true, reuse right-facing sprites for any left-facing orientation (including diagonals).")]
+        [SerializeField]
+        private bool useFlipXForLeft;
+        [Tooltip("If true, reuse left-facing sprites for any right-facing orientation (including diagonals).")]
+        [SerializeField]
+        private bool useFlipXForRight;
 
 #if ENABLE_INPUT_SYSTEM
         [Header("Input")]
@@ -96,12 +99,11 @@ namespace Player
 
         private const string PositionKey = "PlayerPosition";
 
-        // 0=Down, 1=Left, 2=Right, 3=Up
-        private int facingDir = 0;
+        private Direction8 facingDir = Direction8.Down;
         private Vector2 moveDir;
 
-        /// <summary>Current facing direction: 0=Down, 1=Left, 2=Right, 3=Up.</summary>
-        public int FacingDir => facingDir;
+        /// <summary>Current facing direction.</summary>
+        public Direction8 FacingDir => facingDir;
 
         public bool IsMoving => moveDir.sqrMagnitude > 0f;
 
@@ -272,26 +274,23 @@ namespace Player
                 return;
             }
 
-            float x = 0f, y = 0f;
+            Vector2 inputDir = Vector2.zero;
 
 #if ENABLE_INPUT_SYSTEM
             Vector2 raw = moveAction != null ? moveActionValue : Vector2.zero;
             // Snap analog to -1/0/1 so animations are stable
-            x = Mathf.Abs(raw.x) < gamepadDeadzone ? 0f : Mathf.Sign(raw.x);
-            y = Mathf.Abs(raw.y) < gamepadDeadzone ? 0f : Mathf.Sign(raw.y);
+            raw.x = Mathf.Abs(raw.x) < gamepadDeadzone ? 0f : Mathf.Sign(raw.x);
+            raw.y = Mathf.Abs(raw.y) < gamepadDeadzone ? 0f : Mathf.Sign(raw.y);
 #else
             // Legacy input fallback if project uses Old/Both
-            x = Input.GetAxisRaw("Horizontal");
-            y = Input.GetAxisRaw("Vertical");
+            Vector2 raw = new Vector2(Input.GetAxisRaw("Horizontal"), Input.GetAxisRaw("Vertical"));
 #endif
 
-            if (fourWayOnly)
+            if (raw.sqrMagnitude > 0f)
             {
-                if (Mathf.Abs(y) > Mathf.Abs(x)) x = 0f;
-                else if (Mathf.Abs(x) > Mathf.Abs(y)) y = 0f;
+                Direction8 inputFacing = Direction8Utility.FromVector(raw, !fourWayOnly, facingDir);
+                inputDir = fourWayOnly ? Direction8Utility.ToCardinalVector(inputFacing) : Direction8Utility.ToVector(inputFacing);
             }
-
-            Vector2 inputDir = new Vector2(x, y).normalized;
 
             if (inputDir.sqrMagnitude > 0f)
             {
@@ -312,10 +311,7 @@ namespace Player
 
             if (moveDir.sqrMagnitude > 0f)
             {
-                if (Mathf.Abs(moveDir.x) > Mathf.Abs(moveDir.y))
-                    facingDir = moveDir.x < 0 ? 1 : 2; // left/right
-                else
-                    facingDir = moveDir.y < 0 ? 0 : 3; // down/up
+                facingDir = Direction8Utility.FromVector(moveDir, allowDiagonals: true, fallback: facingDir);
             }
 
             // Drive Animator (kept for future use and for state visibility)
@@ -326,20 +322,29 @@ namespace Player
 
         private void RefreshAnimator(bool isMoving)
         {
-            anim.SetBool("IsMoving", isMoving);
-            anim.SetInteger("Dir", facingDir);
+            if (anim == null)
+                return;
 
-            // --- OPTIONAL: Direct sprite override (solves your 'stuck on IdleDown_0' instantly) ---
+            Direction8 visualDir = facingDir;
+            int animatorDir = Direction8Utility.ToAnimatorIndex(visualDir);
+            Direction8 spriteDir = Direction8Utility.SnapToFourWay(visualDir);
+
+            anim.SetBool("IsMoving", isMoving);
+            anim.SetInteger("Dir", animatorDir);
+
+            if (sr == null)
+                return;
+
             Sprite desired = null;
             bool flip = false;
             if (isMoving)
             {
-                switch (facingDir)
+                switch (spriteDir)
                 {
-                    case 0:
+                    case Direction8.Down:
                         desired = walkDown ? walkDown : idleDown;
                         break;
-                    case 1:
+                    case Direction8.Left:
                         if (useFlipXForLeft)
                         {
                             desired = walkRight ? walkRight : idleRight;
@@ -350,7 +355,7 @@ namespace Player
                             desired = walkLeft ? walkLeft : idleLeft;
                         }
                         break;
-                    case 2:
+                    case Direction8.Right:
                         if (useFlipXForRight)
                         {
                             desired = walkLeft ? walkLeft : idleLeft;
@@ -361,19 +366,19 @@ namespace Player
                             desired = walkRight ? walkRight : idleRight;
                         }
                         break;
-                    case 3:
+                    case Direction8.Up:
                         desired = walkUp ? walkUp : idleUp;
                         break;
                 }
             }
             else
             {
-                switch (facingDir)
+                switch (spriteDir)
                 {
-                    case 0:
+                    case Direction8.Down:
                         desired = idleDown;
                         break;
-                    case 1:
+                    case Direction8.Left:
                         if (useFlipXForLeft)
                         {
                             desired = idleRight ? idleRight : walkRight;
@@ -384,7 +389,7 @@ namespace Player
                             desired = idleLeft;
                         }
                         break;
-                    case 2:
+                    case Direction8.Right:
                         if (useFlipXForRight)
                         {
                             desired = idleLeft ? idleLeft : walkLeft;
@@ -395,11 +400,12 @@ namespace Player
                             desired = idleRight;
                         }
                         break;
-                    case 3:
+                    case Direction8.Up:
                         desired = idleUp;
                         break;
                 }
             }
+
             if (desired != null && !freezeSprite)
             {
                 if (sr.flipX != flip)
@@ -442,10 +448,7 @@ namespace Player
                 return;
 
             Vector2 dir = (Vector2)target.position - (Vector2)transform.position;
-            if (Mathf.Abs(dir.x) > Mathf.Abs(dir.y))
-                facingDir = dir.x < 0 ? 1 : 2;
-            else
-                facingDir = dir.y < 0 ? 0 : 3;
+            facingDir = Direction8Utility.FromVector(dir, allowDiagonals: true, fallback: facingDir);
 
             RefreshAnimator(moveDir.sqrMagnitude > 0f);
         }

--- a/Assets/Scripts/Skills/Beastmaster/MergedPetAttackAnimator.cs
+++ b/Assets/Scripts/Skills/Beastmaster/MergedPetAttackAnimator.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using Combat;
 using Pets;
 using Player;
+using Util;
 
 namespace Beastmaster
 {
@@ -67,11 +68,12 @@ namespace Beastmaster
 
         private void HandleAttack()
         {
-            int dir = mover != null ? mover.FacingDir : 0;
+            Direction8 dir = mover != null ? mover.FacingDir : Direction8.Down;
+            int animatorDir = Direction8Utility.ToAnimatorIndex(dir);
             if (animator != null && animator.runtimeAnimatorController != null)
                 animator.SetTrigger("Attack");
-            if (spriteAnimator != null && spriteAnimator.HasHitAnimation(dir))
-                StartCoroutine(PlayHit(dir));
+            if (spriteAnimator != null && spriteAnimator.HasHitAnimation(animatorDir))
+                StartCoroutine(PlayHit(animatorDir));
         }
 
         private System.Collections.IEnumerator PlayHit(int dir)

--- a/Assets/Scripts/Util/Direction8.cs
+++ b/Assets/Scripts/Util/Direction8.cs
@@ -1,0 +1,191 @@
+using UnityEngine;
+
+namespace Util
+{
+    /// <summary>
+    ///     Enumerates the eight principal facing directions in clockwise order starting from down.
+    ///     This keeps player, NPC, pet, and combat systems aligned so orientation logic can be shared.
+    /// </summary>
+    public enum Direction8
+    {
+        Down = 0,
+        DownRight = 1,
+        Right = 2,
+        UpRight = 3,
+        Up = 4,
+        UpLeft = 5,
+        Left = 6,
+        DownLeft = 7
+    }
+
+    /// <summary>
+    ///     Helper utilities for working with <see cref="Direction8"/> values. Centralising these conversions ensures
+    ///     every system uses a consistent clockwise mapping, sprite mirroring, and animator index calculation.
+    /// </summary>
+    public static class Direction8Utility
+    {
+        private const float DiagonalComponent = 0.70710678f; // sqrt(1/2)
+
+        /// <summary>Precomputed unit vectors (clockwise, starting at down) for each enum entry.</summary>
+        private static readonly Vector2[] DirectionVectors =
+        {
+            Vector2.down,
+            new Vector2(DiagonalComponent, -DiagonalComponent),
+            Vector2.right,
+            new Vector2(DiagonalComponent, DiagonalComponent),
+            Vector2.up,
+            new Vector2(-DiagonalComponent, DiagonalComponent),
+            Vector2.left,
+            new Vector2(-DiagonalComponent, -DiagonalComponent)
+        };
+
+        /// <summary>
+        ///     Converts a vector into one of the eight compass directions. Optional flags determine whether diagonals are
+        ///     permitted and which direction should be returned when the vector magnitude is too small to classify.
+        /// </summary>
+        /// <param name="direction">Vector to evaluate. Zero vectors will fall back to <paramref name="fallback"/>.</param>
+        /// <param name="allowDiagonals">When false the result is clamped to the four cardinal directions.</param>
+        /// <param name="fallback">Direction returned if the vector has near-zero magnitude.</param>
+        public static Direction8 FromVector(Vector2 direction, bool allowDiagonals = true, Direction8 fallback = Direction8.Down)
+        {
+            if (direction.sqrMagnitude <= Mathf.Epsilon)
+                return fallback;
+
+            Vector2 normalised = direction.normalized;
+            if (!allowDiagonals)
+            {
+                float absX = Mathf.Abs(normalised.x);
+                float absY = Mathf.Abs(normalised.y);
+                if (absX > absY)
+                    return normalised.x >= 0f ? Direction8.Right : Direction8.Left;
+                if (absY > absX)
+                    return normalised.y >= 0f ? Direction8.Up : Direction8.Down;
+                return normalised.y >= 0f ? Direction8.Up : Direction8.Down;
+            }
+
+            float angle = Mathf.Atan2(normalised.x, -normalised.y) * Mathf.Rad2Deg;
+            if (angle < 0f)
+                angle += 360f;
+            int index = Mathf.RoundToInt(angle / 45f) % 8;
+            return (Direction8)index;
+        }
+
+        /// <summary>
+        ///     Converts a vector into a direction while first enforcing a deadzone. Useful for analog sticks where small noise
+        ///     should be ignored before computing the facing value.
+        /// </summary>
+        public static Direction8 FromVector(Vector2 direction, float deadzone, bool allowDiagonals, Direction8 fallback = Direction8.Down)
+        {
+            if (direction.magnitude <= deadzone)
+                return fallback;
+            return FromVector(direction, allowDiagonals, fallback);
+        }
+
+        /// <summary>Returns the normalised vector corresponding to the supplied direction.</summary>
+        public static Vector2 ToVector(Direction8 direction)
+        {
+            return DirectionVectors[(int)direction];
+        }
+
+        /// <summary>
+        ///     Returns a cardinal-only unit vector for the supplied direction. Diagonals are mapped to whichever axis is
+        ///     dominant (matching the legacy facing logic used before the eight-way refactor).
+        /// </summary>
+        public static Vector2 ToCardinalVector(Direction8 direction)
+        {
+            return ToVector(SnapToFourWay(direction));
+        }
+
+        /// <summary>Snaps any direction to the closest of the four cardinal points.</summary>
+        public static Direction8 SnapToFourWay(Direction8 direction)
+        {
+            Vector2 vec = DirectionVectors[(int)direction];
+            float absX = Mathf.Abs(vec.x);
+            float absY = Mathf.Abs(vec.y);
+
+            if (absX > absY)
+                return vec.x >= 0f ? Direction8.Right : Direction8.Left;
+            if (absY > absX)
+                return vec.y >= 0f ? Direction8.Up : Direction8.Down;
+            return vec.y >= 0f ? Direction8.Up : Direction8.Down;
+        }
+
+        /// <summary>
+        ///     Converts to the 0=Down, 1=Left, 2=Right, 3=Up index set used by legacy animator controllers.
+        ///     Diagonal facings are mapped using their dominant axis so existing 4-way assets continue to work.
+        /// </summary>
+        public static int ToAnimatorIndex(Direction8 direction)
+        {
+            switch (SnapToFourWay(direction))
+            {
+                case Direction8.Left:
+                    return 1;
+                case Direction8.Right:
+                    return 2;
+                case Direction8.Up:
+                    return 3;
+                default:
+                    return 0;
+            }
+        }
+
+        /// <summary>Returns true if the direction is one of the diagonal variants.</summary>
+        public static bool IsDiagonal(Direction8 direction)
+        {
+            return direction == Direction8.DownRight || direction == Direction8.UpRight ||
+                   direction == Direction8.UpLeft || direction == Direction8.DownLeft;
+        }
+
+        /// <summary>Returns true if the direction points towards the right-hand side of the screen.</summary>
+        public static bool IsFacingRight(Direction8 direction)
+        {
+            return direction == Direction8.Right || direction == Direction8.UpRight || direction == Direction8.DownRight;
+        }
+
+        /// <summary>Returns true if the direction points towards the left-hand side of the screen.</summary>
+        public static bool IsFacingLeft(Direction8 direction)
+        {
+            return direction == Direction8.Left || direction == Direction8.UpLeft || direction == Direction8.DownLeft;
+        }
+
+        /// <summary>Returns true if the direction has an upward component.</summary>
+        public static bool IsFacingUp(Direction8 direction)
+        {
+            return direction == Direction8.Up || direction == Direction8.UpLeft || direction == Direction8.UpRight;
+        }
+
+        /// <summary>Returns true if the direction has a downward component.</summary>
+        public static bool IsFacingDown(Direction8 direction)
+        {
+            return direction == Direction8.Down || direction == Direction8.DownLeft || direction == Direction8.DownRight;
+        }
+
+        /// <summary>Mirrors a direction across the vertical axis (left-right swap).</summary>
+        public static Direction8 MirrorHorizontally(Direction8 direction)
+        {
+            return Mirror(direction, mirrorX: true, mirrorY: false);
+        }
+
+        /// <summary>Mirrors a direction across the horizontal axis (up-down swap).</summary>
+        public static Direction8 MirrorVertically(Direction8 direction)
+        {
+            return Mirror(direction, mirrorX: false, mirrorY: true);
+        }
+
+        /// <summary>Mirrors a direction across optional axes.</summary>
+        public static Direction8 Mirror(Direction8 direction, bool mirrorX, bool mirrorY)
+        {
+            if (!mirrorX && !mirrorY)
+                return direction;
+
+            Vector2 vec = DirectionVectors[(int)direction];
+            if (mirrorX)
+                vec.x = -vec.x;
+            if (mirrorY)
+                vec.y = -vec.y;
+
+            return FromVector(vec, allowDiagonals: true, fallback: direction);
+        }
+    }
+}
+

--- a/Assets/Scripts/Util/SpriteDepth.cs
+++ b/Assets/Scripts/Util/SpriteDepth.cs
@@ -24,15 +24,11 @@ namespace Util
             int dir = 0;
             if (player != null)
             {
-                switch (player.FacingDir)
-                {
-                    case 0: // facing down
-                        dir = directionOffset;
-                        break;
-                    case 3: // facing up
-                        dir = -directionOffset;
-                        break;
-                }
+                Direction8 facing = player.FacingDir;
+                if (Direction8Utility.IsFacingDown(facing))
+                    dir = directionOffset;
+                else if (Direction8Utility.IsFacingUp(facing))
+                    dir = -directionOffset;
             }
 
             // Larger (more negative) Y => lower sorting order => appears behind


### PR DESCRIPTION
## Summary
- add a shared Direction8 enum and utility helpers so all movement/animation logic uses a consistent clockwise mapping
- refactor player, NPC, pet, and combat scripts to store facings as Direction8, including animator refresh, mirroring, and halberd cone checks
- update sprite depth offsets and beastmaster attack animator to respect diagonal facings and the new helper conversions

## Testing
- not run (Unity editor environment not available)


------
https://chatgpt.com/codex/tasks/task_e_68dec3d2c03c832e9b5cfb0086d16b15