### PR TITLE
Ensure NPC interaction colliders stay trigger-based

### DIFF
--- a/Assets/Prefabs/NPCS/COPPER_ORE_GOLEM.prefab
+++ b/Assets/Prefabs/NPCS/COPPER_ORE_GOLEM.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 7487083981726320206}
   - component: {fileID: 1285495058149382175}
   - component: {fileID: 1225287366087380678}
+  - component: {fileID: 5466147605252358142}
   - component: {fileID: 4462744165104283374}
   - component: {fileID: 7573619506058784387}
   - component: {fileID: 2394211271730700276}
@@ -165,7 +166,7 @@ BoxCollider2D:
   m_CallbackLayers:
     serializedVersion: 2
     m_Bits: 4294967295
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
@@ -200,6 +201,19 @@ MonoBehaviour:
   hitsplatFallbackOffset: 1
   pendingRespawnDelaySeconds: 0
   respawnSuppressed: 1
+--- !u!114 &5466147605252358142
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8077571585701284791}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 943236ba5ba2478c969c9675931910a8, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  interactionCollider: {fileID: 1225287366087380678}
 --- !u!114 &7573619506058784387
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/NPCS/NPC_GOBLIN.prefab
+++ b/Assets/Prefabs/NPCS/NPC_GOBLIN.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 7487083981726320206}
   - component: {fileID: 1285495058149382175}
   - component: {fileID: 1225287366087380678}
+  - component: {fileID: 3553260803050964942}
   - component: {fileID: 4462744165104283374}
   - component: {fileID: 7573619506058784387}
   - component: {fileID: 2394211271730700276}
@@ -164,7 +165,7 @@ BoxCollider2D:
   m_CallbackLayers:
     serializedVersion: 2
     m_Bits: 4294967295
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
@@ -199,6 +200,19 @@ MonoBehaviour:
   hitsplatFallbackOffset: 1
   pendingRespawnDelaySeconds: 0
   respawnSuppressed: 0
+--- !u!114 &3553260803050964942
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8077571585701284791}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 943236ba5ba2478c969c9675931910a8, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  interactionCollider: {fileID: 1225287366087380678}
 --- !u!114 &7573619506058784387
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/NPCS/NPC_GOBLIN_WARCHIEF.prefab
+++ b/Assets/Prefabs/NPCS/NPC_GOBLIN_WARCHIEF.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 7487083981726320206}
   - component: {fileID: 1285495058149382175}
   - component: {fileID: 1225287366087380678}
+  - component: {fileID: 5249979066121302518}
   - component: {fileID: 4462744165104283374}
   - component: {fileID: 7573619506058784387}
   - component: {fileID: 2394211271730700276}
@@ -163,7 +164,7 @@ BoxCollider2D:
   m_CallbackLayers:
     serializedVersion: 2
     m_Bits: 4294967295
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
@@ -196,6 +197,19 @@ MonoBehaviour:
   hitSplatLibrary: {fileID: 11400000, guid: 3bdb17896f374e8bb098d628ca4ba2f4, type: 2}
   knockbackReceiver: {fileID: -1616939295907987060}
   hitsplatFallbackOffset: 1
+--- !u!114 &5249979066121302518
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8077571585701284791}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 943236ba5ba2478c969c9675931910a8, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  interactionCollider: {fileID: 1225287366087380678}
 --- !u!114 &7573619506058784387
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/NPCS/NPC_GOBLIN_WARMAGE.prefab
+++ b/Assets/Prefabs/NPCS/NPC_GOBLIN_WARMAGE.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 7487083981726320206}
   - component: {fileID: 1285495058149382175}
   - component: {fileID: 1225287366087380678}
+  - component: {fileID: 7960778426191620468}
   - component: {fileID: 4462744165104283374}
   - component: {fileID: 7573619506058784387}
   - component: {fileID: 2394211271730700276}
@@ -162,7 +163,7 @@ BoxCollider2D:
   m_CallbackLayers:
     serializedVersion: 2
     m_Bits: 4294967295
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
@@ -192,6 +193,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   profile: {fileID: 11400000, guid: a2f9345330f24e74da31849069a079ad, type: 2}
   hitSplatLibrary: {fileID: 0}
+--- !u!114 &7960778426191620468
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8077571585701284791}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 943236ba5ba2478c969c9675931910a8, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  interactionCollider: {fileID: 1225287366087380678}
 --- !u!114 &7573619506058784387
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/NPC/Interaction/NpcInteractionCollider.cs
+++ b/Assets/Scripts/NPC/Interaction/NpcInteractionCollider.cs
@@ -1,0 +1,72 @@
+using UnityEngine;
+
+namespace NPC
+{
+    /// <summary>
+    /// Ensures every NPC that exposes interaction scripts keeps a trigger collider active so navigation
+    /// can pass through while interaction clicks remain responsive.
+    /// </summary>
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(Collider2D))]
+    public sealed class NpcInteractionCollider : MonoBehaviour
+    {
+        [SerializeField]
+        [Tooltip("Collider used to detect player interaction clicks.")]
+        private Collider2D interactionCollider;
+
+        /// <summary>
+        /// Provides read-only access to the cached collider so other scripts can reference it if necessary.
+        /// </summary>
+        public Collider2D InteractionCollider => interactionCollider;
+
+        private void Reset()
+        {
+            CacheCollider();
+            EnsureColliderConfigured();
+        }
+
+        private void Awake()
+        {
+            CacheCollider();
+            EnsureColliderConfigured();
+        }
+
+#if UNITY_EDITOR
+        private void OnValidate()
+        {
+            CacheCollider();
+            EnsureColliderConfigured();
+        }
+#endif
+
+        /// <summary>
+        /// Locates and stores the Collider2D component present on this GameObject.
+        /// </summary>
+        private void CacheCollider()
+        {
+            if (interactionCollider != null)
+                return;
+
+            interactionCollider = GetComponent<Collider2D>();
+            if (interactionCollider == null)
+            {
+                Debug.LogError("NpcInteractionCollider requires a Collider2D component on the same GameObject.", this);
+            }
+        }
+
+        /// <summary>
+        /// Guarantees the collider is enabled and configured as a trigger so it does not obstruct movement.
+        /// </summary>
+        private void EnsureColliderConfigured()
+        {
+            if (interactionCollider == null)
+                return;
+
+            if (!interactionCollider.enabled)
+                interactionCollider.enabled = true;
+
+            if (!interactionCollider.isTrigger)
+                interactionCollider.isTrigger = true;
+        }
+    }
+}

--- a/Assets/Scripts/NPC/Interaction/NpcInteractionCollider.cs.meta
+++ b/Assets/Scripts/NPC/Interaction/NpcInteractionCollider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 943236ba5ba2478c969c9675931910a8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add an NpcInteractionCollider helper that caches the local Collider2D and forces it to remain an enabled trigger for interaction scripts
- attach the helper to NPC combat prefabs that host NpcAttackOnClick/NpcInteractable so their colliders no longer block player movement

## Testing
- Not run (Unity editor required for validation)


------
https://chatgpt.com/codex/tasks/task_e_68defbc5a448832e856ee6a9a44061fa