### PR TITLE
Fix firemaking movement guard and namespace collisions

### DIFF
--- a/Assets/Scripts/Player/PlayerCombatLoadout.cs
+++ b/Assets/Scripts/Player/PlayerCombatLoadout.cs
@@ -57,7 +57,7 @@ namespace Player
 
         private void Update()
         {
-            if (Input.GetKeyDown(KeyCode.F))
+            if (UnityEngine.Input.GetKeyDown(KeyCode.F))
                 CycleStyle();
         }
 

--- a/Assets/Scripts/Player/PlayerHitpoints.cs
+++ b/Assets/Scripts/Player/PlayerHitpoints.cs
@@ -202,9 +202,9 @@ namespace Player
 
         private void Update()
         {
-            if (Input.GetKeyDown(KeyCode.J))
+            if (UnityEngine.Input.GetKeyDown(KeyCode.J))
                 ApplyDamage(1);
-            if (Input.GetKeyDown(KeyCode.H))
+            if (UnityEngine.Input.GetKeyDown(KeyCode.H))
                 Heal(1);
         }
 #endif

--- a/Assets/Scripts/Player/PlayerMover.cs
+++ b/Assets/Scripts/Player/PlayerMover.cs
@@ -112,6 +112,9 @@ namespace Player
         /// <summary>True while the movement controller is executing an auto-move routine.</summary>
         public bool IsAutoMoving => movementController != null && movementController.IsAutoMoving;
 
+        /// <summary>True while the movement controller reports active displacement from player input or auto-walk.</summary>
+        public bool IsMoving => movementController != null && movementController.IsMoving;
+
         /// <summary>True while movement input is frozen by external systems.</summary>
         public bool IsMovementFrozen => movementController != null && movementController.IsMovementFrozen;
 


### PR DESCRIPTION
## Summary
- qualify debug-only keybind checks in PlayerHitpoints and PlayerCombatLoadout so they resolve UnityEngine.Input inside the Player namespace
- surface PlayerMover.IsMoving as a passthrough to the movement controller for systems like Firemaking that monitor locomotion

## Testing
- not run (Unity editor unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfb64623d4832ebf8873ad8f12105e