### PR TITLE
Add frame-based directional overrides to player sprite controller

### DIFF
--- a/Assets/Scripts/Player/Visuals/PlayerSpriteController.cs
+++ b/Assets/Scripts/Player/Visuals/PlayerSpriteController.cs
@@ -1,5 +1,7 @@
 // Assets/Scripts/Player/Visuals/PlayerSpriteController.cs
+using System;
 using UnityEngine;
+using UnityEngine.Serialization;
 using Util;
 
 namespace Player.Visuals
@@ -14,24 +16,21 @@ namespace Player.Visuals
     public class PlayerSpriteController : MonoBehaviour, IPlayerSpriteController
     {
         [Header("(Optional) Direct Sprite Override")]
-        [Tooltip("If assigned, these sprites will be applied directly each frame based on Dir/IsMoving. Leave null to rely on Animator clips.")]
-        [SerializeField] private Sprite idleDown;
-        [SerializeField] private Sprite idleDownRight;
-        [SerializeField] private Sprite idleRight;
-        [SerializeField] private Sprite idleUpRight;
-        [SerializeField] private Sprite idleUp;
-        [SerializeField] private Sprite idleUpLeft;
-        [SerializeField] private Sprite idleLeft;
-        [SerializeField] private Sprite idleDownLeft;
+        [Tooltip("Directional overrides can include either legacy single sprites or multi-frame lists for idle/walk states.")]
+        [SerializeField] private DirectionalSpriteOverride downOverrides;
+        [SerializeField] private DirectionalSpriteOverride downRightOverrides;
+        [SerializeField] private DirectionalSpriteOverride rightOverrides;
+        [SerializeField] private DirectionalSpriteOverride upRightOverrides;
+        [SerializeField] private DirectionalSpriteOverride upOverrides;
+        [SerializeField] private DirectionalSpriteOverride upLeftOverrides;
+        [SerializeField] private DirectionalSpriteOverride leftOverrides;
+        [SerializeField] private DirectionalSpriteOverride downLeftOverrides;
 
-        [SerializeField] private Sprite walkDown;
-        [SerializeField] private Sprite walkDownRight;
-        [SerializeField] private Sprite walkRight;
-        [SerializeField] private Sprite walkUpRight;
-        [SerializeField] private Sprite walkUp;
-        [SerializeField] private Sprite walkUpLeft;
-        [SerializeField] private Sprite walkLeft;
-        [SerializeField] private Sprite walkDownLeft;
+        [Header("Sprite Animation Settings")]
+        [SerializeField, Min(0.1f), Tooltip("Frames-per-second used when resolving idle frame lists.")]
+        private float idleAnimationFps = 6f;
+        [SerializeField, Min(0.1f), Tooltip("Frames-per-second used when resolving walking frame lists.")]
+        private float walkAnimationFps = 10f;
 
         [Header("Mirroring")]
         [Tooltip("If true, reuse right-facing sprites for any left-facing orientation (including diagonals).")]
@@ -52,6 +51,13 @@ namespace Player.Visuals
 
         private Animator animator;
         private SpriteRenderer spriteRenderer;
+
+        private Direction8 cachedLookupDirection;
+        private bool cachedIsMoving;
+        private MovementVisualState cachedResolvedState;
+        private Sprite[] cachedResolvedFrames;
+        private int cachedFrameIndex;
+        private float nextFrameTime;
 
         /// <inheritdoc />
         public bool FreezeSprite
@@ -95,33 +101,47 @@ namespace Player.Visuals
             if (freezeSprite)
                 return;
 
-            if (!TryResolveOverrideSprite(direction, isMoving, out Sprite desired, out bool flip))
+            if (!TryResolveVisualState(direction, isMoving, out Sprite[] frames, out Sprite desired, out MovementVisualState resolvedState, out Direction8 lookupDirection, out bool flip))
                 return;
 
             if (spriteRenderer.flipX != flip)
                 spriteRenderer.flipX = flip;
 
-            if (spriteRenderer.sprite != desired)
-                spriteRenderer.sprite = desired;
-        }
-
-        /// <summary>
-        ///     Attempts to resolve an override sprite for the supplied facing direction, including mirroring fallbacks.
-        /// </summary>
-        private bool TryResolveOverrideSprite(Direction8 direction, bool moving, out Sprite sprite, out bool flip)
-        {
-            foreach (var lookup in Direction8Utility.BuildSpriteFallbackOrder(direction, ShouldMirrorOverride))
+            if (frames != null && frames.Length > 0)
             {
-                if (TryGetSpriteForDirection(lookup.Direction, moving, out sprite))
-                {
-                    flip = lookup.FlipX;
-                    return true;
-                }
-            }
+                var shouldReset = cachedResolvedFrames != frames || cachedLookupDirection != lookupDirection || cachedIsMoving != isMoving || cachedResolvedState != resolvedState;
 
-            sprite = null;
-            flip = false;
-            return false;
+                if (shouldReset)
+                {
+                    cachedResolvedFrames = frames;
+                    cachedLookupDirection = lookupDirection;
+                    cachedIsMoving = isMoving;
+                    cachedResolvedState = resolvedState;
+                    cachedFrameIndex = 0;
+                    nextFrameTime = Time.time + GetFrameInterval(resolvedState);
+                }
+                else if (frames.Length > 1 && Time.time >= nextFrameTime)
+                {
+                    cachedFrameIndex = (cachedFrameIndex + 1) % frames.Length;
+                    nextFrameTime = Time.time + GetFrameInterval(cachedResolvedState);
+                }
+
+                var frameSprite = frames[Mathf.Clamp(cachedFrameIndex, 0, frames.Length - 1)];
+                if (spriteRenderer.sprite != frameSprite)
+                    spriteRenderer.sprite = frameSprite;
+            }
+            else if (desired != null)
+            {
+                cachedResolvedFrames = null;
+                cachedLookupDirection = lookupDirection;
+                cachedIsMoving = isMoving;
+                cachedResolvedState = resolvedState;
+                cachedFrameIndex = 0;
+                nextFrameTime = 0f;
+
+                if (spriteRenderer.sprite != desired)
+                    spriteRenderer.sprite = desired;
+            }
         }
 
         /// <summary>Determines whether the supplied direction should mirror its counterpart when resolving overrides.</summary>
@@ -139,183 +159,305 @@ namespace Player.Visuals
             };
         }
 
-        /// <summary>
-        ///     Retrieves the idle and walking sprites for a given direction, preferring the matching state but falling back when required.
-        /// </summary>
-        private bool TryGetSpriteForDirection(Direction8 direction, bool moving, out Sprite sprite)
-        {
-            GetOverrideSprites(direction, out Sprite idleSprite, out Sprite walkSprite);
-            if (moving)
-            {
-                if (walkSprite != null)
-                {
-                    sprite = walkSprite;
-                    return true;
-                }
-
-                if (idleSprite != null)
-                {
-                    sprite = idleSprite;
-                    return true;
-                }
-            }
-            else
-            {
-                if (idleSprite != null)
-                {
-                    sprite = idleSprite;
-                    return true;
-                }
-
-                if (walkSprite != null)
-                {
-                    sprite = walkSprite;
-                    return true;
-                }
-            }
-
-            sprite = null;
-            return false;
-        }
-
-        /// <summary>Populates the idle and walk sprite references for a supplied direction.</summary>
-        private void GetOverrideSprites(Direction8 direction, out Sprite idleSprite, out Sprite walkSprite)
-        {
-            idleSprite = null;
-            walkSprite = null;
-
-            switch (direction)
-            {
-                case Direction8.Down:
-                    idleSprite = idleDown;
-                    walkSprite = walkDown;
-                    break;
-                case Direction8.DownRight:
-                    idleSprite = idleDownRight;
-                    walkSprite = walkDownRight;
-                    break;
-                case Direction8.Right:
-                    idleSprite = idleRight;
-                    walkSprite = walkRight;
-                    break;
-                case Direction8.UpRight:
-                    idleSprite = idleUpRight;
-                    walkSprite = walkUpRight;
-                    break;
-                case Direction8.Up:
-                    idleSprite = idleUp;
-                    walkSprite = walkUp;
-                    break;
-                case Direction8.UpLeft:
-                    idleSprite = idleUpLeft;
-                    walkSprite = walkUpLeft;
-                    break;
-                case Direction8.Left:
-                    idleSprite = idleLeft;
-                    walkSprite = walkLeft;
-                    break;
-                case Direction8.DownLeft:
-                    idleSprite = idleDownLeft;
-                    walkSprite = walkDownLeft;
-                    break;
-            }
-        }
-
         /// <summary>Retrieves the idle override sprite for the supplied facing direction.</summary>
         public Sprite GetIdleSprite(Direction8 direction)
         {
-            return direction switch
-            {
-                Direction8.Down => idleDown,
-                Direction8.DownRight => idleDownRight,
-                Direction8.Right => idleRight,
-                Direction8.UpRight => idleUpRight,
-                Direction8.Up => idleUp,
-                Direction8.UpLeft => idleUpLeft,
-                Direction8.Left => idleLeft,
-                Direction8.DownLeft => idleDownLeft,
-                _ => null
-            };
+            return GetOverride(direction).SingleIdle;
         }
 
         /// <summary>Assigns the idle override sprite for the supplied facing direction.</summary>
         public void SetIdleSprite(Direction8 direction, Sprite sprite)
         {
-            switch (direction)
-            {
-                case Direction8.Down:
-                    idleDown = sprite;
-                    break;
-                case Direction8.DownRight:
-                    idleDownRight = sprite;
-                    break;
-                case Direction8.Right:
-                    idleRight = sprite;
-                    break;
-                case Direction8.UpRight:
-                    idleUpRight = sprite;
-                    break;
-                case Direction8.Up:
-                    idleUp = sprite;
-                    break;
-                case Direction8.UpLeft:
-                    idleUpLeft = sprite;
-                    break;
-                case Direction8.Left:
-                    idleLeft = sprite;
-                    break;
-                case Direction8.DownLeft:
-                    idleDownLeft = sprite;
-                    break;
-            }
+            ref var overrides = ref GetOverrideRef(direction);
+            overrides.SingleIdle = sprite;
         }
 
         /// <summary>Retrieves the walking override sprite for the supplied facing direction.</summary>
         public Sprite GetWalkSprite(Direction8 direction)
         {
-            return direction switch
-            {
-                Direction8.Down => walkDown,
-                Direction8.DownRight => walkDownRight,
-                Direction8.Right => walkRight,
-                Direction8.UpRight => walkUpRight,
-                Direction8.Up => walkUp,
-                Direction8.UpLeft => walkUpLeft,
-                Direction8.Left => walkLeft,
-                Direction8.DownLeft => walkDownLeft,
-                _ => null
-            };
+            return GetOverride(direction).SingleWalk;
         }
 
         /// <summary>Assigns the walking override sprite for the supplied facing direction.</summary>
         public void SetWalkSprite(Direction8 direction, Sprite sprite)
         {
+            ref var overrides = ref GetOverrideRef(direction);
+            overrides.SingleWalk = sprite;
+        }
+
+        /// <inheritdoc />
+        public float IdleAnimationFps => idleAnimationFps;
+
+        /// <inheritdoc />
+        public float WalkAnimationFps => walkAnimationFps;
+
+        /// <inheritdoc />
+        public int GetFrameCount(Direction8 direction, bool moving)
+        {
+            var overrides = GetOverride(direction);
+            var frames = moving ? overrides.WalkFrames : overrides.IdleFrames;
+            if (frames != null && frames.Length > 0)
+                return frames.Length;
+
+            frames = moving ? overrides.IdleFrames : overrides.WalkFrames;
+            if (frames != null && frames.Length > 0)
+                return frames.Length;
+
+            var sprite = moving ? overrides.SingleWalk : overrides.SingleIdle;
+            if (sprite != null)
+                return 1;
+
+            sprite = moving ? overrides.SingleIdle : overrides.SingleWalk;
+            return sprite != null ? 1 : 0;
+        }
+
+        private void OnValidate()
+        {
+            idleAnimationFps = Mathf.Max(0.1f, idleAnimationFps);
+            walkAnimationFps = Mathf.Max(0.1f, walkAnimationFps);
+
+            SeedLegacyFrames(ref downOverrides);
+            SeedLegacyFrames(ref downRightOverrides);
+            SeedLegacyFrames(ref rightOverrides);
+            SeedLegacyFrames(ref upRightOverrides);
+            SeedLegacyFrames(ref upOverrides);
+            SeedLegacyFrames(ref upLeftOverrides);
+            SeedLegacyFrames(ref leftOverrides);
+            SeedLegacyFrames(ref downLeftOverrides);
+        }
+
+        private void SeedLegacyFrames(ref DirectionalSpriteOverride overrides)
+        {
+            overrides.SeedFrameArraysFromLegacySingles();
+        }
+
+        private float GetFrameInterval(MovementVisualState state)
+        {
+            var fps = state == MovementVisualState.Walk ? walkAnimationFps : idleAnimationFps;
+            return fps <= 0f ? float.MaxValue : 1f / fps;
+        }
+
+        private bool TryResolveVisualState(Direction8 direction, bool moving, out Sprite[] frames, out Sprite sprite, out MovementVisualState resolvedState, out Direction8 lookupDirection, out bool flip)
+        {
+            foreach (var lookup in Direction8Utility.BuildSpriteFallbackOrder(direction, ShouldMirrorOverride))
+            {
+                var overrides = GetOverride(lookup.Direction);
+
+                if (moving)
+                {
+                    if (overrides.TryGetFrames(MovementVisualState.Walk, out frames))
+                    {
+                        sprite = null;
+                        resolvedState = MovementVisualState.Walk;
+                        lookupDirection = lookup.Direction;
+                        flip = lookup.FlipX;
+                        return true;
+                    }
+
+                    if (overrides.TryGetFrames(MovementVisualState.Idle, out frames))
+                    {
+                        sprite = null;
+                        resolvedState = MovementVisualState.Idle;
+                        lookupDirection = lookup.Direction;
+                        flip = lookup.FlipX;
+                        return true;
+                    }
+
+                    if (overrides.TryGetSingle(MovementVisualState.Walk, out sprite))
+                    {
+                        frames = null;
+                        resolvedState = MovementVisualState.Walk;
+                        lookupDirection = lookup.Direction;
+                        flip = lookup.FlipX;
+                        return true;
+                    }
+
+                    if (overrides.TryGetSingle(MovementVisualState.Idle, out sprite))
+                    {
+                        frames = null;
+                        resolvedState = MovementVisualState.Idle;
+                        lookupDirection = lookup.Direction;
+                        flip = lookup.FlipX;
+                        return true;
+                    }
+                }
+                else
+                {
+                    if (overrides.TryGetFrames(MovementVisualState.Idle, out frames))
+                    {
+                        sprite = null;
+                        resolvedState = MovementVisualState.Idle;
+                        lookupDirection = lookup.Direction;
+                        flip = lookup.FlipX;
+                        return true;
+                    }
+
+                    if (overrides.TryGetFrames(MovementVisualState.Walk, out frames))
+                    {
+                        sprite = null;
+                        resolvedState = MovementVisualState.Walk;
+                        lookupDirection = lookup.Direction;
+                        flip = lookup.FlipX;
+                        return true;
+                    }
+
+                    if (overrides.TryGetSingle(MovementVisualState.Idle, out sprite))
+                    {
+                        frames = null;
+                        resolvedState = MovementVisualState.Idle;
+                        lookupDirection = lookup.Direction;
+                        flip = lookup.FlipX;
+                        return true;
+                    }
+
+                    if (overrides.TryGetSingle(MovementVisualState.Walk, out sprite))
+                    {
+                        frames = null;
+                        resolvedState = MovementVisualState.Walk;
+                        lookupDirection = lookup.Direction;
+                        flip = lookup.FlipX;
+                        return true;
+                    }
+                }
+            }
+
+            frames = null;
+            sprite = null;
+            resolvedState = moving ? MovementVisualState.Walk : MovementVisualState.Idle;
+            lookupDirection = direction;
+            flip = false;
+            return false;
+        }
+
+        private DirectionalSpriteOverride GetOverride(Direction8 direction)
+        {
+            return direction switch
+            {
+                Direction8.Down => downOverrides,
+                Direction8.DownRight => downRightOverrides,
+                Direction8.Right => rightOverrides,
+                Direction8.UpRight => upRightOverrides,
+                Direction8.Up => upOverrides,
+                Direction8.UpLeft => upLeftOverrides,
+                Direction8.Left => leftOverrides,
+                Direction8.DownLeft => downLeftOverrides,
+                _ => throw new ArgumentOutOfRangeException(nameof(direction), direction, null)
+            };
+        }
+
+        private ref DirectionalSpriteOverride GetOverrideRef(Direction8 direction)
+        {
             switch (direction)
             {
                 case Direction8.Down:
-                    walkDown = sprite;
-                    break;
+                    return ref downOverrides;
                 case Direction8.DownRight:
-                    walkDownRight = sprite;
-                    break;
+                    return ref downRightOverrides;
                 case Direction8.Right:
-                    walkRight = sprite;
-                    break;
+                    return ref rightOverrides;
                 case Direction8.UpRight:
-                    walkUpRight = sprite;
-                    break;
+                    return ref upRightOverrides;
                 case Direction8.Up:
-                    walkUp = sprite;
-                    break;
+                    return ref upOverrides;
                 case Direction8.UpLeft:
-                    walkUpLeft = sprite;
-                    break;
+                    return ref upLeftOverrides;
                 case Direction8.Left:
-                    walkLeft = sprite;
-                    break;
+                    return ref leftOverrides;
                 case Direction8.DownLeft:
-                    walkDownLeft = sprite;
-                    break;
+                    return ref downLeftOverrides;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(direction), direction, null);
+            }
+        }
+
+        private enum MovementVisualState
+        {
+            Idle,
+            Walk
+        }
+
+        [System.Serializable]
+        private struct DirectionalSpriteOverride
+        {
+            [FormerlySerializedAs("idleDown"), FormerlySerializedAs("idleDownRight"), FormerlySerializedAs("idleRight"), FormerlySerializedAs("idleUpRight"), FormerlySerializedAs("idleUp"), FormerlySerializedAs("idleUpLeft"), FormerlySerializedAs("idleLeft"), FormerlySerializedAs("idleDownLeft")]
+            [SerializeField]
+            private Sprite singleIdle;
+
+            [FormerlySerializedAs("walkDown"), FormerlySerializedAs("walkDownRight"), FormerlySerializedAs("walkRight"), FormerlySerializedAs("walkUpRight"), FormerlySerializedAs("walkUp"), FormerlySerializedAs("walkUpLeft"), FormerlySerializedAs("walkLeft"), FormerlySerializedAs("walkDownLeft")]
+            [SerializeField]
+            private Sprite singleWalk;
+
+            [SerializeField]
+            private Sprite[] idleFrames;
+
+            [SerializeField]
+            private Sprite[] walkFrames;
+
+            public Sprite SingleIdle
+            {
+                readonly get => singleIdle;
+                set
+                {
+                    singleIdle = value;
+
+                    if (idleFrames == null || idleFrames.Length == 0)
+                    {
+                        if (value != null)
+                            idleFrames = new[] { value };
+                    }
+                    else if (idleFrames.Length == 1)
+                    {
+                        idleFrames[0] = value;
+                    }
+                }
+            }
+
+            public Sprite SingleWalk
+            {
+                readonly get => singleWalk;
+                set
+                {
+                    singleWalk = value;
+
+                    if (walkFrames == null || walkFrames.Length == 0)
+                    {
+                        if (value != null)
+                            walkFrames = new[] { value };
+                    }
+                    else if (walkFrames.Length == 1)
+                    {
+                        walkFrames[0] = value;
+                    }
+                }
+            }
+
+            public Sprite[] IdleFrames => idleFrames;
+
+            public Sprite[] WalkFrames => walkFrames;
+
+            public void SeedFrameArraysFromLegacySingles()
+            {
+                if ((idleFrames == null || idleFrames.Length == 0) && singleIdle != null)
+                    idleFrames = new[] { singleIdle };
+
+                if ((walkFrames == null || walkFrames.Length == 0) && singleWalk != null)
+                    walkFrames = new[] { singleWalk };
+            }
+
+            public bool TryGetFrames(MovementVisualState state, out Sprite[] frames)
+            {
+                frames = state == MovementVisualState.Walk ? walkFrames : idleFrames;
+                if (frames != null && frames.Length > 0)
+                    return true;
+
+                frames = null;
+                return false;
+            }
+
+            public bool TryGetSingle(MovementVisualState state, out Sprite sprite)
+            {
+                sprite = state == MovementVisualState.Walk ? singleWalk : singleIdle;
+                return sprite != null;
             }
         }
     }
@@ -336,5 +478,14 @@ namespace Player.Visuals
 
         /// <summary>Applies the supplied movement visuals to the animator and sprite renderer.</summary>
         void ApplyMovementVisuals(Direction8 direction, bool isMoving);
+
+        /// <summary>Gets the configured frames-per-second for idle animations.</summary>
+        float IdleAnimationFps { get; }
+
+        /// <summary>Gets the configured frames-per-second for walking animations.</summary>
+        float WalkAnimationFps { get; }
+
+        /// <summary>Retrieves the configured frame count for the supplied direction/state, ignoring fallback logic.</summary>
+        int GetFrameCount(Direction8 direction, bool isMoving);
     }
 }


### PR DESCRIPTION
## Summary
- replace legacy per-direction sprite fields with a serializable override struct that now supports idle and walk frame arrays and exposes configurable FPS
- cache movement animation state and drive frame selection/advancement while respecting mirroring and single-sprite fallbacks
- seed legacy data into frame arrays on validation and extend the player sprite controller interface for querying FPS and frame counts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfcc4cb378832ebbff55e909158ab0