### PR TITLE
Refactor player movement into modular controllers

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -7,6 +7,7 @@ using Skills;
 using Skills.Common;
 using Skills.Mining;
 using Player;
+using Player.Movement;
 using NPC;
 using Pets;
 using UI;
@@ -75,7 +76,7 @@ namespace Combat
         private Inventory.Equipment equipmentComponent;
         private Player.PlayerCombatLoadout loadout;
         private PlayerCombatBinder combatBinder;
-        private PlayerMover mover;
+        private IPlayerMovementController movementController;
         private Coroutine attackRoutine;
         private CombatTarget currentTarget;
         private float nextAttackTime;
@@ -123,7 +124,15 @@ namespace Combat
             equipmentComponent = GetComponent<Inventory.Equipment>() ?? GetComponentInParent<Inventory.Equipment>() ?? GetComponentInChildren<Inventory.Equipment>();
             loadout = GetComponent<Player.PlayerCombatLoadout>() ?? GetComponentInParent<Player.PlayerCombatLoadout>() ?? GetComponentInChildren<Player.PlayerCombatLoadout>();
             combatBinder = GetComponent<PlayerCombatBinder>() ?? GetComponentInParent<PlayerCombatBinder>() ?? GetComponentInChildren<PlayerCombatBinder>();
-            mover = GetComponent<PlayerMover>() ?? GetComponentInParent<PlayerMover>() ?? GetComponentInChildren<PlayerMover>();
+            movementController = GetComponent<PlayerMovementController>()
+                ?? GetComponentInParent<PlayerMovementController>()
+                ?? GetComponentInChildren<PlayerMovementController>();
+
+            if (movementController == null)
+            {
+                var moverFacade = GetComponent<PlayerMover>() ?? GetComponentInParent<PlayerMover>() ?? GetComponentInChildren<PlayerMover>();
+                movementController = moverFacade != null ? moverFacade.MovementController : null;
+            }
 
             if (skills == null)
                 Debug.LogWarning("CombatController could not find a SkillManager; damage will use level 1 stats.", this);
@@ -395,7 +404,7 @@ namespace Combat
                     ShowPickaxeRequirementFeedback();
                     break;
                 }
-                mover?.FaceTarget(target.transform);
+                movementController?.FaceTarget(target.transform);
                 OnAttackStart?.Invoke();
                 ResolveAttack(target);
                 // If the target died from the attack, exit immediately so listeners are notified
@@ -724,7 +733,7 @@ namespace Combat
                 return;
 
             Vector2 origin = transform.position;
-            Direction8 forwardDir = mover != null ? mover.FacingDir : Direction8.Down;
+            Direction8 forwardDir = movementController != null ? movementController.FacingDirection : Direction8.Down;
             Vector2 forward = FacingDirToVector(forwardDir);
             if (forward.sqrMagnitude <= Mathf.Epsilon)
                 forward = Vector2.down;

--- a/Assets/Scripts/NPC/Combat/NpcAttackOnClick.cs
+++ b/Assets/Scripts/NPC/Combat/NpcAttackOnClick.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using UnityEngine;
 using Combat;
 using Player;
+using Player.Movement;
 using Status.Freeze;
 
 namespace NPC
@@ -40,8 +41,9 @@ namespace NPC
             var playerController = FindObjectOfType<CombatController>();
             if (playerController == null)
                 return;
-            var playerMover = playerController.GetComponent<PlayerMover>();
-            if (playerMover == null)
+            var movementController = playerController.GetComponent<PlayerMovementController>()
+                ?? playerController.GetComponent<PlayerMover>()?.MovementController;
+            if (movementController == null)
                 return;
 
             if (heldAttackRoutine != null)
@@ -53,8 +55,9 @@ namespace NPC
             // Determine whether the player is currently frozen so we can decide how to handle
             // the attack click. Frozen players should not be able to move but should retain the
             // attack command so it can fire if the NPC walks into range.
+            var moverFacade = playerController.GetComponent<PlayerMover>() ?? playerController.GetComponentInChildren<PlayerMover>();
             var freezeController = playerController.GetComponent<FrozenStatusController>()
-                ?? playerMover.GetComponent<FrozenStatusController>();
+                ?? moverFacade?.GetComponent<FrozenStatusController>();
             bool playerFrozen = freezeController != null && freezeController.IsFrozen;
 
             float range = playerController.CurrentAttackRange;
@@ -74,7 +77,7 @@ namespace NPC
                 // check whether the NPC moves into range or the freeze expires.
                 heldAttackRoutine = StartCoroutine(HoldAttackWhileFrozen(
                     playerController,
-                    playerMover,
+                    movementController,
                     freezeController,
                     combatant));
                 return;
@@ -82,7 +85,7 @@ namespace NPC
 
             // Default behaviour for mobile players remains unchanged – auto walk into range and
             // fire once close enough.
-            playerMover.MoveTo(transform, range, () => playerController.TryAttackTarget(combatant));
+            movementController.MoveTo(transform, range, () => playerController.TryAttackTarget(combatant));
         }
 
         /// <summary>
@@ -91,12 +94,12 @@ namespace NPC
         /// </summary>
         private IEnumerator HoldAttackWhileFrozen(
             CombatController playerController,
-            PlayerMover playerMover,
+            IPlayerMovementController movementController,
             FrozenStatusController freezeController,
             NpcCombatant target)
         {
             // Small guard to avoid running the routine when any critical dependency is missing.
-            if (playerController == null || playerMover == null || freezeController == null || target == null)
+            if (playerController == null || movementController == null || freezeController == null || target == null)
             {
                 heldAttackRoutine = null;
                 yield break;
@@ -126,11 +129,11 @@ namespace NPC
                 {
                     playerController.TryAttackTarget(target);
                 }
-                else if (!freezeController.IsFrozen && playerMover != null)
+                else if (!freezeController.IsFrozen && movementController != null)
                 {
                     // Once the freeze effect ends resume the standard auto movement logic so the
                     // player chases the NPC if they are still out of range.
-                    playerMover.MoveTo(target.transform, range, () => playerController.TryAttackTarget(target));
+                    movementController.MoveTo(target.transform, range, () => playerController.TryAttackTarget(target));
                 }
             }
 

--- a/Assets/Scripts/Pets/PetFollower.cs
+++ b/Assets/Scripts/Pets/PetFollower.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using Player;
+using Player.Movement;
 using Util;
 
 namespace Pets
@@ -35,7 +36,7 @@ namespace Pets
         private SpriteRenderer sprite;
         private SpriteDepth spriteDepth;
         private PetSpriteAnimator spriteAnimator;
-        private PlayerMover playerMover;
+        private IPlayerMovementController movementController;
         private SpriteRenderer playerSprite;
         private Vector3 currentVelocity;
         private float idleTimer;
@@ -61,12 +62,13 @@ namespace Pets
         public void SetPlayer(Transform newPlayer)
         {
             player = newPlayer;
-            playerMover = null;
+            movementController = null;
             playerSprite = null;
             if (player != null)
             {
                 lastPlayerPos = player.position;
-                playerMover = player.GetComponent<PlayerMover>();
+                movementController = player.GetComponent<PlayerMovementController>()
+                    ?? player.GetComponent<PlayerMover>()?.MovementController;
                 playerSprite = player.GetComponent<SpriteRenderer>();
                 if (playerSprite != null && sprite != null)
                     sprite.sortingLayerID = playerSprite.sortingLayerID;
@@ -158,14 +160,14 @@ namespace Pets
 
             if (spriteAnimator != null)
             {
-                if (!playerMoving && playerMover != null)
-                    spriteAnimator.SetFacing(playerMover.FacingDir);
+                if (!playerMoving && movementController != null)
+                    spriteAnimator.SetFacing(movementController.FacingDirection);
                 spriteAnimator.UpdateVisuals(playerMoving ? velocity : Vector2.zero);
             }
             else if (sprite != null)
             {
-                if (!playerMoving && playerMover != null)
-                    sprite.flipX = Direction8Utility.IsFacingLeft(playerMover.FacingDir);
+                if (!playerMoving && movementController != null)
+                    sprite.flipX = Direction8Utility.IsFacingLeft(movementController.FacingDirection);
                 else
                     sprite.flipX = newPos.x > player.position.x;
             }

--- a/Assets/Scripts/Player/Input/PlayerMovementInput.cs
+++ b/Assets/Scripts/Player/Input/PlayerMovementInput.cs
@@ -1,0 +1,124 @@
+// Assets/Scripts/Player/Input/PlayerMovementInput.cs
+using System;
+using UnityEngine;
+
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+using Core.Input;
+#endif
+
+namespace Player.Input
+{
+    /// <summary>
+    ///     Centralises the player's locomotion input handling. The component resolves the shared Move action via
+    ///     <see cref="InputActionResolver"/>, snaps analog input to OSRS-style cardinals, and raises change events
+    ///     so movement controllers can react without owning Input System subscriptions.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public sealed class PlayerMovementInput : MonoBehaviour
+    {
+        [Tooltip("Deadzone used when reading analog sticks to snap to -1/0/1.")]
+        [SerializeField] private float gamepadDeadzone = 0.3f;
+
+#if ENABLE_INPUT_SYSTEM
+        [Header("Input")]
+        [Tooltip("PlayerInput component that owns the Player action map.")]
+        [SerializeField] private PlayerInput playerInput;
+
+        [Tooltip("Reference to the Player/Move action inside the shared input asset.")]
+        [SerializeField] private InputActionReference moveActionReference;
+
+        private InputAction moveAction;
+        private bool moveActionEnabledByResolver;
+#endif
+
+        /// <summary>Raised whenever the sanitised movement vector changes.</summary>
+        public event Action<Vector2> MoveVectorChanged;
+
+        /// <summary>Most recent sanitised movement vector emitted by the action map.</summary>
+        public Vector2 CurrentValue { get; private set; }
+
+#if ENABLE_INPUT_SYSTEM
+        private void Awake()
+        {
+            if (playerInput == null)
+                playerInput = GetComponent<PlayerInput>();
+        }
+
+        private void OnEnable()
+        {
+            moveAction = InputActionResolver.Resolve(playerInput, moveActionReference, "Move", out moveActionEnabledByResolver);
+            if (moveAction == null)
+                return;
+
+            moveAction.performed += HandleMovePerformed;
+            moveAction.canceled += HandleMoveCanceled;
+            UpdateValue(moveAction.ReadValue<Vector2>());
+        }
+
+        private void OnDisable()
+        {
+            if (moveAction != null)
+            {
+                moveAction.performed -= HandleMovePerformed;
+                moveAction.canceled -= HandleMoveCanceled;
+
+                if (moveActionEnabledByResolver)
+                    moveAction.Disable();
+            }
+
+            moveAction = null;
+            moveActionEnabledByResolver = false;
+            UpdateValue(Vector2.zero);
+        }
+
+        private void HandleMovePerformed(InputAction.CallbackContext context)
+        {
+            UpdateValue(context.ReadValue<Vector2>());
+        }
+
+        private void HandleMoveCanceled(InputAction.CallbackContext context)
+        {
+            UpdateValue(Vector2.zero);
+        }
+#else
+        private void OnEnable()
+        {
+            UpdateValue(Vector2.zero);
+        }
+
+        private void OnDisable()
+        {
+            UpdateValue(Vector2.zero);
+        }
+
+        private void Update()
+        {
+            Vector2 raw = new Vector2(UnityEngine.Input.GetAxisRaw("Horizontal"), UnityEngine.Input.GetAxisRaw("Vertical"));
+            UpdateValue(raw);
+        }
+#endif
+
+        /// <summary>
+        ///     Applies deadzone snapping, updates the cached value, and fires change events when the effective input vector changes.
+        /// </summary>
+        private void UpdateValue(Vector2 rawValue)
+        {
+            Vector2 sanitised = new Vector2(SnapAxis(rawValue.x), SnapAxis(rawValue.y));
+            if (sanitised == CurrentValue)
+                return;
+
+            CurrentValue = sanitised;
+            MoveVectorChanged?.Invoke(CurrentValue);
+        }
+
+        /// <summary>Snaps an individual axis to -1, 0, or 1 using the configured deadzone.</summary>
+        private float SnapAxis(float value)
+        {
+            if (Mathf.Abs(value) < gamepadDeadzone)
+                return 0f;
+
+            return Mathf.Sign(value);
+        }
+    }
+}

--- a/Assets/Scripts/Player/Movement/PlayerMovementController.cs
+++ b/Assets/Scripts/Player/Movement/PlayerMovementController.cs
@@ -1,0 +1,405 @@
+// Assets/Scripts/Player/Movement/PlayerMovementController.cs
+using System;
+using System.Collections;
+using UnityEngine;
+using Combat;
+using Player.Input;
+using Player.Visuals;
+using Skills;
+using Util;
+
+namespace Player.Movement
+{
+    /// <summary>
+    ///     Handles player locomotion, including manual input, auto-move routines, and tick-aligned persistence prompts.
+    ///     The controller focuses purely on movement mechanics while <see cref="Player.PlayerMover"/> orchestrates
+    ///     persistence and scene lifecycle concerns.
+    /// </summary>
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(Rigidbody2D))]
+    public sealed class PlayerMovementController : MonoBehaviour, IPlayerMovementController
+    {
+        [Header("Movement")]
+        [SerializeField, Tooltip("Base walking speed in world units per second.")]
+        private float moveSpeed = 3.5f;
+
+        [SerializeField, Tooltip("Restricts manual input to the four cardinal directions when enabled.")]
+        private bool fourWayOnly = true;
+
+        [SerializeField, Tooltip("Optional explicit reference to the movement input provider.")]
+        private PlayerMovementInput movementInput;
+
+        [SerializeField, Tooltip("Sprite controller used to update facing visuals and mirror flags.")]
+        private PlayerSpriteController spriteController;
+
+        [SerializeField, Tooltip("Optional combat controller used to abort combat when manual movement occurs.")]
+        private CombatController combatController;
+
+        [SerializeField, Tooltip("Inventory reference used to honour bank-open movement locks.")]
+        private Inventory.Inventory inventory;
+
+        /// <summary>
+        ///     Interval in seconds used to prompt position saves while the player is moving. Matches the legacy behaviour from
+        ///     <see cref="Player.PlayerMover"/> so autosaves remain consistent.
+        /// </summary>
+        private const float MovementSaveInterval = 2f;
+
+        private Rigidbody2D body;
+        private Vector2 moveDir;
+        private Direction8 facingDir = Direction8.Down;
+        private Coroutine moveRoutine;
+        private bool moveRoutineActive;
+        private bool movementFrozen;
+        private bool isTransitioning;
+        private bool wasMoving;
+        private float movementSaveTimer;
+        private bool freezeSpriteStateBeforeFreeze;
+
+        /// <summary>Event raised whenever a persistence save should capture the current position.</summary>
+        public event Action MovementSaveRequested;
+
+        /// <inheritdoc />
+        public Direction8 FacingDirection => facingDir;
+
+        /// <inheritdoc />
+        public bool IsAutoMoving => moveRoutineActive;
+
+        /// <inheritdoc />
+        public bool IsMovementFrozen => movementFrozen;
+
+        /// <inheritdoc />
+        public bool IsMoving => moveDir.sqrMagnitude > 0f;
+
+        /// <inheritdoc />
+        public float MoveSpeed
+        {
+            get => moveSpeed;
+            set => moveSpeed = Mathf.Max(0f, value);
+        }
+
+        private void Awake()
+        {
+            body = GetComponent<Rigidbody2D>();
+            if (movementInput == null)
+                movementInput = GetComponent<PlayerMovementInput>();
+            if (spriteController == null)
+                spriteController = GetComponent<PlayerSpriteController>();
+            if (combatController == null)
+                combatController = GetComponent<CombatController>();
+            if (inventory == null)
+                inventory = GetComponent<Inventory.Inventory>();
+
+            ConfigureBody();
+        }
+
+        private void OnEnable()
+        {
+            if (movementInput != null)
+            {
+                movementInput.MoveVectorChanged += HandleMoveVectorChanged;
+                pendingInput = movementInput.CurrentValue;
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (movementInput != null)
+                movementInput.MoveVectorChanged -= HandleMoveVectorChanged;
+
+            CancelAutoMoveRoutine();
+            moveDir = Vector2.zero;
+            pendingInput = Vector2.zero;
+            ApplyForcedIdle();
+        }
+
+        private void OnDestroy()
+        {
+            CancelAutoMoveRoutine();
+        }
+
+        private void Update()
+        {
+            if (isTransitioning)
+            {
+                HaltForExternalControl();
+                return;
+            }
+
+            if (movementFrozen)
+            {
+                HaltForExternalControl();
+                return;
+            }
+
+            if (Inventory.InventoryDebugMenu.HasTextInputFocus || AdminF2Menu.HasTextInputFocus)
+            {
+                HaltForExternalControl();
+                return;
+            }
+
+            if (inventory != null && inventory.BankOpen)
+            {
+                HaltForExternalControl();
+                return;
+            }
+
+            ProcessManualInput();
+            UpdateFacingFromMovement();
+            ApplyVisualsAndPersistence();
+        }
+
+        private void FixedUpdate()
+        {
+            body.linearVelocity = moveDir * moveSpeed;
+        }
+
+        /// <inheritdoc />
+        public void SetMovementFrozen(bool frozen)
+        {
+            if (movementFrozen == frozen)
+                return;
+
+            movementFrozen = frozen;
+            if (movementFrozen)
+            {
+                freezeSpriteStateBeforeFreeze = spriteController != null && spriteController.FreezeSprite;
+                StopMovement();
+                if (spriteController != null)
+                    spriteController.FreezeSprite = true;
+            }
+            else if (spriteController != null)
+            {
+                spriteController.FreezeSprite = freezeSpriteStateBeforeFreeze;
+            }
+        }
+
+        /// <inheritdoc />
+        public void SetTransitioning(bool transitioning)
+        {
+            if (isTransitioning == transitioning)
+                return;
+
+            isTransitioning = transitioning;
+            if (isTransitioning)
+                StopMovement();
+        }
+
+        /// <inheritdoc />
+        public void FaceTarget(Transform target)
+        {
+            if (target == null)
+                return;
+
+            Vector2 dir = (Vector2)target.position - (Vector2)transform.position;
+            if (dir.sqrMagnitude <= 0.0001f)
+                return;
+
+            facingDir = Direction8Utility.FromVector(dir, allowDiagonals: true, fallback: facingDir);
+            spriteController?.ApplyMovementVisuals(facingDir, IsMoving);
+        }
+
+        /// <inheritdoc />
+        public void MoveTo(Vector2 target, float stopDistance, Action onComplete = null)
+        {
+            CancelAutoMoveRoutine();
+            moveRoutine = StartCoroutine(MoveToRoutine(target, stopDistance, onComplete));
+            moveRoutineActive = true;
+        }
+
+        /// <inheritdoc />
+        public void MoveTo(Transform target, float stopDistance, Action onComplete = null)
+        {
+            CancelAutoMoveRoutine();
+            moveRoutine = StartCoroutine(MoveToRoutine(target, stopDistance, onComplete));
+            moveRoutineActive = true;
+        }
+
+        /// <inheritdoc />
+        public void StopMovement()
+        {
+            moveDir = Vector2.zero;
+            body.linearVelocity = Vector2.zero;
+            CancelAutoMoveRoutine();
+            spriteController?.ApplyMovementVisuals(facingDir, false);
+            ApplyForcedIdle();
+        }
+
+        private void ProcessManualInput()
+        {
+            Vector2 desiredDirection = Vector2.zero;
+            if (pendingInput.sqrMagnitude > 0f)
+            {
+                Direction8 inputFacing = Direction8Utility.FromVector(pendingInput, allowDiagonals: !fourWayOnly, fallback: facingDir);
+                desiredDirection = fourWayOnly
+                    ? Direction8Utility.ToCardinalVector(inputFacing)
+                    : Direction8Utility.ToVector(inputFacing);
+
+                if (moveRoutineActive)
+                    CancelAutoMoveRoutine();
+
+                combatController?.CancelCombat();
+            }
+
+            if (!moveRoutineActive)
+                moveDir = desiredDirection;
+        }
+
+        private void UpdateFacingFromMovement()
+        {
+            if (moveDir.sqrMagnitude <= 0f)
+                return;
+
+            facingDir = Direction8Utility.FromVector(moveDir, allowDiagonals: true, fallback: facingDir);
+        }
+
+        private void ApplyVisualsAndPersistence()
+        {
+            bool moving = moveDir.sqrMagnitude > 0f;
+            spriteController?.ApplyMovementVisuals(facingDir, moving);
+            HandleMovementPersistence(moving);
+        }
+
+        private void HaltForExternalControl()
+        {
+            moveDir = Vector2.zero;
+            body.linearVelocity = Vector2.zero;
+            spriteController?.ApplyMovementVisuals(facingDir, false);
+            ApplyForcedIdle();
+        }
+
+        private void ApplyForcedIdle()
+        {
+            if (wasMoving)
+                MovementSaveRequested?.Invoke();
+
+            wasMoving = false;
+            movementSaveTimer = 0f;
+        }
+
+        private void HandleMovementPersistence(bool moving)
+        {
+            if (moving)
+            {
+                movementSaveTimer += Time.unscaledDeltaTime;
+                if (movementSaveTimer >= MovementSaveInterval)
+                {
+                    MovementSaveRequested?.Invoke();
+                    movementSaveTimer = 0f;
+                }
+            }
+            else if (wasMoving)
+            {
+                MovementSaveRequested?.Invoke();
+                movementSaveTimer = 0f;
+            }
+
+            wasMoving = moving;
+        }
+
+        private void HandleMoveVectorChanged(Vector2 input)
+        {
+            pendingInput = input;
+        }
+
+        private void ConfigureBody()
+        {
+            body.bodyType = RigidbodyType2D.Dynamic;
+            body.gravityScale = 0f;
+            body.constraints = RigidbodyConstraints2D.FreezeRotation;
+            body.interpolation = RigidbodyInterpolation2D.Interpolate;
+            body.WakeUp();
+        }
+
+        private void CancelAutoMoveRoutine()
+        {
+            if (moveRoutine != null)
+                StopCoroutine(moveRoutine);
+
+            moveRoutine = null;
+            moveRoutineActive = false;
+        }
+
+        private IEnumerator MoveToRoutine(Vector2 target, float stopDistance, Action onComplete)
+        {
+            moveRoutineActive = true;
+            while (Vector2.Distance(transform.position, target) > stopDistance)
+            {
+                Vector2 dir = (target - (Vector2)transform.position).normalized;
+                moveDir = dir;
+                yield return null;
+            }
+
+            StopMovement();
+            onComplete?.Invoke();
+        }
+
+        private IEnumerator MoveToRoutine(Transform target, float stopDistance, Action onComplete)
+        {
+            moveRoutineActive = true;
+            while (target != null && Vector2.Distance(transform.position, target.position) > stopDistance)
+            {
+                Vector2 dir = ((Vector2)target.position - (Vector2)transform.position).normalized;
+                moveDir = dir;
+                yield return null;
+            }
+
+            StopMovement();
+            if (target != null)
+                onComplete?.Invoke();
+        }
+
+        /// <summary>
+        ///     Restores runtime references when the inspector rebinds serialized fields.
+        /// </summary>
+        private void OnValidate()
+        {
+            if (movementInput == null)
+                movementInput = GetComponent<PlayerMovementInput>();
+            if (spriteController == null)
+                spriteController = GetComponent<PlayerSpriteController>();
+            if (combatController == null)
+                combatController = GetComponent<CombatController>();
+            if (inventory == null)
+                inventory = GetComponent<Inventory.Inventory>();
+        }
+    }
+
+    /// <summary>
+    ///     Public contract that external systems depend on when issuing player movement commands.
+    /// </summary>
+    public interface IPlayerMovementController
+    {
+        /// <summary>Current facing direction resolved from input or auto-move targets.</summary>
+        Direction8 FacingDirection { get; }
+
+        /// <summary>True while an auto-move routine is active.</summary>
+        bool IsAutoMoving { get; }
+
+        /// <summary>True while external systems have frozen the controller.</summary>
+        bool IsMovementFrozen { get; }
+
+        /// <summary>True while any movement is currently being applied.</summary>
+        bool IsMoving { get; }
+
+        /// <summary>Gets or sets the base walking speed applied to manual and auto movement.</summary>
+        float MoveSpeed { get; set; }
+
+        /// <summary>Enables or disables external freezing of the player's movement.</summary>
+        void SetMovementFrozen(bool frozen);
+
+        /// <summary>Signals that scene transitions are in progress so manual input is ignored.</summary>
+        void SetTransitioning(bool transitioning);
+
+        /// <summary>Forces the player to face a supplied transform immediately.</summary>
+        void FaceTarget(Transform target);
+
+        /// <summary>Begins walking towards a world-space location until within the supplied distance.</summary>
+        void MoveTo(Vector2 target, float stopDistance, Action onComplete = null);
+
+        /// <summary>Begins walking towards a transform until within the supplied distance.</summary>
+        void MoveTo(Transform target, float stopDistance, Action onComplete = null);
+
+        /// <summary>Immediately halts all movement, cancelling auto-move routines and clearing velocity.</summary>
+        void StopMovement();
+    }
+}

--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -1,103 +1,41 @@
-﻿// Assets/Scripts/Player/PlayerMover.cs
+// Assets/Scripts/Player/PlayerMover.cs
 using UnityEngine;
-using UnityEngine.InputSystem;
 using UnityEngine.SceneManagement;
 using System;
-using System.Collections;
-using Core.Input;
 using Core.Save;
 using World;
 using Pets;
 using Util;
-using Combat;
-using Skills;
 using Status.Freeze;
+using Player.Input;
+using Player.Movement;
+using Player.Visuals;
 
 namespace Player
 {
-    [RequireComponent(typeof(Rigidbody2D))]
-    [RequireComponent(typeof(Animator))]
-    [RequireComponent(typeof(SpriteRenderer))]
+    [RequireComponent(typeof(PlayerMovementController))]
+    [RequireComponent(typeof(PlayerMovementInput))]
+    [RequireComponent(typeof(PlayerSpriteController))]
     [RequireComponent(typeof(FrozenStatusController))]
     public class PlayerMover : ScenePersistentObject, ISaveable
     {
-        [Header("Movement")]
-        public float moveSpeed = 3.5f;
-        public bool fourWayOnly = true;
-        [Tooltip("Deadzone used when reading analog sticks to snap to -1/0/1.")]
-        public float gamepadDeadzone = 0.3f;
+        [Header("Movement Components")]
+        [SerializeField, Tooltip("Handles physics-driven locomotion and persistence timers.")]
+        private PlayerMovementController movementController;
+
+        [SerializeField, Tooltip("Resolves player movement input via the shared action map.")]
+        private PlayerMovementInput movementInput;
+
+        [SerializeField, Tooltip("Drives sprite overrides and facing visuals.")]
+        private PlayerSpriteController spriteController;
 
         [HideInInspector]
         public bool CanDrop = true;
 
-        [HideInInspector]
-        public bool freezeSprite = false;
-
-        [Header("(Optional) Direct Sprite Override")]
-        [Tooltip("If assigned, these sprites will be applied directly each frame based on Dir/IsMoving. Leave null to rely on Animator clips.")]
-        public Sprite idleDown, idleDownRight, idleRight, idleUpRight, idleUp, idleUpLeft, idleLeft, idleDownLeft;
-        public Sprite walkDown, walkDownRight, walkRight, walkUpRight, walkUp, walkUpLeft, walkLeft, walkDownLeft;
-        [Header("Mirroring")]
-        [Tooltip("If true, reuse right-facing sprites for any left-facing orientation (including diagonals).")]
-        [SerializeField]
-        private bool useFlipXForLeft;
-        [Tooltip("If true, reuse left-facing sprites for any right-facing orientation (including diagonals).")]
-        [SerializeField]
-        private bool useFlipXForRight;
-        [Tooltip("If true, reuse Down-Right sprites for Down-Left facings by mirroring them.")]
-        [SerializeField]
-        private bool useFlipXForDownLeft = true;
-        [Tooltip("If true, reuse Up-Right sprites for Up-Left facings by mirroring them.")]
-        [SerializeField]
-        private bool useFlipXForUpLeft = true;
-        [Tooltip("If true, reuse Up-Left sprites for Up-Right facings by mirroring them.")]
-        [SerializeField]
-        private bool useFlipXForUpRight;
-        [Tooltip("If true, reuse Down-Left sprites for Down-Right facings by mirroring them.")]
-        [SerializeField]
-        private bool useFlipXForDownRight;
-
-#if ENABLE_INPUT_SYSTEM
-        [Header("Input")]
-        [Tooltip("PlayerInput component that owns the Player action map.")]
-        [SerializeField]
-        private PlayerInput playerInput;
-
-        [Tooltip("Reference to the Player/Move action inside the shared input asset.")]
-        [SerializeField]
-        private InputActionReference moveActionReference;
-#endif
-
-        private Rigidbody2D rb;
-        private Animator anim;
-        private SpriteRenderer sr;
-        private Inventory.Inventory inventory;
-        private CombatController combat;
         private GameObject petToMove;
         private bool isTransitioning;
-        private bool isAutoMoving;
-        private Coroutine moveRoutine;
-        private bool movementFrozen;
-        private bool freezeSpriteStateBeforeFreeze;
-        /// <summary>Tracks whether the previous frame considered the player to be moving.</summary>
-        private bool wasMoving;
-        /// <summary>
-        /// Timer used while the player is moving to trigger periodic position saves so autosaves are
-        /// always close to the most recent location.
-        /// </summary>
-        private float movementSaveTimer;
-        /// <summary>
-        /// When true this mover has been registered with the <see cref="SaveManager"/> and should
-        /// be unregistered during teardown.
-        /// </summary>
         private bool registeredWithSaveManager;
-        /// <summary>
-        /// Interval in seconds used to persist the position while movement is in progress. This
-        /// keeps the stored location reasonably fresh without hammering the save file every frame.
-        /// </summary>
-        private const float MovementSaveInterval = 2f;
 
-        // Ensure only one player persists across scene loads.
         private static PlayerMover instance;
 
         [Serializable]
@@ -111,61 +49,10 @@ namespace Player
 
         private const string PositionKey = "PlayerPosition";
 
-        private Direction8 facingDir = Direction8.Down;
-        private Vector2 moveDir;
-
-        /// <summary>Current facing direction.</summary>
-        public Direction8 FacingDir => facingDir;
-
-        public bool IsMoving => moveDir.sqrMagnitude > 0f;
-
-        /// <summary>True while external systems have frozen player movement.</summary>
-        public bool IsMovementFrozen => movementFrozen;
-
-        /// <summary>
-        ///     Indicates whether the mover is currently following an auto-move request issued through
-        ///     <see cref="MoveTo(Vector2,float,System.Action)"/> or <see cref="MoveTo(Transform,float,System.Action)"/>.
-        ///     Gathering controllers use this to determine if an automatically initiated walk is still in progress.
-        /// </summary>
-        public bool IsAutoMoving => isAutoMoving;
-
-        /// <summary>
-        ///     Allows external systems to check or override whether the mover mirrors right-facing sprites when
-        ///     travelling left. Beastmaster visual swaps rely on being able to persist and restore this value when
-        ///     temporarily applying a pet's appearance to the player.
-        /// </summary>
-        public bool UseFlipXForLeft
-        {
-            get => useFlipXForLeft;
-            set => useFlipXForLeft = value;
-        }
-
-        /// <summary>
-        ///     Allows external systems to check or override whether the mover mirrors left-facing sprites when
-        ///     travelling right. This mirrors <see cref="UseFlipXForLeft"/> for the opposite direction and is exposed
-        ///     for the same Beastmaster visual swap workflow.
-        /// </summary>
-        public bool UseFlipXForRight
-        {
-            get => useFlipXForRight;
-            set => useFlipXForRight = value;
-        }
-
-#if ENABLE_INPUT_SYSTEM
-        private InputAction moveAction;
-        private bool moveActionEnabledByResolver;
-        private Vector2 moveActionValue;
-#endif
-
         protected override void Awake()
         {
             base.Awake();
 
-            // Destroy any duplicate player instances that might exist in
-            // newly loaded scenes before they can register themselves as
-            // persistent objects.  This prevents two players from
-            // destroying each other during scene transitions and also
-            // avoids multiple AudioListeners.
             if (instance != null && instance != this)
             {
                 Destroy(gameObject);
@@ -174,28 +61,18 @@ namespace Player
 
             instance = this;
 
-            rb = GetComponent<Rigidbody2D>();
-            anim = GetComponent<Animator>();
-            sr  = GetComponent<SpriteRenderer>();
-            inventory = GetComponent<Inventory.Inventory>();
-            combat = GetComponent<CombatController>();
-#if ENABLE_INPUT_SYSTEM
-            // Fallback to the local PlayerInput if one exists and no explicit reference was supplied.
-            if (playerInput == null)
-                playerInput = GetComponent<PlayerInput>();
-#endif
-            var depth = GetComponent<SpriteDepth>();
-            if (depth != null)
-                depth.directionOffset = 1;
-
-            rb.bodyType = RigidbodyType2D.Dynamic;
-            rb.gravityScale = 0f;
-            rb.constraints = RigidbodyConstraints2D.FreezeRotation;
-            rb.interpolation = RigidbodyInterpolation2D.Interpolate;
-            rb.WakeUp();
+            if (movementController == null)
+                movementController = GetComponent<PlayerMovementController>();
+            if (movementInput == null)
+                movementInput = GetComponent<PlayerMovementInput>();
+            if (spriteController == null)
+                spriteController = GetComponent<PlayerSpriteController>();
 
             SaveManager.Register(this);
             registeredWithSaveManager = true;
+
+            if (movementController != null)
+                movementController.MovementSaveRequested += HandleMovementSaveRequested;
 
             SceneTransitionManager.TransitionStarted += OnTransitionStarted;
             SceneTransitionManager.TransitionCompleted += OnTransitionCompleted;
@@ -203,64 +80,24 @@ namespace Player
 
         private void OnEnable()
         {
-            // Register this mover with the SceneTransitionManager so the player persists across scene swaps.
             SceneTransitionManager.RegisterPersistentObject(this);
-
-#if ENABLE_INPUT_SYSTEM
-            moveAction = InputActionResolver.Resolve(playerInput, moveActionReference, "Move", out moveActionEnabledByResolver);
-
-            if (moveAction != null)
-            {
-                moveAction.performed += OnMovePerformed;
-                moveAction.canceled += OnMoveCanceled;
-                moveActionValue = moveAction.ReadValue<Vector2>();
-            }
-#endif
         }
 
         private void OnDisable()
         {
-            HandleForcedIdle();
-#if ENABLE_INPUT_SYSTEM
-            if (moveAction != null)
-            {
-                moveAction.performed -= OnMovePerformed;
-                moveAction.canceled -= OnMoveCanceled;
-
-                if (moveActionEnabledByResolver)
-                    moveAction.Disable();
-            }
-
-            moveAction = null;
-            moveActionEnabledByResolver = false;
-            moveActionValue = Vector2.zero;
-#endif
-
-            // Remove this mover from the persistence registry when disabled so duplicates do not accumulate.
             SceneTransitionManager.UnregisterPersistentObject(this);
         }
 
-#if ENABLE_INPUT_SYSTEM
-        private void OnMovePerformed(InputAction.CallbackContext context)
-        {
-            // Cache the most recent movement vector supplied by the Player action map.
-            moveActionValue = context.ReadValue<Vector2>();
-        }
-
-        private void OnMoveCanceled(InputAction.CallbackContext context)
-        {
-            moveActionValue = Vector2.zero;
-        }
-#endif
-
         private void OnDestroy()
         {
-            HandleForcedIdle();
             if (instance == this)
                 instance = null;
 
             SceneTransitionManager.TransitionStarted -= OnTransitionStarted;
             SceneTransitionManager.TransitionCompleted -= OnTransitionCompleted;
+
+            if (movementController != null)
+                movementController.MovementSaveRequested -= HandleMovementSaveRequested;
 
             if (registeredWithSaveManager)
             {
@@ -269,342 +106,66 @@ namespace Player
             }
         }
 
-        void Update()
-        {
-            if (isTransitioning)
-            {
-                moveDir = Vector2.zero;
-                rb.linearVelocity = Vector2.zero;
-                anim.SetBool("IsMoving", false);
-                HandleForcedIdle();
-                return;
-            }
+        /// <summary>Current facing direction provided by the movement controller.</summary>
+        public Direction8 FacingDir => movementController != null ? movementController.FacingDirection : Direction8.Down;
 
-            if (movementFrozen)
-            {
-                moveDir = Vector2.zero;
-                if (rb != null)
-                    rb.linearVelocity = Vector2.zero;
-                anim.SetBool("IsMoving", false);
-                HandleForcedIdle();
-                return;
-            }
+        /// <summary>True while the movement controller is executing an auto-move routine.</summary>
+        public bool IsAutoMoving => movementController != null && movementController.IsAutoMoving;
 
-            if (Inventory.InventoryDebugMenu.HasTextInputFocus || AdminF2Menu.HasTextInputFocus)
-            {
-                moveDir = Vector2.zero;
-                rb.linearVelocity = Vector2.zero;
-                anim.SetBool("IsMoving", false);
-                HandleForcedIdle();
-                return;
-            }
+        /// <summary>True while movement input is frozen by external systems.</summary>
+        public bool IsMovementFrozen => movementController != null && movementController.IsMovementFrozen;
 
-            if (inventory != null && inventory.BankOpen)
-            {
-                moveDir = Vector2.zero;
-                rb.linearVelocity = Vector2.zero;
-                anim.SetBool("IsMoving", false);
-                HandleForcedIdle();
-                return;
-            }
+        /// <summary>Exposes the underlying movement controller for systems that require direct access.</summary>
+        public PlayerMovementController MovementController => movementController;
 
-            Vector2 inputDir = Vector2.zero;
+        /// <summary>Exposes the sprite controller responsible for directional art overrides.</summary>
+        public PlayerSpriteController SpriteController => spriteController;
 
-#if ENABLE_INPUT_SYSTEM
-            Vector2 raw = moveAction != null ? moveActionValue : Vector2.zero;
-            // Snap analog to -1/0/1 so animations are stable
-            raw.x = Mathf.Abs(raw.x) < gamepadDeadzone ? 0f : Mathf.Sign(raw.x);
-            raw.y = Mathf.Abs(raw.y) < gamepadDeadzone ? 0f : Mathf.Sign(raw.y);
-#else
-            // Legacy input fallback if project uses Old/Both
-            Vector2 raw = new Vector2(Input.GetAxisRaw("Horizontal"), Input.GetAxisRaw("Vertical"));
-#endif
+        /// <summary>Exposes the input provider responsible for resolving the Move action.</summary>
+        public PlayerMovementInput MovementInput => movementInput;
 
-            if (raw.sqrMagnitude > 0f)
-            {
-                Direction8 inputFacing = Direction8Utility.FromVector(raw, !fourWayOnly, facingDir);
-                inputDir = fourWayOnly ? Direction8Utility.ToCardinalVector(inputFacing) : Direction8Utility.ToVector(inputFacing);
-            }
-
-            if (inputDir.sqrMagnitude > 0f)
-            {
-                if (isAutoMoving)
-                {
-                    isAutoMoving = false;
-                    if (moveRoutine != null)
-                    {
-                        StopCoroutine(moveRoutine);
-                        moveRoutine = null;
-                    }
-                }
-                combat?.CancelCombat();
-            }
-
-            if (!isAutoMoving)
-                moveDir = inputDir;
-
-            if (moveDir.sqrMagnitude > 0f)
-            {
-                facingDir = Direction8Utility.FromVector(moveDir, allowDiagonals: true, fallback: facingDir);
-            }
-
-            // Drive Animator (kept for future use and for state visibility)
-            bool isMoving = moveDir.sqrMagnitude > 0f;
-            RefreshAnimator(isMoving);
-            HandleMovementPersistenceAfterUpdate(isMoving);
-        }
-
-        private void RefreshAnimator(bool isMoving)
-        {
-            if (anim == null)
-                return;
-
-            Direction8 visualDir = facingDir;
-            int animatorDir = Direction8Utility.ToAnimatorIndex(visualDir);
-            Direction8 spriteDir = visualDir;
-
-            anim.SetBool("IsMoving", isMoving);
-            anim.SetInteger("Dir", animatorDir);
-
-            if (sr == null)
-                return;
-
-            Sprite desired = null;
-            bool flip = false;
-            desired = ResolveOverrideSprite(spriteDir, isMoving, out flip);
-
-            if (desired != null && !freezeSprite)
-            {
-                if (sr.flipX != flip)
-                    sr.flipX = flip;
-                if (sr.sprite != desired)
-                    sr.sprite = desired;
-            }
-        }
-
-        /// <summary>
-        ///     Resolves the sprite to display for the supplied direction using the optional override fields. The lookup
-        ///     respects diagonal-specific art, mirrors configured directions when requested, and gracefully falls back to
-        ///     cardinal frames when bespoke assets are unavailable.
-        /// </summary>
-        private Sprite ResolveOverrideSprite(Direction8 direction, bool moving, out bool flip)
-        {
-            foreach (var lookup in Direction8Utility.BuildSpriteFallbackOrder(direction, ShouldMirrorOverride))
-            {
-                Sprite sprite = GetSpriteForDirection(lookup.Direction, moving);
-                if (sprite != null)
-                {
-                    flip = lookup.FlipX;
-                    return sprite;
-                }
-            }
-
-            flip = false;
-            return null;
-        }
-
-        /// <summary>Returns true when the supplied direction is configured to borrow sprites from its mirrored counterpart.</summary>
-        private bool ShouldMirrorOverride(Direction8 direction)
-        {
-            switch (direction)
-            {
-                case Direction8.Left:
-                    return useFlipXForLeft;
-                case Direction8.Right:
-                    return useFlipXForRight;
-                case Direction8.DownLeft:
-                    return useFlipXForDownLeft;
-                case Direction8.UpLeft:
-                    return useFlipXForUpLeft;
-                case Direction8.UpRight:
-                    return useFlipXForUpRight;
-                case Direction8.DownRight:
-                    return useFlipXForDownRight;
-                default:
-                    return false;
-            }
-        }
-
-        /// <summary>
-        ///     Retrieves the idle/walk sprite assigned for the requested direction. When one of the pair is missing the
-        ///     available sprite is returned regardless of movement state so fallback logic still has something to render.
-        /// </summary>
-        private Sprite GetSpriteForDirection(Direction8 direction, bool moving)
-        {
-            GetOverrideSprites(direction, out Sprite idleSprite, out Sprite walkSprite);
-            if (moving)
-            {
-                if (walkSprite != null)
-                    return walkSprite;
-                if (idleSprite != null)
-                    return idleSprite;
-            }
-            else
-            {
-                if (idleSprite != null)
-                    return idleSprite;
-                if (walkSprite != null)
-                    return walkSprite;
-            }
-
-            return null;
-        }
-
-        /// <summary>Populates the idle and walk sprite references for a given direction.</summary>
-        private void GetOverrideSprites(Direction8 direction, out Sprite idleSprite, out Sprite walkSprite)
-        {
-            idleSprite = null;
-            walkSprite = null;
-
-            switch (direction)
-            {
-                case Direction8.Down:
-                    idleSprite = idleDown;
-                    walkSprite = walkDown;
-                    break;
-                case Direction8.DownRight:
-                    idleSprite = idleDownRight;
-                    walkSprite = walkDownRight;
-                    break;
-                case Direction8.Right:
-                    idleSprite = idleRight;
-                    walkSprite = walkRight;
-                    break;
-                case Direction8.UpRight:
-                    idleSprite = idleUpRight;
-                    walkSprite = walkUpRight;
-                    break;
-                case Direction8.Up:
-                    idleSprite = idleUp;
-                    walkSprite = walkUp;
-                    break;
-                case Direction8.UpLeft:
-                    idleSprite = idleUpLeft;
-                    walkSprite = walkUpLeft;
-                    break;
-                case Direction8.Left:
-                    idleSprite = idleLeft;
-                    walkSprite = walkLeft;
-                    break;
-                case Direction8.DownLeft:
-                    idleSprite = idleDownLeft;
-                    walkSprite = walkDownLeft;
-                    break;
-            }
-        }
-
-        void FixedUpdate()
-        {
-            rb.linearVelocity = moveDir * moveSpeed;
-        }
-
-        /// <summary>
-        /// Enables or disables external freezing of the player's movement.
-        /// </summary>
-        /// <param name="frozen">When true input and auto movement are halted.</param>
+        /// <summary>Delegates to the movement controller to freeze or unfreeze locomotion.</summary>
         public void SetMovementFrozen(bool frozen)
         {
-            if (movementFrozen == frozen)
-                return;
-
-            movementFrozen = frozen;
-            if (movementFrozen)
-            {
-                freezeSpriteStateBeforeFreeze = freezeSprite;
-                StopMovement();
-                freezeSprite = true;
-            }
-            else
-            {
-                freezeSprite = freezeSpriteStateBeforeFreeze;
-            }
+            movementController?.SetMovementFrozen(frozen);
         }
 
-        public void FaceTarget(Transform target)
-        {
-            if (target == null)
-                return;
-
-            Vector2 dir = (Vector2)target.position - (Vector2)transform.position;
-            facingDir = Direction8Utility.FromVector(dir, allowDiagonals: true, fallback: facingDir);
-
-            RefreshAnimator(moveDir.sqrMagnitude > 0f);
-        }
-
-        public void MoveTo(Vector2 target, float stopDistance, Action onComplete = null)
-        {
-            if (moveRoutine != null)
-                StopCoroutine(moveRoutine);
-            moveRoutine = StartCoroutine(MoveToRoutine(target, stopDistance, onComplete));
-        }
-
-        public void MoveTo(Transform target, float stopDistance, Action onComplete = null)
-        {
-            if (moveRoutine != null)
-                StopCoroutine(moveRoutine);
-            moveRoutine = StartCoroutine(MoveToRoutine(target, stopDistance, onComplete));
-        }
-
-        private IEnumerator MoveToRoutine(Vector2 target, float stopDistance, Action onComplete)
-        {
-            isAutoMoving = true;
-            while (Vector2.Distance(transform.position, target) > stopDistance)
-            {
-                Vector2 dir = (target - (Vector2)transform.position).normalized;
-                moveDir = dir;
-                yield return null;
-            }
-            StopMovement();
-            isAutoMoving = false;
-            moveRoutine = null;
-            onComplete?.Invoke();
-        }
-
-        private IEnumerator MoveToRoutine(Transform target, float stopDistance, Action onComplete)
-        {
-            isAutoMoving = true;
-            while (target != null && Vector2.Distance(transform.position, target.position) > stopDistance)
-            {
-                Vector2 dir = ((Vector2)target.position - (Vector2)transform.position).normalized;
-                moveDir = dir;
-                yield return null;
-            }
-            StopMovement();
-            isAutoMoving = false;
-            moveRoutine = null;
-            if (target != null)
-                onComplete?.Invoke();
-        }
-
-        /// <summary>
-        /// Immediately halts any current movement and updates animation state.
-        /// </summary>
+        /// <summary>Immediately halts all movement via the movement controller.</summary>
         public void StopMovement()
         {
-            moveDir = Vector2.zero;
-            if (rb != null)
-                rb.linearVelocity = Vector2.zero;
-            if (anim != null)
-                anim.SetBool("IsMoving", false);
-            if (moveRoutine != null)
-            {
-                StopCoroutine(moveRoutine);
-                moveRoutine = null;
-            }
-            isAutoMoving = false;
-            HandleForcedIdle();
+            movementController?.StopMovement();
         }
 
-        void OnApplicationQuit()
+        /// <summary>Faces the supplied target using the movement controller.</summary>
+        public void FaceTarget(Transform target)
         {
-            SavePosition();
+            movementController?.FaceTarget(target);
         }
 
-        /// <summary>
-        /// Persist the player's current position to the active save profile. The data is queued for
-        /// asynchronous persistence by <see cref="SaveManager"/> so callers should not assume the
-        /// save has reached disk immediately after this method returns.
-        /// </summary>
+        /// <summary>Begins an auto-move towards a world position.</summary>
+        public void MoveTo(Vector2 target, float stopDistance, Action onComplete = null)
+        {
+            movementController?.MoveTo(target, stopDistance, onComplete);
+        }
+
+        /// <summary>Begins an auto-move towards a transform.</summary>
+        public void MoveTo(Transform target, float stopDistance, Action onComplete = null)
+        {
+            movementController?.MoveTo(target, stopDistance, onComplete);
+        }
+
+        private void OnTransitionStarted()
+        {
+            isTransitioning = true;
+            movementController?.SetTransitioning(true);
+        }
+
+        private void OnTransitionCompleted()
+        {
+            isTransitioning = false;
+            movementController?.SetTransitioning(false);
+        }
+
         public void SavePosition()
         {
             Vector3 pos = transform.position;
@@ -619,18 +180,11 @@ namespace Player
             SaveManager.UpdateLastKnownLocation(data.scene, pos);
         }
 
-        /// <summary>
-        /// Invoked by <see cref="SaveManager"/> during autosaves to capture the latest player position.
-        /// </summary>
         public void Save()
         {
             SavePosition();
         }
 
-        /// <summary>
-        /// Invoked by <see cref="SaveManager"/> when the profile changes or during initialisation to
-        /// restore the player to the saved location.
-        /// </summary>
         public void Load()
         {
             LoadPosition();
@@ -689,25 +243,9 @@ namespace Player
                 }
             }
 
-            // Always unsubscribe after handling the scene load so duplicate registrations cannot accumulate.
             SceneManager.sceneLoaded -= OnSceneLoaded;
         }
 
-        private void OnTransitionStarted()
-        {
-            isTransitioning = true;
-            HandleForcedIdle();
-        }
-
-        private void OnTransitionCompleted()
-        {
-            isTransitioning = false;
-        }
-
-        /// <summary>
-        /// Attempts to move the player to the coordinates stored in the active save profile.
-        /// </summary>
-        /// <returns>True when a saved location existed and was applied.</returns>
         private bool ApplySavedPosition()
         {
             var data = SaveManager.Load<PositionData>(PositionKey);
@@ -718,17 +256,10 @@ namespace Player
             return true;
         }
 
-        public override void OnBeforeSceneUnload()
-        {
-            base.OnBeforeSceneUnload();
-        }
-
         public override void OnAfterSceneLoad(Scene scene)
         {
             base.OnAfterSceneLoad(scene);
 
-            // Track which positioning strategy ended up being used so we only persist when a valid
-            // location has been resolved for this scene.
             bool positionedFromSpawn = false;
             bool positionedFromSave = false;
 
@@ -758,10 +289,6 @@ namespace Player
 
             bool shouldPersistPosition = positionedFromSpawn || positionedFromSave;
 
-            // Realign an active pet so it appears beside the player rather than
-            // lingering at the origin during scene swaps.  Without this pass the
-            // pet spawns at (0,0) because the player may not exist yet when the
-            // pet system restores its position during the load sequence.
             var activePet = PetDropSystem.ActivePetObject;
             if (activePet != null)
             {
@@ -781,9 +308,6 @@ namespace Player
                     Destroy(p);
             }
 
-            // Remove any extra AudioListeners that may have been loaded with the
-            // new scene.  Unity requires exactly one listener and keeping only the
-            // player's avoids console warnings and audio glitches.
             var myListener = GetComponentInChildren<AudioListener>();
             if (myListener != null)
             {
@@ -799,42 +323,14 @@ namespace Player
                 SavePosition();
         }
 
-        /// <summary>
-        /// Handles persistence updates while movement input is processed so the saved location stays
-        /// current without incurring unnecessary writes.
-        /// </summary>
-        /// <param name="isMoving">Whether the player is considered to be moving this frame.</param>
-        private void HandleMovementPersistenceAfterUpdate(bool isMoving)
+        private void HandleMovementSaveRequested()
         {
-            if (isMoving)
-            {
-                movementSaveTimer += Time.unscaledDeltaTime;
-                if (movementSaveTimer >= MovementSaveInterval)
-                {
-                    SavePosition();
-                    movementSaveTimer = 0f;
-                }
-            }
-            else if (wasMoving)
-            {
-                SavePosition();
-                movementSaveTimer = 0f;
-            }
-
-            wasMoving = isMoving;
+            SavePosition();
         }
 
-        /// <summary>
-        /// Ensures that any forced stop caused by transitions, menus, or scripted calls immediately
-        /// persists the current position so reloads resume from the correct spot.
-        /// </summary>
-        private void HandleForcedIdle()
+        private void OnApplicationQuit()
         {
-            if (wasMoving)
-                SavePosition();
-
-            wasMoving = false;
-            movementSaveTimer = 0f;
+            SavePosition();
         }
     }
 }

--- a/Assets/Scripts/Player/Visuals/PlayerSpriteController.cs
+++ b/Assets/Scripts/Player/Visuals/PlayerSpriteController.cs
@@ -1,0 +1,340 @@
+// Assets/Scripts/Player/Visuals/PlayerSpriteController.cs
+using UnityEngine;
+using Util;
+
+namespace Player.Visuals
+{
+    /// <summary>
+    ///     Drives the player's sprite renderer and animator states, supporting optional directional overrides
+    ///     and configurable mirroring flags so OSRS-style diagonal reuse behaves correctly.
+    /// </summary>
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(Animator))]
+    [RequireComponent(typeof(SpriteRenderer))]
+    public class PlayerSpriteController : MonoBehaviour, IPlayerSpriteController
+    {
+        [Header("(Optional) Direct Sprite Override")]
+        [Tooltip("If assigned, these sprites will be applied directly each frame based on Dir/IsMoving. Leave null to rely on Animator clips.")]
+        [SerializeField] private Sprite idleDown;
+        [SerializeField] private Sprite idleDownRight;
+        [SerializeField] private Sprite idleRight;
+        [SerializeField] private Sprite idleUpRight;
+        [SerializeField] private Sprite idleUp;
+        [SerializeField] private Sprite idleUpLeft;
+        [SerializeField] private Sprite idleLeft;
+        [SerializeField] private Sprite idleDownLeft;
+
+        [SerializeField] private Sprite walkDown;
+        [SerializeField] private Sprite walkDownRight;
+        [SerializeField] private Sprite walkRight;
+        [SerializeField] private Sprite walkUpRight;
+        [SerializeField] private Sprite walkUp;
+        [SerializeField] private Sprite walkUpLeft;
+        [SerializeField] private Sprite walkLeft;
+        [SerializeField] private Sprite walkDownLeft;
+
+        [Header("Mirroring")]
+        [Tooltip("If true, reuse right-facing sprites for any left-facing orientation (including diagonals).")]
+        [SerializeField] private bool useFlipXForLeft;
+        [Tooltip("If true, reuse left-facing sprites for any right-facing orientation (including diagonals).")]
+        [SerializeField] private bool useFlipXForRight;
+        [Tooltip("If true, reuse Down-Right sprites for Down-Left facings by mirroring them.")]
+        [SerializeField] private bool useFlipXForDownLeft = true;
+        [Tooltip("If true, reuse Up-Right sprites for Up-Left facings by mirroring them.")]
+        [SerializeField] private bool useFlipXForUpLeft = true;
+        [Tooltip("If true, reuse Up-Left sprites for Up-Right facings by mirroring them.")]
+        [SerializeField] private bool useFlipXForUpRight;
+        [Tooltip("If true, reuse Down-Left sprites for Down-Right facings by mirroring them.")]
+        [SerializeField] private bool useFlipXForDownRight;
+
+        [Tooltip("When enabled, keeps the current sprite frame static while allowing the animator parameters to continue updating.")]
+        [SerializeField] private bool freezeSprite;
+
+        private Animator animator;
+        private SpriteRenderer spriteRenderer;
+
+        /// <inheritdoc />
+        public bool FreezeSprite
+        {
+            get => freezeSprite;
+            set => freezeSprite = value;
+        }
+
+        /// <inheritdoc />
+        public bool UseFlipXForLeft
+        {
+            get => useFlipXForLeft;
+            set => useFlipXForLeft = value;
+        }
+
+        /// <inheritdoc />
+        public bool UseFlipXForRight
+        {
+            get => useFlipXForRight;
+            set => useFlipXForRight = value;
+        }
+
+        private void Awake()
+        {
+            animator = GetComponent<Animator>();
+            spriteRenderer = GetComponent<SpriteRenderer>();
+        }
+
+        /// <inheritdoc />
+        public void ApplyMovementVisuals(Direction8 direction, bool isMoving)
+        {
+            if (animator != null)
+            {
+                animator.SetBool("IsMoving", isMoving);
+                animator.SetInteger("Dir", Direction8Utility.ToAnimatorIndex(direction));
+            }
+
+            if (spriteRenderer == null)
+                return;
+
+            if (freezeSprite)
+                return;
+
+            if (!TryResolveOverrideSprite(direction, isMoving, out Sprite desired, out bool flip))
+                return;
+
+            if (spriteRenderer.flipX != flip)
+                spriteRenderer.flipX = flip;
+
+            if (spriteRenderer.sprite != desired)
+                spriteRenderer.sprite = desired;
+        }
+
+        /// <summary>
+        ///     Attempts to resolve an override sprite for the supplied facing direction, including mirroring fallbacks.
+        /// </summary>
+        private bool TryResolveOverrideSprite(Direction8 direction, bool moving, out Sprite sprite, out bool flip)
+        {
+            foreach (var lookup in Direction8Utility.BuildSpriteFallbackOrder(direction, ShouldMirrorOverride))
+            {
+                if (TryGetSpriteForDirection(lookup.Direction, moving, out sprite))
+                {
+                    flip = lookup.FlipX;
+                    return true;
+                }
+            }
+
+            sprite = null;
+            flip = false;
+            return false;
+        }
+
+        /// <summary>Determines whether the supplied direction should mirror its counterpart when resolving overrides.</summary>
+        private bool ShouldMirrorOverride(Direction8 direction)
+        {
+            return direction switch
+            {
+                Direction8.Left => useFlipXForLeft,
+                Direction8.Right => useFlipXForRight,
+                Direction8.DownLeft => useFlipXForDownLeft,
+                Direction8.UpLeft => useFlipXForUpLeft,
+                Direction8.UpRight => useFlipXForUpRight,
+                Direction8.DownRight => useFlipXForDownRight,
+                _ => false
+            };
+        }
+
+        /// <summary>
+        ///     Retrieves the idle and walking sprites for a given direction, preferring the matching state but falling back when required.
+        /// </summary>
+        private bool TryGetSpriteForDirection(Direction8 direction, bool moving, out Sprite sprite)
+        {
+            GetOverrideSprites(direction, out Sprite idleSprite, out Sprite walkSprite);
+            if (moving)
+            {
+                if (walkSprite != null)
+                {
+                    sprite = walkSprite;
+                    return true;
+                }
+
+                if (idleSprite != null)
+                {
+                    sprite = idleSprite;
+                    return true;
+                }
+            }
+            else
+            {
+                if (idleSprite != null)
+                {
+                    sprite = idleSprite;
+                    return true;
+                }
+
+                if (walkSprite != null)
+                {
+                    sprite = walkSprite;
+                    return true;
+                }
+            }
+
+            sprite = null;
+            return false;
+        }
+
+        /// <summary>Populates the idle and walk sprite references for a supplied direction.</summary>
+        private void GetOverrideSprites(Direction8 direction, out Sprite idleSprite, out Sprite walkSprite)
+        {
+            idleSprite = null;
+            walkSprite = null;
+
+            switch (direction)
+            {
+                case Direction8.Down:
+                    idleSprite = idleDown;
+                    walkSprite = walkDown;
+                    break;
+                case Direction8.DownRight:
+                    idleSprite = idleDownRight;
+                    walkSprite = walkDownRight;
+                    break;
+                case Direction8.Right:
+                    idleSprite = idleRight;
+                    walkSprite = walkRight;
+                    break;
+                case Direction8.UpRight:
+                    idleSprite = idleUpRight;
+                    walkSprite = walkUpRight;
+                    break;
+                case Direction8.Up:
+                    idleSprite = idleUp;
+                    walkSprite = walkUp;
+                    break;
+                case Direction8.UpLeft:
+                    idleSprite = idleUpLeft;
+                    walkSprite = walkUpLeft;
+                    break;
+                case Direction8.Left:
+                    idleSprite = idleLeft;
+                    walkSprite = walkLeft;
+                    break;
+                case Direction8.DownLeft:
+                    idleSprite = idleDownLeft;
+                    walkSprite = walkDownLeft;
+                    break;
+            }
+        }
+
+        /// <summary>Retrieves the idle override sprite for the supplied facing direction.</summary>
+        public Sprite GetIdleSprite(Direction8 direction)
+        {
+            return direction switch
+            {
+                Direction8.Down => idleDown,
+                Direction8.DownRight => idleDownRight,
+                Direction8.Right => idleRight,
+                Direction8.UpRight => idleUpRight,
+                Direction8.Up => idleUp,
+                Direction8.UpLeft => idleUpLeft,
+                Direction8.Left => idleLeft,
+                Direction8.DownLeft => idleDownLeft,
+                _ => null
+            };
+        }
+
+        /// <summary>Assigns the idle override sprite for the supplied facing direction.</summary>
+        public void SetIdleSprite(Direction8 direction, Sprite sprite)
+        {
+            switch (direction)
+            {
+                case Direction8.Down:
+                    idleDown = sprite;
+                    break;
+                case Direction8.DownRight:
+                    idleDownRight = sprite;
+                    break;
+                case Direction8.Right:
+                    idleRight = sprite;
+                    break;
+                case Direction8.UpRight:
+                    idleUpRight = sprite;
+                    break;
+                case Direction8.Up:
+                    idleUp = sprite;
+                    break;
+                case Direction8.UpLeft:
+                    idleUpLeft = sprite;
+                    break;
+                case Direction8.Left:
+                    idleLeft = sprite;
+                    break;
+                case Direction8.DownLeft:
+                    idleDownLeft = sprite;
+                    break;
+            }
+        }
+
+        /// <summary>Retrieves the walking override sprite for the supplied facing direction.</summary>
+        public Sprite GetWalkSprite(Direction8 direction)
+        {
+            return direction switch
+            {
+                Direction8.Down => walkDown,
+                Direction8.DownRight => walkDownRight,
+                Direction8.Right => walkRight,
+                Direction8.UpRight => walkUpRight,
+                Direction8.Up => walkUp,
+                Direction8.UpLeft => walkUpLeft,
+                Direction8.Left => walkLeft,
+                Direction8.DownLeft => walkDownLeft,
+                _ => null
+            };
+        }
+
+        /// <summary>Assigns the walking override sprite for the supplied facing direction.</summary>
+        public void SetWalkSprite(Direction8 direction, Sprite sprite)
+        {
+            switch (direction)
+            {
+                case Direction8.Down:
+                    walkDown = sprite;
+                    break;
+                case Direction8.DownRight:
+                    walkDownRight = sprite;
+                    break;
+                case Direction8.Right:
+                    walkRight = sprite;
+                    break;
+                case Direction8.UpRight:
+                    walkUpRight = sprite;
+                    break;
+                case Direction8.Up:
+                    walkUp = sprite;
+                    break;
+                case Direction8.UpLeft:
+                    walkUpLeft = sprite;
+                    break;
+                case Direction8.Left:
+                    walkLeft = sprite;
+                    break;
+                case Direction8.DownLeft:
+                    walkDownLeft = sprite;
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Public contract exposed by <see cref="PlayerSpriteController"/> so other systems only depend on sprite-specific behaviour.
+    /// </summary>
+    public interface IPlayerSpriteController
+    {
+        /// <summary>Gets or sets whether sprite swapping is temporarily frozen.</summary>
+        bool FreezeSprite { get; set; }
+
+        /// <summary>Gets or sets whether right-facing sprites should be mirrored for left facings.</summary>
+        bool UseFlipXForLeft { get; set; }
+
+        /// <summary>Gets or sets whether left-facing sprites should be mirrored for right facings.</summary>
+        bool UseFlipXForRight { get; set; }
+
+        /// <summary>Applies the supplied movement visuals to the animator and sprite renderer.</summary>
+        void ApplyMovementVisuals(Direction8 direction, bool isMoving);
+    }
+}

--- a/Assets/Scripts/Skills/Beastmaster/MergedPetAttackAnimator.cs
+++ b/Assets/Scripts/Skills/Beastmaster/MergedPetAttackAnimator.cs
@@ -2,6 +2,8 @@ using UnityEngine;
 using Combat;
 using Pets;
 using Player;
+using Player.Movement;
+using Player.Visuals;
 using Util;
 
 namespace Beastmaster
@@ -12,7 +14,8 @@ namespace Beastmaster
     public class MergedPetAttackAnimator : MonoBehaviour
     {
         [SerializeField] private CombatController combat;
-        [SerializeField] private PlayerMover mover;
+        [SerializeField] private PlayerMovementController movementController;
+        [SerializeField] private PlayerSpriteController spriteController;
         [SerializeField] private Animator animator;
         [SerializeField] private PetSpriteAnimator spriteAnimator;
 
@@ -20,8 +23,22 @@ namespace Beastmaster
         {
             if (combat == null)
                 combat = GetComponent<CombatController>() ?? GetComponentInParent<CombatController>();
-            if (mover == null)
-                mover = GetComponent<PlayerMover>() ?? GetComponentInChildren<PlayerMover>();
+            if (movementController == null)
+                movementController = GetComponent<PlayerMovementController>() ?? GetComponentInChildren<PlayerMovementController>();
+            if (movementController == null)
+            {
+                var moverFacade = GetComponent<PlayerMover>() ?? GetComponentInChildren<PlayerMover>();
+                if (moverFacade != null)
+                    movementController = moverFacade.MovementController;
+            }
+            if (spriteController == null)
+                spriteController = GetComponent<PlayerSpriteController>() ?? GetComponentInChildren<PlayerSpriteController>();
+            if (spriteController == null)
+            {
+                var moverFacade = GetComponent<PlayerMover>() ?? GetComponentInChildren<PlayerMover>();
+                if (moverFacade != null)
+                    spriteController = moverFacade.SpriteController;
+            }
             if (animator == null)
                 animator = GetComponent<Animator>() ?? GetComponentInChildren<Animator>();
             if (spriteAnimator == null)
@@ -80,7 +97,7 @@ namespace Beastmaster
 
         private void HandleAttack()
         {
-            Direction8 dir = mover != null ? mover.FacingDir : Direction8.Down;
+            Direction8 dir = movementController != null ? movementController.FacingDirection : Direction8.Down;
             if (animator != null && animator.runtimeAnimatorController != null)
             {
                 animator.SetInteger("Dir", Direction8Utility.ToAnimatorIndex8(dir));
@@ -92,11 +109,12 @@ namespace Beastmaster
 
         private System.Collections.IEnumerator PlayHit(Direction8 dir)
         {
-            if (mover != null)
-                mover.freezeSprite = true;
+            bool originalFreeze = spriteController != null && spriteController.FreezeSprite;
+            if (spriteController != null)
+                spriteController.FreezeSprite = true;
             yield return StartCoroutine(spriteAnimator.PlayHitAnimation(dir));
-            if (mover != null)
-                mover.freezeSprite = false;
+            if (spriteController != null)
+                spriteController.FreezeSprite = originalFreeze;
         }
     }
 }

--- a/Assets/Scripts/Skills/Beastmaster/PetMergeController.cs
+++ b/Assets/Scripts/Skills/Beastmaster/PetMergeController.cs
@@ -5,6 +5,7 @@ using Pets;
 using UI;
 using EquipmentSystem;
 using Player;
+using Player.Movement;
 
 namespace Beastmaster
 {
@@ -23,6 +24,7 @@ namespace Beastmaster
         [SerializeField] private PlayerCombatBinder combatBinder;
         [SerializeField] private MergeHudTimer hudTimer;
         [SerializeField] private PlayerMover playerMover;
+        private IPlayerMovementController movementController;
 
         private IBeastmasterService beastmaster;
         private IPetService petService;
@@ -70,6 +72,7 @@ namespace Beastmaster
                 hudTimer = GetComponentInChildren<MergeHudTimer>(true) ?? FindObjectOfType<MergeHudTimer>(true);
             if (playerMover == null)
                 playerMover = GetComponent<PlayerMover>();
+            movementController = playerMover != null ? playerMover.MovementController : GetComponent<PlayerMovementController>();
 
             if (beastmaster == null)
                 Debug.LogWarning("PetMergeController missing IBeastmasterService component.");
@@ -109,12 +112,17 @@ namespace Beastmaster
 
         private void ApplySpeedModifier()
         {
-            if (playerMover == null)
-                playerMover = GetComponent<PlayerMover>();
-            if (playerMover == null)
+            if (movementController == null)
+            {
+                if (playerMover == null)
+                    playerMover = GetComponent<PlayerMover>();
+                movementController = playerMover != null ? playerMover.MovementController : GetComponent<PlayerMovementController>();
+            }
+
+            if (movementController == null)
                 return;
-            originalMoveSpeed = playerMover.moveSpeed;
-            playerMover.moveSpeed = originalMoveSpeed * GetSpeedMultiplier();
+            originalMoveSpeed = movementController.MoveSpeed;
+            movementController.MoveSpeed = originalMoveSpeed * GetSpeedMultiplier();
         }
 
         private float GetSpeedMultiplier()
@@ -136,8 +144,8 @@ namespace Beastmaster
 
         private void RestoreSpeed()
         {
-            if (playerMover != null)
-                playerMover.moveSpeed = originalMoveSpeed;
+            if (movementController != null)
+                movementController.MoveSpeed = originalMoveSpeed;
         }
 
         /// <summary>Attempt to start merging with the active pet.</summary>

--- a/Assets/Scripts/Skills/Beastmaster/PlayerVisualBinder.cs
+++ b/Assets/Scripts/Skills/Beastmaster/PlayerVisualBinder.cs
@@ -1,6 +1,8 @@
 using UnityEngine;
 using Pets;
 using Player;
+using Player.Visuals;
+using Util;
 
 namespace Beastmaster
 {
@@ -11,7 +13,7 @@ namespace Beastmaster
     {
         [SerializeField] private SpriteRenderer spriteRenderer;
         [SerializeField] private Animator animator;
-        [SerializeField] private PlayerMover playerMover;
+        [SerializeField] private PlayerSpriteController spriteController;
         [SerializeField] private MergedPetAttackAnimator attackAnimator;
 
         private RuntimeAnimatorController originalController;
@@ -32,10 +34,14 @@ namespace Beastmaster
                 animator = GetComponent<Animator>();
             if (animator == null)
                 animator = GetComponentInChildren<Animator>();
-            if (playerMover == null)
-                playerMover = GetComponent<PlayerMover>();
-            if (playerMover == null)
-                playerMover = GetComponentInChildren<PlayerMover>();
+            if (spriteController == null)
+                spriteController = GetComponent<PlayerSpriteController>() ?? GetComponentInChildren<PlayerSpriteController>();
+            if (spriteController == null)
+            {
+                var mover = GetComponent<PlayerMover>() ?? GetComponentInChildren<PlayerMover>();
+                if (mover != null)
+                    spriteController = mover.SpriteController;
+            }
             if (attackAnimator == null)
                 attackAnimator = GetComponent<MergedPetAttackAnimator>();
             if (attackAnimator == null)
@@ -44,18 +50,18 @@ namespace Beastmaster
                 originalSprite = spriteRenderer.sprite;
             if (animator != null)
                 originalController = animator.runtimeAnimatorController;
-            if (playerMover != null)
+            if (spriteController != null)
             {
-                origIdleDown = playerMover.idleDown;
-                origIdleLeft = playerMover.idleLeft;
-                origIdleRight = playerMover.idleRight;
-                origIdleUp = playerMover.idleUp;
-                origWalkDown = playerMover.walkDown;
-                origWalkLeft = playerMover.walkLeft;
-                origWalkRight = playerMover.walkRight;
-                origWalkUp = playerMover.walkUp;
-                origUseFlipXForLeft = playerMover.UseFlipXForLeft;
-                origUseFlipXForRight = playerMover.UseFlipXForRight;
+                origIdleDown = spriteController.GetIdleSprite(Direction8.Down);
+                origIdleLeft = spriteController.GetIdleSprite(Direction8.Left);
+                origIdleRight = spriteController.GetIdleSprite(Direction8.Right);
+                origIdleUp = spriteController.GetIdleSprite(Direction8.Up);
+                origWalkDown = spriteController.GetWalkSprite(Direction8.Down);
+                origWalkLeft = spriteController.GetWalkSprite(Direction8.Left);
+                origWalkRight = spriteController.GetWalkSprite(Direction8.Right);
+                origWalkUp = spriteController.GetWalkSprite(Direction8.Up);
+                origUseFlipXForLeft = spriteController.UseFlipXForLeft;
+                origUseFlipXForRight = spriteController.UseFlipXForRight;
             }
             origScale = transform.localScale;
             origFlipX = spriteRenderer != null && spriteRenderer.flipX;
@@ -72,31 +78,31 @@ namespace Beastmaster
                 animator.runtimeAnimatorController = profile.controller;
             if (spriteRenderer != null && profile.baseSprite != null)
                 spriteRenderer.sprite = profile.baseSprite;
-            if (playerMover != null)
+            if (spriteController != null)
             {
                 if (profile.controller == null)
                 {
-                    if (profile.idleDown != null) playerMover.idleDown = profile.idleDown;
-                    if (profile.idleLeft != null) playerMover.idleLeft = profile.idleLeft;
-                    if (profile.idleRight != null) playerMover.idleRight = profile.idleRight;
-                    if (profile.idleUp != null) playerMover.idleUp = profile.idleUp;
-                    if (profile.walkDown != null) playerMover.walkDown = profile.walkDown;
-                    if (profile.walkLeft != null) playerMover.walkLeft = profile.walkLeft;
-                    if (profile.walkRight != null) playerMover.walkRight = profile.walkRight;
-                    if (profile.walkUp != null) playerMover.walkUp = profile.walkUp;
-                    playerMover.UseFlipXForLeft = profile.useFlipXForLeft;
-                    playerMover.UseFlipXForRight = profile.useFlipXForRight;
+                    if (profile.idleDown != null) spriteController.SetIdleSprite(Direction8.Down, profile.idleDown);
+                    if (profile.idleLeft != null) spriteController.SetIdleSprite(Direction8.Left, profile.idleLeft);
+                    if (profile.idleRight != null) spriteController.SetIdleSprite(Direction8.Right, profile.idleRight);
+                    if (profile.idleUp != null) spriteController.SetIdleSprite(Direction8.Up, profile.idleUp);
+                    if (profile.walkDown != null) spriteController.SetWalkSprite(Direction8.Down, profile.walkDown);
+                    if (profile.walkLeft != null) spriteController.SetWalkSprite(Direction8.Left, profile.walkLeft);
+                    if (profile.walkRight != null) spriteController.SetWalkSprite(Direction8.Right, profile.walkRight);
+                    if (profile.walkUp != null) spriteController.SetWalkSprite(Direction8.Up, profile.walkUp);
+                    spriteController.UseFlipXForLeft = profile.useFlipXForLeft;
+                    spriteController.UseFlipXForRight = profile.useFlipXForRight;
                 }
                 else
                 {
-                    playerMover.idleDown = null;
-                    playerMover.idleLeft = null;
-                    playerMover.idleRight = null;
-                    playerMover.idleUp = null;
-                    playerMover.walkDown = null;
-                    playerMover.walkLeft = null;
-                    playerMover.walkRight = null;
-                    playerMover.walkUp = null;
+                    spriteController.SetIdleSprite(Direction8.Down, null);
+                    spriteController.SetIdleSprite(Direction8.Left, null);
+                    spriteController.SetIdleSprite(Direction8.Right, null);
+                    spriteController.SetIdleSprite(Direction8.Up, null);
+                    spriteController.SetWalkSprite(Direction8.Down, null);
+                    spriteController.SetWalkSprite(Direction8.Left, null);
+                    spriteController.SetWalkSprite(Direction8.Right, null);
+                    spriteController.SetWalkSprite(Direction8.Up, null);
                 }
             }
             transform.localScale = profile.localScale;
@@ -118,18 +124,18 @@ namespace Beastmaster
                 spriteRenderer.flipX = origFlipX;
             }
             transform.localScale = origScale;
-            if (playerMover != null)
+            if (spriteController != null)
             {
-                playerMover.idleDown = origIdleDown;
-                playerMover.idleLeft = origIdleLeft;
-                playerMover.idleRight = origIdleRight;
-                playerMover.idleUp = origIdleUp;
-                playerMover.walkDown = origWalkDown;
-                playerMover.walkLeft = origWalkLeft;
-                playerMover.walkRight = origWalkRight;
-                playerMover.walkUp = origWalkUp;
-                playerMover.UseFlipXForLeft = origUseFlipXForLeft;
-                playerMover.UseFlipXForRight = origUseFlipXForRight;
+                spriteController.SetIdleSprite(Direction8.Down, origIdleDown);
+                spriteController.SetIdleSprite(Direction8.Left, origIdleLeft);
+                spriteController.SetIdleSprite(Direction8.Right, origIdleRight);
+                spriteController.SetIdleSprite(Direction8.Up, origIdleUp);
+                spriteController.SetWalkSprite(Direction8.Down, origWalkDown);
+                spriteController.SetWalkSprite(Direction8.Left, origWalkLeft);
+                spriteController.SetWalkSprite(Direction8.Right, origWalkRight);
+                spriteController.SetWalkSprite(Direction8.Up, origWalkUp);
+                spriteController.UseFlipXForLeft = origUseFlipXForLeft;
+                spriteController.UseFlipXForRight = origUseFlipXForRight;
             }
             attackAnimator?.ClearPetLook();
         }

--- a/Assets/Scripts/Skills/Common/GatheringController.cs
+++ b/Assets/Scripts/Skills/Common/GatheringController.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.InputSystem;
 using Player;
+using Player.Movement;
 using Core.Input;
 
 namespace Skills.Common
@@ -70,8 +71,8 @@ namespace Skills.Common
         private TSkill skill;
 
         [SerializeField]
-        [Tooltip("Player mover used to detect when the character begins to walk away from the resource.")]
-        private PlayerMover playerMover;
+        [Tooltip("Movement controller used to detect when the character begins to walk away from the resource.")]
+        private PlayerMovementController explicitMovementController;
 
         [SerializeField]
         [Tooltip("Camera used for translating screen clicks into world positions.")]
@@ -112,7 +113,9 @@ namespace Skills.Common
         /// <summary>
         ///     Cached reference to the movement controller used for cancellation checks.
         /// </summary>
-        protected PlayerMover PlayerMover => playerMover;
+        protected IPlayerMovementController MovementController => playerMovement;
+
+        private IPlayerMovementController playerMovement;
 
         /// <summary>
         ///     Camera used for cursor raycasts. Falls back to <see cref="Camera.main"/> when left empty.
@@ -145,7 +148,7 @@ namespace Skills.Common
         protected float ProspectCooldownSeconds => prospectCooldownSeconds;
 
         /// <summary>
-        ///     When <c>true</c> the controller will instruct the <see cref="PlayerMover"/> to walk into range before
+        ///     When <c>true</c> the controller will instruct the <see cref="IPlayerMovementController"/> to walk into range before
         ///     attempting to start the gathering action.
         /// </summary>
         protected virtual bool AllowAutoMoveToNodes => autoMoveIntoRange;
@@ -197,8 +200,24 @@ namespace Skills.Common
         {
             if (skill == null)
                 skill = GetComponent<TSkill>();
-            if (playerMover == null)
-                playerMover = GetComponent<PlayerMover>();
+
+            if (playerMovement == null && explicitMovementController != null)
+                playerMovement = explicitMovementController;
+
+            if (playerMovement == null)
+            {
+                playerMovement = GetComponent<PlayerMovementController>()
+                    ?? GetComponentInParent<PlayerMovementController>()
+                    ?? GetComponentInChildren<PlayerMovementController>();
+
+                if (playerMovement == null)
+                {
+                    var moverFacade = GetComponent<PlayerMover>() ?? GetComponentInParent<PlayerMover>() ?? GetComponentInChildren<PlayerMover>();
+                    if (moverFacade != null)
+                        playerMovement = moverFacade.MovementController;
+                }
+            }
+
             if (worldCamera == null)
                 worldCamera = Camera.main;
             if (playerInput == null)
@@ -351,7 +370,7 @@ namespace Skills.Common
             if (!IsPerformingAction)
                 return;
 
-            if (CancelOnPlayerMovement && playerMover != null && playerMover.IsMoving)
+            if (CancelOnPlayerMovement && playerMovement != null && playerMovement.IsMoving)
             {
                 RequestStopAction();
                 return;
@@ -474,7 +493,7 @@ namespace Skills.Common
             if (!AllowAutoMoveToNodes)
                 return;
 
-            if (playerMover == null)
+            if (playerMovement == null)
             {
                 ShowFeedback(GetOutOfRangeMessage(node), node);
                 return;
@@ -491,9 +510,9 @@ namespace Skills.Common
             float stopDistance = CalculateAutoApproachStopDistance(approachingRange);
 
             if (approachingTransform != null)
-                playerMover.MoveTo(approachingTransform, stopDistance, HandleAutoApproachComplete);
+                playerMovement.MoveTo(approachingTransform, stopDistance, HandleAutoApproachComplete);
             else
-                playerMover.MoveTo((Vector2)approachingPoint, stopDistance, HandleAutoApproachComplete);
+                playerMovement.MoveTo((Vector2)approachingPoint, stopDistance, HandleAutoApproachComplete);
         }
 
         /// <summary>
@@ -516,13 +535,13 @@ namespace Skills.Common
                 return;
             }
 
-            if (playerMover == null)
+            if (playerMovement == null)
             {
                 CancelAutoApproach(true);
                 return;
             }
 
-            if (playerMover.IsAutoMoving)
+            if (playerMovement.IsAutoMoving)
                 return;
 
             if (IsWithinInteractionRange(approachingNode))
@@ -538,7 +557,7 @@ namespace Skills.Common
         }
 
         /// <summary>
-        ///     Callback invoked by <see cref="PlayerMover.MoveTo(Vector2,float,System.Action)"/> once the player reaches the
+        ///     Callback invoked by <see cref="IPlayerMovementController.MoveTo(Vector2,float,System.Action)"/> once the player reaches the
         ///     desired position. Revalidates the node before attempting to start the action.
         /// </summary>
         private void HandleAutoApproachComplete()
@@ -569,8 +588,8 @@ namespace Skills.Common
             if (!isApproachingNode)
                 return;
 
-            if (stopMovement && playerMover != null)
-                playerMover.StopMovement();
+            if (stopMovement && playerMovement != null)
+                playerMovement.StopMovement();
 
             ClearAutoApproachState();
         }
@@ -588,7 +607,7 @@ namespace Skills.Common
         }
 
         /// <summary>
-        ///     Calculates the distance the <see cref="PlayerMover"/> should use when auto moving towards a node.
+        ///     Calculates the distance the <see cref="IPlayerMovementController"/> should use when auto moving towards a node.
         /// </summary>
         private float CalculateAutoApproachStopDistance(float interactionRange)
         {

--- a/Assets/Scripts/Status/Freeze/FrozenStatusController.cs
+++ b/Assets/Scripts/Status/Freeze/FrozenStatusController.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using Player.Visuals;
 
 namespace Status.Freeze
 {
@@ -14,6 +15,7 @@ namespace Status.Freeze
     {
         [SerializeField, Tooltip("Optional explicit player movement component to control when frozen.")]
         private Player.PlayerMover playerMover;
+        private IPlayerSpriteController playerSpriteController;
 
         [SerializeField, Tooltip("Optional NPC wanderer component that should pause when frozen.")]
         private NPC.NpcWanderer npcWanderer;
@@ -36,7 +38,7 @@ namespace Status.Freeze
         /// <summary>Flag indicating whether the entity is currently frozen.</summary>
         private bool frozen;
 
-        /// <summary>Caches the previous value of <see cref="Player.PlayerMover.freezeSprite"/> so it can be restored.</summary>
+        /// <summary>Caches the previous sprite freeze flag so it can be restored when the effect ends.</summary>
         private bool cachedFreezeSpriteValue;
 
         /// <summary>Provides external visibility of the frozen state for debugging.</summary>
@@ -57,6 +59,10 @@ namespace Status.Freeze
                 npcWanderer = GetComponent<NPC.NpcWanderer>();
             if (rigidBody == null)
                 rigidBody = GetComponent<Rigidbody2D>();
+            if (playerSpriteController == null && playerMover != null)
+                playerSpriteController = playerMover.SpriteController;
+            if (playerSpriteController == null)
+                playerSpriteController = GetComponent<PlayerSpriteController>();
         }
 
         private void OnEnable()
@@ -223,13 +229,17 @@ namespace Status.Freeze
             {
                 if (frozen)
                 {
-                    cachedFreezeSpriteValue = playerMover.freezeSprite;
+                    if (playerSpriteController == null)
+                        playerSpriteController = playerMover.SpriteController ?? playerMover.GetComponent<PlayerSpriteController>();
+
+                    cachedFreezeSpriteValue = playerSpriteController != null && playerSpriteController.FreezeSprite;
                     playerMover.SetMovementFrozen(true);
                 }
                 else
                 {
                     playerMover.SetMovementFrozen(false);
-                    playerMover.freezeSprite = cachedFreezeSpriteValue;
+                    if (playerSpriteController != null)
+                        playerSpriteController.FreezeSprite = cachedFreezeSpriteValue;
                 }
             }
 

--- a/Assets/Scripts/Util/SpriteDepth.cs
+++ b/Assets/Scripts/Util/SpriteDepth.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using Player;
+using Player.Movement;
 
 namespace Util
 {
@@ -11,20 +12,26 @@ namespace Util
         public int directionOffset;   // magnitude for direction-based tweak
 
         private SpriteRenderer sr;
-        private PlayerMover player;
+        private IPlayerMovementController movementController;
 
         void Awake()
         {
             sr = GetComponent<SpriteRenderer>();
-            player = FindObjectOfType<PlayerMover>();
+            movementController = FindObjectOfType<PlayerMovementController>();
+            if (movementController == null)
+            {
+                var mover = FindObjectOfType<PlayerMover>();
+                if (mover != null)
+                    movementController = mover.MovementController;
+            }
         }
 
         void LateUpdate()
         {
             int dir = 0;
-            if (player != null)
+            if (movementController != null)
             {
-                Direction8 facing = player.FacingDir;
+                Direction8 facing = movementController.FacingDirection;
                 if (Direction8Utility.IsFacingDown(facing))
                     dir = directionOffset;
                 else if (Direction8Utility.IsFacingUp(facing))


### PR DESCRIPTION
## Summary
- extract a dedicated `PlayerMovementController` to own locomotion, auto-walk, and save timing logic
- add `PlayerMovementInput` and `PlayerSpriteController` components to isolate input wiring and visual overrides
- update `PlayerMover` plus dependent combat, gathering, pet, and freeze systems to consume the new movement/sprite interfaces

## Testing
- not run (editor-only refactor)


------
https://chatgpt.com/codex/tasks/task_e_68dfa70d0a94832ea495dc07483a4946