### PR TITLE
Expand eight-direction sprite support across animators

### DIFF
--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -800,15 +800,16 @@ namespace NPC
             }
 
             npcFacing?.FaceTarget(target.transform);
-            var animator = npcFacing?.Animator;
-            if (animator != null)
+            var spriteAnimator = npcFacing?.Animator;
+            if (spriteAnimator != null)
             {
-                int facingDir = Direction8Utility.ToAnimatorIndex(npcFacing.FacingDirection);
-                if (animator.HasAttackAnimation(facingDir))
+                Direction8 facingDir = npcFacing.FacingDirection;
+                spriteAnimator.animator?.SetInteger(spriteAnimator.dirParam, Direction8Utility.ToAnimatorIndex8(facingDir));
+                if (spriteAnimator.HasAttackAnimation(facingDir))
                 {
                     if (spriteSwapRoutine != null)
                         StopCoroutine(spriteSwapRoutine);
-                    spriteSwapRoutine = StartCoroutine(animator.PlayAttackAnimation(facingDir));
+                    spriteSwapRoutine = StartCoroutine(spriteAnimator.PlayAttackAnimation(facingDir));
                 }
             }
 

--- a/Assets/Scripts/NPC/Combat/NpcFacing.cs
+++ b/Assets/Scripts/NPC/Combat/NpcFacing.cs
@@ -56,7 +56,7 @@ namespace NPC
             FacingDirection = Direction8Utility.FromVector(direction, allowDiagonals: true, fallback: FacingDirection);
 
             if (spriteAnimator != null)
-                spriteAnimator.SetFacing(Direction8Utility.ToAnimatorIndex(FacingDirection));
+                spriteAnimator.SetFacing(FacingDirection);
             else if (spriteRenderer != null)
                 spriteRenderer.flipX = Direction8Utility.IsFacingRight(FacingDirection);
         }

--- a/Assets/Scripts/NPC/Combat/NpcSpriteAnimator.cs
+++ b/Assets/Scripts/NPC/Combat/NpcSpriteAnimator.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using Util;
 
 namespace NPC
 {
@@ -12,7 +13,7 @@ namespace NPC
         [Header("Visuals")]
         public VisualMode visualMode = VisualMode.Animator;
 
-        [Tooltip("Animator with parameters Dir(int 0=Down,1=Left,2=Right,3=Up) and IsMoving(bool). Used in Animator mode.")]
+        [Tooltip("Animator with parameters Dir(int 0-7 following Direction8 order) and IsMoving(bool). Used in Animator mode.")]
         public Animator animator;
         public string dirParam = "Dir";
         public string isMovingParam = "IsMoving";
@@ -22,23 +23,35 @@ namespace NPC
         public SpriteRenderer spriteRenderer;
 
         [Header("SpriteSwap Sets (used only in SpriteSwap mode)")]
-        [Tooltip("Frames used when idle (Down). Leave empty to fall back to first frame of WalkDown.")]
+        [Tooltip("Frames used when idle (Down/Diagonals/Cardinals). Leave empty to fall back to matching walk frames.")]
         public Sprite[] idleDown;
-        public Sprite[] idleLeft;
+        public Sprite[] idleDownRight;
         public Sprite[] idleRight;
+        public Sprite[] idleUpRight;
         public Sprite[] idleUp;
+        public Sprite[] idleUpLeft;
+        public Sprite[] idleLeft;
+        public Sprite[] idleDownLeft;
 
-        [Tooltip("Frames used when moving (Down/Left/Right/Up).")]
+        [Tooltip("Frames used when moving (Down/Diagonals/Cardinals).")]
         public Sprite[] walkDown;
-        public Sprite[] walkLeft;
+        public Sprite[] walkDownRight;
         public Sprite[] walkRight;
+        public Sprite[] walkUpRight;
         public Sprite[] walkUp;
+        public Sprite[] walkUpLeft;
+        public Sprite[] walkLeft;
+        public Sprite[] walkDownLeft;
 
-        [Tooltip("Frames used when attacking (Down/Left/Right/Up).")]
+        [Tooltip("Frames used when attacking (Down/Diagonals/Cardinals).")]
         public Sprite[] attackDown;
-        public Sprite[] attackLeft;
+        public Sprite[] attackDownRight;
         public Sprite[] attackRight;
+        public Sprite[] attackUpRight;
         public Sprite[] attackUp;
+        public Sprite[] attackUpLeft;
+        public Sprite[] attackLeft;
+        public Sprite[] attackDownLeft;
 
         [Tooltip("If true, ignore Left arrays and flip the Right sprites for left-facing.")]
         public bool useFlipXForLeft = true;
@@ -46,16 +59,40 @@ namespace NPC
         [Tooltip("If true, ignore Right arrays and flip the Left sprites for right-facing.")]
         public bool useFlipXForRight = false;
 
+        [Tooltip("If true, reuse Down-Left sprites for Down-Right facings by mirroring them.")]
+        public bool useFlipXForDownRight = false;
+
+        [Tooltip("If true, reuse Up-Left sprites for Up-Right facings by mirroring them.")]
+        public bool useFlipXForUpRight = false;
+
+        [Tooltip("If true, reuse Up-Right sprites for Up-Left facings by mirroring them.")]
+        public bool useFlipXForUpLeft = true;
+
+        [Tooltip("If true, reuse Down-Right sprites for Down-Left facings by mirroring them.")]
+        public bool useFlipXForDownLeft = true;
+
         [Tooltip("If true, ignore Left attack arrays and flip the Right sprites for left-facing attacks.")]
         public bool useFlipXForLeftAttack = true;
 
         [Tooltip("If true, ignore Right attack arrays and flip the Left sprites for right-facing attacks.")]
         public bool useFlipXForRightAttack = false;
 
+        [Tooltip("If true, reuse Down-Left attack sprites for Down-Right facings by mirroring them.")]
+        public bool useFlipXForDownRightAttack = false;
+
+        [Tooltip("If true, reuse Up-Left attack sprites for Up-Right facings by mirroring them.")]
+        public bool useFlipXForUpRightAttack = false;
+
+        [Tooltip("If true, reuse Up-Right attack sprites for Up-Left facings by mirroring them.")]
+        public bool useFlipXForUpLeftAttack = true;
+
+        [Tooltip("If true, reuse Down-Right attack sprites for Down-Left facings by mirroring them.")]
+        public bool useFlipXForDownLeftAttack = true;
+
         [Tooltip("Frames per second for SpriteSwap animation.")]
         public float animationFPS = 6f;
 
-        private int _currentDir = 0;
+        private Direction8 _currentDir = Direction8.Down;
         private bool _currentlyMoving = false;
         private float _animClock = 0f;
         private int _animFrame = 0;
@@ -78,175 +115,252 @@ namespace NPC
         /// </summary>
         public void UpdateVisuals(Vector2 velocity)
         {
-            if (_overridePlaying) return;
+            if (_overridePlaying)
+                return;
 
             _currentlyMoving = velocity.sqrMagnitude > 0.0001f;
 
             if (_currentlyMoving)
             {
-                if (Mathf.Abs(velocity.x) > Mathf.Abs(velocity.y))
-                    _currentDir = velocity.x < 0f ? 1 : 2; // Left : Right
-                else
-                    _currentDir = velocity.y < 0f ? 0 : 3; // Down : Up
+                _currentDir = Direction8Utility.FromVector(velocity, allowDiagonals: true, fallback: _currentDir);
             }
 
             if (visualMode == VisualMode.Animator)
             {
-                if (animator == null) return;
+                if (animator == null)
+                    return;
                 animator.SetBool(isMovingParam, _currentlyMoving);
-                if (_currentlyMoving)
-                    animator.SetInteger(dirParam, _currentDir);
+                animator.SetInteger(dirParam, Direction8Utility.ToAnimatorIndex8(_currentDir));
                 return;
             }
 
-            if (spriteRenderer == null) return;
+            if (spriteRenderer == null)
+                return;
 
             float fps = Mathf.Max(0.01f, animationFPS);
             _animClock += Time.fixedDeltaTime * fps;
-            int frames;
-            Sprite[] set = SelectSpriteSet(_currentlyMoving, _currentDir, out frames);
+            Sprite[] set = SelectSpriteSet(_currentlyMoving, _currentDir, out int frames, out bool flip);
 
-            if (frames <= 0) return;
+            if (frames <= 0)
+                return;
 
             _animFrame = Mathf.FloorToInt(_animClock) % frames;
-            spriteRenderer.flipX = false;
-
-            if (useFlipXForLeft && _currentDir == 1)
-            {
-                Sprite[] rightSet = SelectSpriteSet(_currentlyMoving, 2, out frames);
-                if (frames > 0)
-                {
-                    _animFrame = Mathf.FloorToInt(_animClock) % frames;
-                    spriteRenderer.sprite = rightSet[_animFrame];
-                    spriteRenderer.flipX = true;
-                    return;
-                }
-            }
-
-            if (useFlipXForRight && _currentDir == 2)
-            {
-                bool prevFlipLeft = useFlipXForLeft;
-                useFlipXForLeft = false;
-                Sprite[] leftSet = SelectSpriteSet(_currentlyMoving, 1, out frames);
-                useFlipXForLeft = prevFlipLeft;
-                if (frames > 0)
-                {
-                    _animFrame = Mathf.FloorToInt(_animClock) % frames;
-                    spriteRenderer.sprite = leftSet[_animFrame];
-                    spriteRenderer.flipX = true;
-                    return;
-                }
-            }
-
+            spriteRenderer.flipX = flip;
             spriteRenderer.sprite = set[_animFrame];
         }
 
-        /// <summary>Force the animator to face the given direction (0=Down,1=Left,2=Right,3=Up).</summary>
-        public void SetFacing(int dir)
+        /// <summary>Force the animator to face the given direction.</summary>
+        public void SetFacing(Direction8 dir)
         {
-            _currentDir = Mathf.Clamp(dir, 0, 3);
+            _currentDir = dir;
         }
 
-        public bool HasAttackAnimation(int dir)
+        public bool HasAttackAnimation(Direction8 dir)
         {
-            Sprite[] set = SelectAttackSpriteSet(dir, out int frames);
+            Sprite[] set = SelectAttackSpriteSet(dir, out int frames, out _);
             return frames > 0;
         }
 
-        public System.Collections.IEnumerator PlayAttackAnimation(int dir)
+        public System.Collections.IEnumerator PlayAttackAnimation(Direction8 dir)
         {
             if (visualMode == VisualMode.Animator)
             {
                 if (animator != null)
                 {
-                    animator.SetInteger(dirParam, Mathf.Clamp(dir, 0, 3));
+                    animator.SetInteger(dirParam, Direction8Utility.ToAnimatorIndex8(dir));
                     animator.SetTrigger(attackTrigger);
                 }
                 yield break;
             }
 
-            Sprite[] set = SelectAttackSpriteSet(dir, out int frames);
+            Sprite[] set = SelectAttackSpriteSet(dir, out int frames, out bool flip);
             if (frames == 0 || spriteRenderer == null)
                 yield break;
 
             _overridePlaying = true;
-            _currentDir = Mathf.Clamp(dir, 0, 3);
+            _currentDir = dir;
             float fps = Mathf.Max(0.01f, animationFPS);
             for (int i = 0; i < frames; i++)
             {
                 spriteRenderer.sprite = set[i];
-                spriteRenderer.flipX = (_currentDir == 1 && useFlipXForLeftAttack) || (_currentDir == 2 && useFlipXForRightAttack);
+                spriteRenderer.flipX = flip;
                 yield return new WaitForSeconds(1f / fps);
             }
             _overridePlaying = false;
             _animClock = 0f;
         }
 
-        private Sprite[] SelectSpriteSet(bool moving, int dir, out int frames)
+        /// <summary>
+        ///     Resolves the appropriate idle or walk sprite set for the requested direction, mirroring as configured
+        ///     and falling back to cardinal facings when bespoke diagonal art is unavailable.
+        /// </summary>
+        private Sprite[] SelectSpriteSet(bool moving, Direction8 dir, out int frames, out bool flip)
         {
-            Sprite[] set = null;
+            foreach (var lookup in Direction8Utility.BuildSpriteFallbackOrder(dir, ShouldMirrorMovement))
+            {
+                Sprite[] set = GetMovementSprites(lookup.Direction, moving);
+                if (set != null && set.Length > 0)
+                {
+                    frames = set.Length;
+                    flip = lookup.FlipX;
+                    return set;
+                }
+            }
+
+            frames = 0;
+            flip = false;
+            return System.Array.Empty<Sprite>();
+        }
+
+        /// <summary>
+        ///     Locates the correct attack animation frames for the supplied direction, using mirroring and down-facing
+        ///     defaults where needed so attacks never fail to render.
+        /// </summary>
+        private Sprite[] SelectAttackSpriteSet(Direction8 dir, out int frames, out bool flip)
+        {
+            foreach (var lookup in Direction8Utility.BuildSpriteFallbackOrder(dir, ShouldMirrorAttack))
+            {
+                Sprite[] set = GetAttackSprites(lookup.Direction);
+                if (set != null && set.Length > 0)
+                {
+                    frames = set.Length;
+                    flip = lookup.FlipX;
+                    return set;
+                }
+            }
+
+            frames = 0;
+            flip = false;
+            return System.Array.Empty<Sprite>();
+        }
+
+        /// <summary>Returns either the idle or walk frames for the specified direction, depending on movement state.</summary>
+        private Sprite[] GetMovementSprites(Direction8 dir, bool moving)
+        {
+            Sprite[] idle = null;
+            Sprite[] walk = null;
+            switch (dir)
+            {
+                case Direction8.Down:
+                    idle = idleDown;
+                    walk = walkDown;
+                    break;
+                case Direction8.DownRight:
+                    idle = idleDownRight;
+                    walk = walkDownRight;
+                    break;
+                case Direction8.Right:
+                    idle = idleRight;
+                    walk = walkRight;
+                    break;
+                case Direction8.UpRight:
+                    idle = idleUpRight;
+                    walk = walkUpRight;
+                    break;
+                case Direction8.Up:
+                    idle = idleUp;
+                    walk = walkUp;
+                    break;
+                case Direction8.UpLeft:
+                    idle = idleUpLeft;
+                    walk = walkUpLeft;
+                    break;
+                case Direction8.Left:
+                    idle = idleLeft;
+                    walk = walkLeft;
+                    break;
+                case Direction8.DownLeft:
+                    idle = idleDownLeft;
+                    walk = walkDownLeft;
+                    break;
+            }
 
             if (moving)
             {
-                switch (dir)
-                {
-                    case 0: set = walkDown; break;
-                    case 1: set = useFlipXForLeft ? walkRight : walkLeft; break;
-                    case 2: set = useFlipXForRight ? walkLeft : walkRight; break;
-                    case 3: set = walkUp; break;
-                }
+                if (walk != null && walk.Length > 0)
+                    return walk;
+                if (idle != null && idle.Length > 0)
+                    return idle;
             }
             else
             {
-                switch (dir)
-                {
-                    case 0: set = idleDown != null && idleDown.Length > 0 ? idleDown : (walkDown ?? idleDown); break;
-                    case 1:
-                        set = useFlipXForLeft
-                            ? (idleRight != null && idleRight.Length > 0 ? idleRight : walkRight)
-                            : (idleLeft != null && idleLeft.Length > 0 ? idleLeft : walkLeft);
-                        break;
-                    case 2:
-                        set = useFlipXForRight
-                            ? (idleLeft != null && idleLeft.Length > 0 ? idleLeft : walkLeft)
-                            : (idleRight != null && idleRight.Length > 0 ? idleRight : walkRight);
-                        break;
-                    case 3: set = idleUp != null && idleUp.Length > 0 ? idleUp : (walkUp ?? idleUp); break;
-                }
+                if (idle != null && idle.Length > 0)
+                    return idle;
+                if (walk != null && walk.Length > 0)
+                    return walk;
             }
 
-            if (set == null || set.Length == 0)
-            {
-                if (!moving)
-                {
-                    if (idleDown != null && idleDown.Length > 0) { frames = idleDown.Length; return idleDown; }
-                    if (walkDown != null && walkDown.Length > 0) { frames = walkDown.Length; return walkDown; }
-                }
-                else
-                {
-                    if (useFlipXForRight && walkLeft != null && walkLeft.Length > 0) { frames = walkLeft.Length; return walkLeft; }
-                    if (walkRight != null && walkRight.Length > 0) { frames = walkRight.Length; return walkRight; }
-                    if (walkDown != null && walkDown.Length > 0) { frames = walkDown.Length; return walkDown; }
-                }
-            }
-
-            frames = set != null ? set.Length : 0;
-            return set ?? System.Array.Empty<Sprite>();
+            return null;
         }
 
-        private Sprite[] SelectAttackSpriteSet(int dir, out int frames)
+        /// <summary>Retrieves the configured attack frames for the supplied direction.</summary>
+        private Sprite[] GetAttackSprites(Direction8 dir)
         {
-            Sprite[] set = null;
             switch (dir)
             {
-                case 0: set = attackDown; break;
-                case 1: set = useFlipXForLeftAttack ? attackRight : attackLeft; break;
-                case 2: set = useFlipXForRightAttack ? attackLeft : attackRight; break;
-                case 3: set = attackUp; break;
+                case Direction8.Down:
+                    return attackDown;
+                case Direction8.DownRight:
+                    return attackDownRight;
+                case Direction8.Right:
+                    return attackRight;
+                case Direction8.UpRight:
+                    return attackUpRight;
+                case Direction8.Up:
+                    return attackUp;
+                case Direction8.UpLeft:
+                    return attackUpLeft;
+                case Direction8.Left:
+                    return attackLeft;
+                case Direction8.DownLeft:
+                    return attackDownLeft;
+                default:
+                    return null;
             }
+        }
 
-            frames = set != null ? set.Length : 0;
-            return set ?? System.Array.Empty<Sprite>();
+        /// <summary>Determines whether the movement animation for the given direction should be mirrored from its counterpart.</summary>
+        private bool ShouldMirrorMovement(Direction8 dir)
+        {
+            switch (dir)
+            {
+                case Direction8.Left:
+                    return useFlipXForLeft;
+                case Direction8.Right:
+                    return useFlipXForRight;
+                case Direction8.DownLeft:
+                    return useFlipXForDownLeft;
+                case Direction8.UpLeft:
+                    return useFlipXForUpLeft;
+                case Direction8.UpRight:
+                    return useFlipXForUpRight;
+                case Direction8.DownRight:
+                    return useFlipXForDownRight;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>Determines whether the attack animation for the given direction should reuse the mirrored counterpart.</summary>
+        private bool ShouldMirrorAttack(Direction8 dir)
+        {
+            switch (dir)
+            {
+                case Direction8.Left:
+                    return useFlipXForLeftAttack;
+                case Direction8.Right:
+                    return useFlipXForRightAttack;
+                case Direction8.DownLeft:
+                    return useFlipXForDownLeftAttack;
+                case Direction8.UpLeft:
+                    return useFlipXForUpLeftAttack;
+                case Direction8.UpRight:
+                    return useFlipXForUpRightAttack;
+                case Direction8.DownRight:
+                    return useFlipXForDownRightAttack;
+                default:
+                    return false;
+            }
         }
     }
 }

--- a/Assets/Scripts/Pets/IPetService.cs
+++ b/Assets/Scripts/Pets/IPetService.cs
@@ -16,19 +16,35 @@ namespace Pets
         public RuntimeAnimatorController controller;
         public Sprite baseSprite;
         public Sprite idleDown;
+        public Sprite idleDownRight;
         public Sprite idleLeft;
         public Sprite idleRight;
         public Sprite idleUp;
+        public Sprite idleUpRight;
+        public Sprite idleUpLeft;
+        public Sprite idleDownLeft;
         public Sprite walkDown;
+        public Sprite walkDownRight;
         public Sprite walkLeft;
         public Sprite walkRight;
         public Sprite walkUp;
+        public Sprite walkUpRight;
+        public Sprite walkUpLeft;
+        public Sprite walkDownLeft;
         public Sprite[] hitDown;
+        public Sprite[] hitDownRight;
         public Sprite[] hitLeft;
         public Sprite[] hitRight;
         public Sprite[] hitUp;
+        public Sprite[] hitUpRight;
+        public Sprite[] hitUpLeft;
+        public Sprite[] hitDownLeft;
         public bool useFlipXForLeft;
         public bool useFlipXForRight;
+        public bool useFlipXForDownLeft;
+        public bool useFlipXForUpLeft;
+        public bool useFlipXForUpRight;
+        public bool useFlipXForDownRight;
         public Vector3 localScale = Vector3.one;
     }
 

--- a/Assets/Scripts/Pets/PetCombatController.cs
+++ b/Assets/Scripts/Pets/PetCombatController.cs
@@ -281,20 +281,21 @@ namespace Pets
 
             Vector2 diff = target.transform.position - transform.position;
             Direction8 facingDir = Direction8Utility.FromVector(diff, allowDiagonals: true, fallback: Direction8.Down);
-            int animatorFacing = Direction8Utility.ToAnimatorIndex(facingDir);
-
             if (spriteAnimator != null)
-                spriteAnimator.SetFacing(animatorFacing);
+                spriteAnimator.SetFacing(facingDir);
             else if (spriteRenderer != null)
                 spriteRenderer.flipX = Direction8Utility.IsFacingRight(facingDir);
 
             if (animator != null)
+            {
+                animator.SetInteger("Dir", Direction8Utility.ToAnimatorIndex8(facingDir));
                 animator.SetTrigger("Attack");
-            else if (spriteAnimator != null && spriteAnimator.HasHitAnimation(animatorFacing))
+            }
+            else if (spriteAnimator != null && spriteAnimator.HasHitAnimation(facingDir))
             {
                 if (spriteSwapRoutine != null)
                     StopCoroutine(spriteSwapRoutine);
-                spriteSwapRoutine = StartCoroutine(spriteAnimator.PlayHitAnimation(animatorFacing));
+                spriteSwapRoutine = StartCoroutine(spriteAnimator.PlayHitAnimation(facingDir));
             }
             else if (spriteRenderer != null && definition != null && definition.attackSprite != null)
             {

--- a/Assets/Scripts/Pets/PetFollower.cs
+++ b/Assets/Scripts/Pets/PetFollower.cs
@@ -159,7 +159,7 @@ namespace Pets
             if (spriteAnimator != null)
             {
                 if (!playerMoving && playerMover != null)
-                    spriteAnimator.SetFacing(Direction8Utility.ToAnimatorIndex(playerMover.FacingDir));
+                    spriteAnimator.SetFacing(playerMover.FacingDir);
                 spriteAnimator.UpdateVisuals(playerMoving ? velocity : Vector2.zero);
             }
             else if (sprite != null)

--- a/Assets/Scripts/Pets/PetServiceAdapter.cs
+++ b/Assets/Scripts/Pets/PetServiceAdapter.cs
@@ -56,19 +56,35 @@ namespace Pets
                 if (psa != null)
                 {
                     if (psa.idleDown != null && psa.idleDown.Length > 0) profile.idleDown = psa.idleDown[0];
-                    if (psa.idleLeft != null && psa.idleLeft.Length > 0) profile.idleLeft = psa.idleLeft[0];
+                    if (psa.idleDownRight != null && psa.idleDownRight.Length > 0) profile.idleDownRight = psa.idleDownRight[0];
                     if (psa.idleRight != null && psa.idleRight.Length > 0) profile.idleRight = psa.idleRight[0];
+                    if (psa.idleUpRight != null && psa.idleUpRight.Length > 0) profile.idleUpRight = psa.idleUpRight[0];
                     if (psa.idleUp != null && psa.idleUp.Length > 0) profile.idleUp = psa.idleUp[0];
+                    if (psa.idleUpLeft != null && psa.idleUpLeft.Length > 0) profile.idleUpLeft = psa.idleUpLeft[0];
+                    if (psa.idleLeft != null && psa.idleLeft.Length > 0) profile.idleLeft = psa.idleLeft[0];
+                    if (psa.idleDownLeft != null && psa.idleDownLeft.Length > 0) profile.idleDownLeft = psa.idleDownLeft[0];
                     if (psa.walkDown != null && psa.walkDown.Length > 0) profile.walkDown = psa.walkDown[0];
-                    if (psa.walkLeft != null && psa.walkLeft.Length > 0) profile.walkLeft = psa.walkLeft[0];
+                    if (psa.walkDownRight != null && psa.walkDownRight.Length > 0) profile.walkDownRight = psa.walkDownRight[0];
                     if (psa.walkRight != null && psa.walkRight.Length > 0) profile.walkRight = psa.walkRight[0];
+                    if (psa.walkUpRight != null && psa.walkUpRight.Length > 0) profile.walkUpRight = psa.walkUpRight[0];
                     if (psa.walkUp != null && psa.walkUp.Length > 0) profile.walkUp = psa.walkUp[0];
+                    if (psa.walkUpLeft != null && psa.walkUpLeft.Length > 0) profile.walkUpLeft = psa.walkUpLeft[0];
+                    if (psa.walkLeft != null && psa.walkLeft.Length > 0) profile.walkLeft = psa.walkLeft[0];
+                    if (psa.walkDownLeft != null && psa.walkDownLeft.Length > 0) profile.walkDownLeft = psa.walkDownLeft[0];
                     if (psa.hitDown != null && psa.hitDown.Length > 0) profile.hitDown = psa.hitDown;
-                    if (psa.hitLeft != null && psa.hitLeft.Length > 0) profile.hitLeft = psa.hitLeft;
+                    if (psa.hitDownRight != null && psa.hitDownRight.Length > 0) profile.hitDownRight = psa.hitDownRight;
                     if (psa.hitRight != null && psa.hitRight.Length > 0) profile.hitRight = psa.hitRight;
+                    if (psa.hitUpRight != null && psa.hitUpRight.Length > 0) profile.hitUpRight = psa.hitUpRight;
                     if (psa.hitUp != null && psa.hitUp.Length > 0) profile.hitUp = psa.hitUp;
+                    if (psa.hitUpLeft != null && psa.hitUpLeft.Length > 0) profile.hitUpLeft = psa.hitUpLeft;
+                    if (psa.hitLeft != null && psa.hitLeft.Length > 0) profile.hitLeft = psa.hitLeft;
+                    if (psa.hitDownLeft != null && psa.hitDownLeft.Length > 0) profile.hitDownLeft = psa.hitDownLeft;
                     profile.useFlipXForLeft = psa.useFlipXForLeft;
                     profile.useFlipXForRight = psa.useFlipXForRight;
+                    profile.useFlipXForDownLeft = psa.useFlipXForDownLeft;
+                    profile.useFlipXForUpLeft = psa.useFlipXForUpLeft;
+                    profile.useFlipXForUpRight = psa.useFlipXForUpRight;
+                    profile.useFlipXForDownRight = psa.useFlipXForDownRight;
                 }
             }
             return profile;

--- a/Assets/Scripts/Pets/PetSpriteAnimator.cs
+++ b/Assets/Scripts/Pets/PetSpriteAnimator.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using Util;
 
 namespace Pets
 {
@@ -10,34 +11,35 @@ namespace Pets
         [Tooltip("SpriteRenderer used for displaying pet sprites (auto-found if null).")]
         public SpriteRenderer spriteRenderer;
 
-        [Tooltip("Frames used when idle and facing up.")]
-        public Sprite[] idleUp;
-        [Tooltip("Frames used when walking and facing up.")]
-        public Sprite[] walkUp;
-
-        [Tooltip("Frames used when idle and facing down.")]
+        [Tooltip("Frames used when idle (Down/Diagonals/Cardinals).")]
         public Sprite[] idleDown;
-        [Tooltip("Frames used when walking and facing down.")]
-        public Sprite[] walkDown;
-
-        [Tooltip("Frames used when idle and facing left.")]
-        public Sprite[] idleLeft;
-        [Tooltip("Frames used when walking and facing left.")]
-        public Sprite[] walkLeft;
-
-        [Tooltip("Frames used when idle and facing right.")]
+        public Sprite[] idleDownRight;
         public Sprite[] idleRight;
-        [Tooltip("Frames used when walking and facing right.")]
-        public Sprite[] walkRight;
+        public Sprite[] idleUpRight;
+        public Sprite[] idleUp;
+        public Sprite[] idleUpLeft;
+        public Sprite[] idleLeft;
+        public Sprite[] idleDownLeft;
 
-        [Tooltip("Frames used when attacking and facing up.")]
-        public Sprite[] hitUp;
-        [Tooltip("Frames used when attacking and facing down.")]
+        [Tooltip("Frames used when walking (Down/Diagonals/Cardinals).")]
+        public Sprite[] walkDown;
+        public Sprite[] walkDownRight;
+        public Sprite[] walkRight;
+        public Sprite[] walkUpRight;
+        public Sprite[] walkUp;
+        public Sprite[] walkUpLeft;
+        public Sprite[] walkLeft;
+        public Sprite[] walkDownLeft;
+
+        [Tooltip("Frames used when attacking (Down/Diagonals/Cardinals).")]
         public Sprite[] hitDown;
-        [Tooltip("Frames used when attacking and facing left.")]
-        public Sprite[] hitLeft;
-        [Tooltip("Frames used when attacking and facing right.")]
+        public Sprite[] hitDownRight;
         public Sprite[] hitRight;
+        public Sprite[] hitUpRight;
+        public Sprite[] hitUp;
+        public Sprite[] hitUpLeft;
+        public Sprite[] hitLeft;
+        public Sprite[] hitDownLeft;
 
         [Tooltip("If true, ignore Left arrays and flip the Right sprites for left-facing.")]
         public bool useFlipXForLeft = true;
@@ -45,10 +47,22 @@ namespace Pets
         [Tooltip("If true, ignore Right arrays and flip the Left sprites for right-facing.")]
         public bool useFlipXForRight = false;
 
+        [Tooltip("If true, reuse Down-Right sprites for Down-Left facings by mirroring them.")]
+        public bool useFlipXForDownLeft = true;
+
+        [Tooltip("If true, reuse Up-Right sprites for Up-Left facings by mirroring them.")]
+        public bool useFlipXForUpLeft = true;
+
+        [Tooltip("If true, reuse Up-Left sprites for Up-Right facings by mirroring them.")]
+        public bool useFlipXForUpRight = false;
+
+        [Tooltip("If true, reuse Down-Left sprites for Down-Right facings by mirroring them.")]
+        public bool useFlipXForDownRight = false;
+
         [Tooltip("Frames per second for the sprite swapping animation.")]
         public float animationFPS = 6f;
 
-        private int _currentDir = 0; // 0=Down,1=Left,2=Right,3=Up
+        private Direction8 _currentDir = Direction8.Down;
         private bool _currentlyMoving = false;
         private float _animClock = 0f;
         private int _animFrame = 0;
@@ -65,126 +79,217 @@ namespace Pets
         /// </summary>
         public void UpdateVisuals(Vector2 velocity)
         {
-            if (_overridePlaying) return;
+            if (_overridePlaying)
+                return;
 
             _currentlyMoving = velocity.sqrMagnitude > 0.0001f;
 
             if (_currentlyMoving)
             {
-                if (Mathf.Abs(velocity.x) > Mathf.Abs(velocity.y))
-                    _currentDir = velocity.x < 0f ? 1 : 2; // Left : Right
-                else
-                    _currentDir = velocity.y < 0f ? 0 : 3; // Down : Up
+                _currentDir = Direction8Utility.FromVector(velocity, allowDiagonals: true, fallback: _currentDir);
             }
 
-            if (spriteRenderer == null) return;
+            if (spriteRenderer == null)
+                return;
 
             float fps = Mathf.Max(0.01f, animationFPS);
             _animClock += Time.deltaTime * fps;
-            Sprite[] set = SelectSpriteSet(_currentlyMoving, _currentDir, out int frames);
+            Sprite[] set = SelectSpriteSet(_currentlyMoving, _currentDir, out int frames, out bool flip);
 
-            if (frames <= 0) return;
+            if (frames <= 0)
+                return;
 
             _animFrame = Mathf.FloorToInt(_animClock) % frames;
             spriteRenderer.sprite = set[_animFrame];
-            spriteRenderer.flipX = (_currentDir == 1 && useFlipXForLeft) || (_currentDir == 2 && useFlipXForRight);
+            spriteRenderer.flipX = flip;
         }
 
-        /// <summary>Force the animator to face the given direction (0=Down,1=Left,2=Right,3=Up).</summary>
-        public void SetFacing(int dir)
+        /// <summary>Force the animator to face the given direction.</summary>
+        public void SetFacing(Direction8 dir)
         {
-            _currentDir = Mathf.Clamp(dir, 0, 3);
+            _currentDir = dir;
         }
 
-        public bool HasHitAnimation(int dir)
+        public bool HasHitAnimation(Direction8 dir)
         {
-            Sprite[] set = SelectHitSpriteSet(dir, out int frames);
+            Sprite[] set = SelectHitSpriteSet(dir, out int frames, out _);
             return frames > 0;
         }
 
-        public System.Collections.IEnumerator PlayHitAnimation(int dir)
+        public System.Collections.IEnumerator PlayHitAnimation(Direction8 dir)
         {
-            Sprite[] set = SelectHitSpriteSet(dir, out int frames);
+            Sprite[] set = SelectHitSpriteSet(dir, out int frames, out bool flip);
             if (frames == 0 || spriteRenderer == null)
                 yield break;
 
             _overridePlaying = true;
-            _currentDir = Mathf.Clamp(dir, 0, 3);
+            _currentDir = dir;
             float fps = Mathf.Max(0.01f, animationFPS);
             for (int i = 0; i < frames; i++)
             {
                 spriteRenderer.sprite = set[i];
-                spriteRenderer.flipX = (_currentDir == 1 && useFlipXForLeft) || (_currentDir == 2 && useFlipXForRight);
+                spriteRenderer.flipX = flip;
                 yield return new WaitForSeconds(1f / fps);
             }
             _overridePlaying = false;
             _animClock = 0f;
         }
 
-        private Sprite[] SelectHitSpriteSet(int dir, out int frames)
+        /// <summary>
+        ///     Resolves the hit animation frames for a given direction using mirroring and cardinal fallbacks so merged
+        ///     attacks always find a frame set.
+        /// </summary>
+        private Sprite[] SelectHitSpriteSet(Direction8 dir, out int frames, out bool flip)
         {
-            Sprite[] set = null;
-            switch (dir)
+            foreach (var lookup in Direction8Utility.BuildSpriteFallbackOrder(dir, ShouldMirrorHit))
             {
-                case 0: set = hitDown; break;
-                case 1: set = useFlipXForLeft ? hitRight : hitLeft; break;
-                case 2: set = useFlipXForRight ? hitLeft : hitRight; break;
-                case 3: set = hitUp; break;
+                Sprite[] set = GetHitSprites(lookup.Direction);
+                if (set != null && set.Length > 0)
+                {
+                    frames = set.Length;
+                    flip = lookup.FlipX;
+                    return set;
+                }
             }
 
-            frames = set != null ? set.Length : 0;
-            return set ?? System.Array.Empty<Sprite>();
+            frames = 0;
+            flip = false;
+            return System.Array.Empty<Sprite>();
         }
 
-        private Sprite[] SelectSpriteSet(bool moving, int dir, out int frames)
+        /// <summary>
+        ///     Resolves the active idle/walk frames for the supplied direction, respecting mirroring preferences and
+        ///     gracefully falling back to cardinal facings.
+        /// </summary>
+        private Sprite[] SelectSpriteSet(bool moving, Direction8 dir, out int frames, out bool flip)
         {
-            Sprite[] set = null;
+            foreach (var lookup in Direction8Utility.BuildSpriteFallbackOrder(dir, ShouldMirrorMovement))
+            {
+                Sprite[] set = GetMovementSprites(lookup.Direction, moving);
+                if (set != null && set.Length > 0)
+                {
+                    frames = set.Length;
+                    flip = lookup.FlipX;
+                    return set;
+                }
+            }
+
+            frames = 0;
+            flip = false;
+            return System.Array.Empty<Sprite>();
+        }
+
+        /// <summary>Returns either the idle or walk frames for the given direction based on current movement state.</summary>
+        private Sprite[] GetMovementSprites(Direction8 dir, bool moving)
+        {
+            Sprite[] idle = null;
+            Sprite[] walk = null;
+            switch (dir)
+            {
+                case Direction8.Down:
+                    idle = idleDown;
+                    walk = walkDown;
+                    break;
+                case Direction8.DownRight:
+                    idle = idleDownRight;
+                    walk = walkDownRight;
+                    break;
+                case Direction8.Right:
+                    idle = idleRight;
+                    walk = walkRight;
+                    break;
+                case Direction8.UpRight:
+                    idle = idleUpRight;
+                    walk = walkUpRight;
+                    break;
+                case Direction8.Up:
+                    idle = idleUp;
+                    walk = walkUp;
+                    break;
+                case Direction8.UpLeft:
+                    idle = idleUpLeft;
+                    walk = walkUpLeft;
+                    break;
+                case Direction8.Left:
+                    idle = idleLeft;
+                    walk = walkLeft;
+                    break;
+                case Direction8.DownLeft:
+                    idle = idleDownLeft;
+                    walk = walkDownLeft;
+                    break;
+            }
 
             if (moving)
             {
-                switch (dir)
-                {
-                    case 0: set = walkDown; break;
-                    case 1: set = useFlipXForLeft ? walkRight : walkLeft; break;
-                    case 2: set = useFlipXForRight ? walkLeft : walkRight; break;
-                    case 3: set = walkUp; break;
-                }
+                if (walk != null && walk.Length > 0)
+                    return walk;
+                if (idle != null && idle.Length > 0)
+                    return idle;
             }
             else
             {
-                switch (dir)
-                {
-                    case 0: set = idleDown != null && idleDown.Length > 0 ? idleDown : walkDown; break;
-                    case 1:
-                        set = useFlipXForLeft
-                            ? (idleRight != null && idleRight.Length > 0 ? idleRight : walkRight)
-                            : (idleLeft != null && idleLeft.Length > 0 ? idleLeft : walkLeft);
-                        break;
-                    case 2:
-                        set = useFlipXForRight
-                            ? (idleLeft != null && idleLeft.Length > 0 ? idleLeft : walkLeft)
-                            : (idleRight != null && idleRight.Length > 0 ? idleRight : walkRight);
-                        break;
-                    case 3: set = idleUp != null && idleUp.Length > 0 ? idleUp : walkUp; break;
-                }
+                if (idle != null && idle.Length > 0)
+                    return idle;
+                if (walk != null && walk.Length > 0)
+                    return walk;
             }
 
-            if (set == null || set.Length == 0)
+            return null;
+        }
+
+        /// <summary>Retrieves the configured hit animation frames for the supplied direction.</summary>
+        private Sprite[] GetHitSprites(Direction8 dir)
+        {
+            switch (dir)
             {
-                if (!moving)
-                {
-                    if (idleDown != null && idleDown.Length > 0) { frames = idleDown.Length; return idleDown; }
-                    if (walkDown != null && walkDown.Length > 0) { frames = walkDown.Length; return walkDown; }
-                }
-                else
-                {
-                    if (walkRight != null && walkRight.Length > 0) { frames = walkRight.Length; return walkRight; }
-                    if (walkDown != null && walkDown.Length > 0) { frames = walkDown.Length; return walkDown; }
-                }
+                case Direction8.Down:
+                    return hitDown;
+                case Direction8.DownRight:
+                    return hitDownRight;
+                case Direction8.Right:
+                    return hitRight;
+                case Direction8.UpRight:
+                    return hitUpRight;
+                case Direction8.Up:
+                    return hitUp;
+                case Direction8.UpLeft:
+                    return hitUpLeft;
+                case Direction8.Left:
+                    return hitLeft;
+                case Direction8.DownLeft:
+                    return hitDownLeft;
+                default:
+                    return null;
             }
+        }
 
-            frames = set != null ? set.Length : 0;
-            return set ?? System.Array.Empty<Sprite>();
+        /// <summary>Returns true when the movement animation should reuse its mirrored counterpart via horizontal flipping.</summary>
+        private bool ShouldMirrorMovement(Direction8 dir)
+        {
+            switch (dir)
+            {
+                case Direction8.Left:
+                    return useFlipXForLeft;
+                case Direction8.Right:
+                    return useFlipXForRight;
+                case Direction8.DownLeft:
+                    return useFlipXForDownLeft;
+                case Direction8.UpLeft:
+                    return useFlipXForUpLeft;
+                case Direction8.UpRight:
+                    return useFlipXForUpRight;
+                case Direction8.DownRight:
+                    return useFlipXForDownRight;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>Mirroring preference for hit animations (shares settings with movement mirroring).</summary>
+        private bool ShouldMirrorHit(Direction8 dir)
+        {
+            return ShouldMirrorMovement(dir);
         }
     }
 }

--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -35,8 +35,8 @@ namespace Player
 
         [Header("(Optional) Direct Sprite Override")]
         [Tooltip("If assigned, these sprites will be applied directly each frame based on Dir/IsMoving. Leave null to rely on Animator clips.")]
-        public Sprite idleDown, idleLeft, idleRight, idleUp;
-        public Sprite walkDown, walkLeft, walkRight, walkUp;
+        public Sprite idleDown, idleDownRight, idleRight, idleUpRight, idleUp, idleUpLeft, idleLeft, idleDownLeft;
+        public Sprite walkDown, walkDownRight, walkRight, walkUpRight, walkUp, walkUpLeft, walkLeft, walkDownLeft;
         [Header("Mirroring")]
         [Tooltip("If true, reuse right-facing sprites for any left-facing orientation (including diagonals).")]
         [SerializeField]
@@ -44,6 +44,18 @@ namespace Player
         [Tooltip("If true, reuse left-facing sprites for any right-facing orientation (including diagonals).")]
         [SerializeField]
         private bool useFlipXForRight;
+        [Tooltip("If true, reuse Down-Right sprites for Down-Left facings by mirroring them.")]
+        [SerializeField]
+        private bool useFlipXForDownLeft = true;
+        [Tooltip("If true, reuse Up-Right sprites for Up-Left facings by mirroring them.")]
+        [SerializeField]
+        private bool useFlipXForUpLeft = true;
+        [Tooltip("If true, reuse Up-Left sprites for Up-Right facings by mirroring them.")]
+        [SerializeField]
+        private bool useFlipXForUpRight;
+        [Tooltip("If true, reuse Down-Left sprites for Down-Right facings by mirroring them.")]
+        [SerializeField]
+        private bool useFlipXForDownRight;
 
 #if ENABLE_INPUT_SYSTEM
         [Header("Input")]
@@ -327,7 +339,7 @@ namespace Player
 
             Direction8 visualDir = facingDir;
             int animatorDir = Direction8Utility.ToAnimatorIndex(visualDir);
-            Direction8 spriteDir = Direction8Utility.SnapToFourWay(visualDir);
+            Direction8 spriteDir = visualDir;
 
             anim.SetBool("IsMoving", isMoving);
             anim.SetInteger("Dir", animatorDir);
@@ -337,74 +349,7 @@ namespace Player
 
             Sprite desired = null;
             bool flip = false;
-            if (isMoving)
-            {
-                switch (spriteDir)
-                {
-                    case Direction8.Down:
-                        desired = walkDown ? walkDown : idleDown;
-                        break;
-                    case Direction8.Left:
-                        if (useFlipXForLeft)
-                        {
-                            desired = walkRight ? walkRight : idleRight;
-                            flip = true;
-                        }
-                        else
-                        {
-                            desired = walkLeft ? walkLeft : idleLeft;
-                        }
-                        break;
-                    case Direction8.Right:
-                        if (useFlipXForRight)
-                        {
-                            desired = walkLeft ? walkLeft : idleLeft;
-                            flip = true;
-                        }
-                        else
-                        {
-                            desired = walkRight ? walkRight : idleRight;
-                        }
-                        break;
-                    case Direction8.Up:
-                        desired = walkUp ? walkUp : idleUp;
-                        break;
-                }
-            }
-            else
-            {
-                switch (spriteDir)
-                {
-                    case Direction8.Down:
-                        desired = idleDown;
-                        break;
-                    case Direction8.Left:
-                        if (useFlipXForLeft)
-                        {
-                            desired = idleRight ? idleRight : walkRight;
-                            flip = true;
-                        }
-                        else
-                        {
-                            desired = idleLeft;
-                        }
-                        break;
-                    case Direction8.Right:
-                        if (useFlipXForRight)
-                        {
-                            desired = idleLeft ? idleLeft : walkLeft;
-                            flip = true;
-                        }
-                        else
-                        {
-                            desired = idleRight;
-                        }
-                        break;
-                    case Direction8.Up:
-                        desired = idleUp;
-                        break;
-                }
-            }
+            desired = ResolveOverrideSprite(spriteDir, isMoving, out flip);
 
             if (desired != null && !freezeSprite)
             {
@@ -412,6 +357,117 @@ namespace Player
                     sr.flipX = flip;
                 if (sr.sprite != desired)
                     sr.sprite = desired;
+            }
+        }
+
+        /// <summary>
+        ///     Resolves the sprite to display for the supplied direction using the optional override fields. The lookup
+        ///     respects diagonal-specific art, mirrors configured directions when requested, and gracefully falls back to
+        ///     cardinal frames when bespoke assets are unavailable.
+        /// </summary>
+        private Sprite ResolveOverrideSprite(Direction8 direction, bool moving, out bool flip)
+        {
+            foreach (var lookup in Direction8Utility.BuildSpriteFallbackOrder(direction, ShouldMirrorOverride))
+            {
+                Sprite sprite = GetSpriteForDirection(lookup.Direction, moving);
+                if (sprite != null)
+                {
+                    flip = lookup.FlipX;
+                    return sprite;
+                }
+            }
+
+            flip = false;
+            return null;
+        }
+
+        /// <summary>Returns true when the supplied direction is configured to borrow sprites from its mirrored counterpart.</summary>
+        private bool ShouldMirrorOverride(Direction8 direction)
+        {
+            switch (direction)
+            {
+                case Direction8.Left:
+                    return useFlipXForLeft;
+                case Direction8.Right:
+                    return useFlipXForRight;
+                case Direction8.DownLeft:
+                    return useFlipXForDownLeft;
+                case Direction8.UpLeft:
+                    return useFlipXForUpLeft;
+                case Direction8.UpRight:
+                    return useFlipXForUpRight;
+                case Direction8.DownRight:
+                    return useFlipXForDownRight;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        ///     Retrieves the idle/walk sprite assigned for the requested direction. When one of the pair is missing the
+        ///     available sprite is returned regardless of movement state so fallback logic still has something to render.
+        /// </summary>
+        private Sprite GetSpriteForDirection(Direction8 direction, bool moving)
+        {
+            GetOverrideSprites(direction, out Sprite idleSprite, out Sprite walkSprite);
+            if (moving)
+            {
+                if (walkSprite != null)
+                    return walkSprite;
+                if (idleSprite != null)
+                    return idleSprite;
+            }
+            else
+            {
+                if (idleSprite != null)
+                    return idleSprite;
+                if (walkSprite != null)
+                    return walkSprite;
+            }
+
+            return null;
+        }
+
+        /// <summary>Populates the idle and walk sprite references for a given direction.</summary>
+        private void GetOverrideSprites(Direction8 direction, out Sprite idleSprite, out Sprite walkSprite)
+        {
+            idleSprite = null;
+            walkSprite = null;
+
+            switch (direction)
+            {
+                case Direction8.Down:
+                    idleSprite = idleDown;
+                    walkSprite = walkDown;
+                    break;
+                case Direction8.DownRight:
+                    idleSprite = idleDownRight;
+                    walkSprite = walkDownRight;
+                    break;
+                case Direction8.Right:
+                    idleSprite = idleRight;
+                    walkSprite = walkRight;
+                    break;
+                case Direction8.UpRight:
+                    idleSprite = idleUpRight;
+                    walkSprite = walkUpRight;
+                    break;
+                case Direction8.Up:
+                    idleSprite = idleUp;
+                    walkSprite = walkUp;
+                    break;
+                case Direction8.UpLeft:
+                    idleSprite = idleUpLeft;
+                    walkSprite = walkUpLeft;
+                    break;
+                case Direction8.Left:
+                    idleSprite = idleLeft;
+                    walkSprite = walkLeft;
+                    break;
+                case Direction8.DownLeft:
+                    idleSprite = idleDownLeft;
+                    walkSprite = walkDownLeft;
+                    break;
             }
         }
 

--- a/Assets/Scripts/Skills/Beastmaster/MergedPetAttackAnimator.cs
+++ b/Assets/Scripts/Skills/Beastmaster/MergedPetAttackAnimator.cs
@@ -49,11 +49,19 @@ namespace Beastmaster
             if (spriteAnimator.spriteRenderer == null)
                 spriteAnimator.spriteRenderer = GetComponent<SpriteRenderer>() ?? GetComponentInChildren<SpriteRenderer>();
             spriteAnimator.hitDown = profile.hitDown;
-            spriteAnimator.hitLeft = profile.hitLeft;
+            spriteAnimator.hitDownRight = profile.hitDownRight;
             spriteAnimator.hitRight = profile.hitRight;
+            spriteAnimator.hitUpRight = profile.hitUpRight;
             spriteAnimator.hitUp = profile.hitUp;
+            spriteAnimator.hitUpLeft = profile.hitUpLeft;
+            spriteAnimator.hitLeft = profile.hitLeft;
+            spriteAnimator.hitDownLeft = profile.hitDownLeft;
             spriteAnimator.useFlipXForLeft = profile.useFlipXForLeft;
             spriteAnimator.useFlipXForRight = profile.useFlipXForRight;
+            spriteAnimator.useFlipXForDownLeft = profile.useFlipXForDownLeft;
+            spriteAnimator.useFlipXForUpLeft = profile.useFlipXForUpLeft;
+            spriteAnimator.useFlipXForUpRight = profile.useFlipXForUpRight;
+            spriteAnimator.useFlipXForDownRight = profile.useFlipXForDownRight;
         }
 
         public void ClearPetLook()
@@ -61,22 +69,28 @@ namespace Beastmaster
             if (spriteAnimator == null)
                 return;
             spriteAnimator.hitDown = null;
+            spriteAnimator.hitDownRight = null;
             spriteAnimator.hitLeft = null;
             spriteAnimator.hitRight = null;
             spriteAnimator.hitUp = null;
+            spriteAnimator.hitUpRight = null;
+            spriteAnimator.hitUpLeft = null;
+            spriteAnimator.hitDownLeft = null;
         }
 
         private void HandleAttack()
         {
             Direction8 dir = mover != null ? mover.FacingDir : Direction8.Down;
-            int animatorDir = Direction8Utility.ToAnimatorIndex(dir);
             if (animator != null && animator.runtimeAnimatorController != null)
+            {
+                animator.SetInteger("Dir", Direction8Utility.ToAnimatorIndex8(dir));
                 animator.SetTrigger("Attack");
-            if (spriteAnimator != null && spriteAnimator.HasHitAnimation(animatorDir))
-                StartCoroutine(PlayHit(animatorDir));
+            }
+            if (spriteAnimator != null && spriteAnimator.HasHitAnimation(dir))
+                StartCoroutine(PlayHit(dir));
         }
 
-        private System.Collections.IEnumerator PlayHit(int dir)
+        private System.Collections.IEnumerator PlayHit(Direction8 dir)
         {
             if (mover != null)
                 mover.freezeSprite = true;

--- a/Assets/Scripts/Util/Direction8.cs
+++ b/Assets/Scripts/Util/Direction8.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Util
@@ -68,6 +69,25 @@ namespace Util
                 angle += 360f;
             int index = Mathf.RoundToInt(angle / 45f) % 8;
             return (Direction8)index;
+        }
+
+        /// <summary>
+        ///     Lightweight descriptor returned when building sprite fallback orders. It packages together the
+        ///     source direction to probe for art and whether that lookup expects a horizontal flip when rendered.
+        /// </summary>
+        public readonly struct SpriteLookup
+        {
+            public SpriteLookup(Direction8 direction, bool flipX)
+            {
+                Direction = direction;
+                FlipX = flipX;
+            }
+
+            /// <summary>The direction whose sprite data should be queried.</summary>
+            public Direction8 Direction { get; }
+
+            /// <summary>True when the resolved sprite should be mirrored horizontally.</summary>
+            public bool FlipX { get; }
         }
 
         /// <summary>
@@ -185,6 +205,92 @@ namespace Util
                 vec.y = -vec.y;
 
             return FromVector(vec, allowDiagonals: true, fallback: direction);
+        }
+
+        /// <summary>
+        ///     Extracts the horizontal and vertical cardinal components that make up a diagonal direction. When the
+        ///     supplied direction is already cardinal the method simply returns that direction for both outputs.
+        /// </summary>
+        /// <param name="direction">Direction to decompose.</param>
+        /// <param name="vertical">Receives the vertical component (Up/Down).</param>
+        /// <param name="horizontal">Receives the horizontal component (Left/Right).</param>
+        public static void GetDiagonalComponents(Direction8 direction, out Direction8 vertical, out Direction8 horizontal)
+        {
+            switch (direction)
+            {
+                case Direction8.UpRight:
+                    vertical = Direction8.Up;
+                    horizontal = Direction8.Right;
+                    break;
+                case Direction8.UpLeft:
+                    vertical = Direction8.Up;
+                    horizontal = Direction8.Left;
+                    break;
+                case Direction8.DownRight:
+                    vertical = Direction8.Down;
+                    horizontal = Direction8.Right;
+                    break;
+                case Direction8.DownLeft:
+                    vertical = Direction8.Down;
+                    horizontal = Direction8.Left;
+                    break;
+                default:
+                    vertical = SnapToFourWay(direction);
+                    horizontal = vertical;
+                    break;
+            }
+        }
+
+        /// <summary>
+        ///     Enumerates a best-effort lookup order for sprite assets that can represent the supplied direction. Diagonal
+        ///     facings fall back to their horizontal and vertical components before defaulting to down-facing art. The
+        ///     <paramref name="shouldMirror"/> callback is used to decide whether a lookup should pull from the mirrored
+        ///     counterpart and apply a horizontal flip.
+        /// </summary>
+        /// <param name="direction">Desired facing direction.</param>
+        /// <param name="shouldMirror">Callback returning true when the specified direction prefers mirrored art.</param>
+        /// <returns>Sequence of sprite lookups ordered by preference.</returns>
+        public static IEnumerable<SpriteLookup> BuildSpriteFallbackOrder(Direction8 direction, System.Func<Direction8, bool> shouldMirror)
+        {
+            yield return new SpriteLookup(direction, false);
+
+            Direction8 mirror = MirrorHorizontally(direction);
+            bool mirrorAdded = false;
+            if (mirror != direction && shouldMirror(direction))
+            {
+                yield return new SpriteLookup(mirror, true);
+                mirrorAdded = true;
+            }
+
+            if (IsDiagonal(direction))
+            {
+                GetDiagonalComponents(direction, out var vertical, out var horizontal);
+
+                yield return new SpriteLookup(horizontal, false);
+                if (shouldMirror(horizontal))
+                    yield return new SpriteLookup(MirrorHorizontally(horizontal), true);
+
+                yield return new SpriteLookup(vertical, false);
+                if (shouldMirror(vertical))
+                    yield return new SpriteLookup(MirrorHorizontally(vertical), true);
+
+                if (!mirrorAdded && mirror != direction && shouldMirror(mirror))
+                    yield return new SpriteLookup(mirror, true);
+            }
+            else if (!mirrorAdded && mirror != direction && shouldMirror(mirror))
+            {
+                // If the mirrored direction stores the authoritative art, probe it before falling back to Down.
+                yield return new SpriteLookup(mirror, true);
+            }
+
+            if (direction != Direction8.Down)
+                yield return new SpriteLookup(Direction8.Down, false);
+        }
+
+        /// <summary>Maps the direction to its eight-way animator index (Down=0 ... DownLeft=7).</summary>
+        public static int ToAnimatorIndex8(Direction8 direction)
+        {
+            return (int)direction;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add eight-direction sprite overrides to `PlayerMover` and reuse a new `Direction8` fallback helper for mirrored frames
- upgrade NPC and pet sprite animators, facing, and combat hooks to drive eight-direction animation data with mirroring-aware fallbacks
- propagate diagonal hit arrays and flip flags through pet visual profiles so merged pet attacks can leverage the expanded assets

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68decd320f5c832e845ed967a58b4c6f