### PR TITLE
Guard NPC animator attack updates

### DIFF
--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -918,8 +918,20 @@ namespace NPC
             if (spriteAnimator != null)
             {
                 Direction8 facingDir = npcFacing.FacingDirection;
-                spriteAnimator.animator?.SetInteger(spriteAnimator.dirParam, Direction8Utility.ToAnimatorIndex8(facingDir));
-                if (spriteAnimator.HasAttackAnimation(facingDir))
+                bool usingAnimator = spriteAnimator.visualMode == NpcSpriteAnimator.VisualMode.Animator && spriteAnimator.animator != null;
+
+                if (usingAnimator)
+                {
+                    if (spriteSwapRoutine != null)
+                    {
+                        StopCoroutine(spriteSwapRoutine);
+                        spriteSwapRoutine = null;
+                    }
+
+                    spriteAnimator.animator.SetInteger(spriteAnimator.dirParam, Direction8Utility.ToAnimatorIndex8(facingDir));
+                    StartCoroutine(spriteAnimator.PlayAttackAnimation(facingDir));
+                }
+                else if (spriteAnimator.HasAttackAnimation(facingDir))
                 {
                     if (spriteSwapRoutine != null)
                         StopCoroutine(spriteSwapRoutine);


### PR DESCRIPTION
## Summary
- guard the animator updates in `BaseNpcCombat.ResolveAttack` so sprite-swap NPCs skip missing Animator components
- keep sprite-swap attack routines active for non-Animator visual mode NPCs while ensuring animator-driven NPCs still trigger attacks

## Testing
- not run (Unity editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68def5291c64832e94bae0cac9693a8d