### PR TITLE
Expose PlayerMover flip mirroring controls for beastmaster visuals

### DIFF
--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -129,6 +129,28 @@ namespace Player
         /// </summary>
         public bool IsAutoMoving => isAutoMoving;
 
+        /// <summary>
+        ///     Allows external systems to check or override whether the mover mirrors right-facing sprites when
+        ///     travelling left. Beastmaster visual swaps rely on being able to persist and restore this value when
+        ///     temporarily applying a pet's appearance to the player.
+        /// </summary>
+        public bool UseFlipXForLeft
+        {
+            get => useFlipXForLeft;
+            set => useFlipXForLeft = value;
+        }
+
+        /// <summary>
+        ///     Allows external systems to check or override whether the mover mirrors left-facing sprites when
+        ///     travelling right. This mirrors <see cref="UseFlipXForLeft"/> for the opposite direction and is exposed
+        ///     for the same Beastmaster visual swap workflow.
+        /// </summary>
+        public bool UseFlipXForRight
+        {
+            get => useFlipXForRight;
+            set => useFlipXForRight = value;
+        }
+
 #if ENABLE_INPUT_SYSTEM
         private InputAction moveAction;
         private bool moveActionEnabledByResolver;

--- a/Assets/Scripts/Skills/Beastmaster/PlayerVisualBinder.cs
+++ b/Assets/Scripts/Skills/Beastmaster/PlayerVisualBinder.cs
@@ -54,8 +54,8 @@ namespace Beastmaster
                 origWalkLeft = playerMover.walkLeft;
                 origWalkRight = playerMover.walkRight;
                 origWalkUp = playerMover.walkUp;
-                origUseFlipXForLeft = playerMover.useFlipXForLeft;
-                origUseFlipXForRight = playerMover.useFlipXForRight;
+                origUseFlipXForLeft = playerMover.UseFlipXForLeft;
+                origUseFlipXForRight = playerMover.UseFlipXForRight;
             }
             origScale = transform.localScale;
             origFlipX = spriteRenderer != null && spriteRenderer.flipX;
@@ -84,8 +84,8 @@ namespace Beastmaster
                     if (profile.walkLeft != null) playerMover.walkLeft = profile.walkLeft;
                     if (profile.walkRight != null) playerMover.walkRight = profile.walkRight;
                     if (profile.walkUp != null) playerMover.walkUp = profile.walkUp;
-                    playerMover.useFlipXForLeft = profile.useFlipXForLeft;
-                    playerMover.useFlipXForRight = profile.useFlipXForRight;
+                    playerMover.UseFlipXForLeft = profile.useFlipXForLeft;
+                    playerMover.UseFlipXForRight = profile.useFlipXForRight;
                 }
                 else
                 {
@@ -128,8 +128,8 @@ namespace Beastmaster
                 playerMover.walkLeft = origWalkLeft;
                 playerMover.walkRight = origWalkRight;
                 playerMover.walkUp = origWalkUp;
-                playerMover.useFlipXForLeft = origUseFlipXForLeft;
-                playerMover.useFlipXForRight = origUseFlipXForRight;
+                playerMover.UseFlipXForLeft = origUseFlipXForLeft;
+                playerMover.UseFlipXForRight = origUseFlipXForRight;
             }
             attackAnimator?.ClearPetLook();
         }


### PR DESCRIPTION
## Summary
- expose public accessors on PlayerMover for left/right flip mirroring
- update PlayerVisualBinder to read and restore mirroring through the new properties when swapping pet visuals

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ded3d0a1ec832eb873ff922fd4687c