### PR TITLE
Include cooking in tick progress tracker refactor

### DIFF
--- a/Assets/Scripts/Skills/Common/TickProgressTracker.cs
+++ b/Assets/Scripts/Skills/Common/TickProgressTracker.cs
@@ -1,0 +1,106 @@
+using System;
+using UnityEngine;
+
+namespace Skills.Common
+{
+    /// <summary>
+    ///     Utility that tracks progress for tick-based actions and exposes
+    ///     events so skills can react uniformly when an action advances or
+    ///     completes.
+    /// </summary>
+    [Serializable]
+    public sealed class TickProgressTracker
+    {
+        private int requiredTicks;
+        private int progressTicks;
+
+        /// <summary>
+        ///     Raised whenever <see cref="Reset"/> is called so listeners can
+        ///     respond to requirement changes (e.g., HUD progress bars).
+        /// </summary>
+        public event Action<int> ProgressReset;
+
+        /// <summary>
+        ///     Raised after <see cref="Advance"/> increments the tracker. The
+        ///     callback receives the current tick progress and the required
+        ///     tick count for the active action.
+        /// </summary>
+        public event Action<int, int> TickAdvanced;
+
+        /// <summary>
+        ///     Raised when <see cref="Advance"/> reaches the required tick
+        ///     count. Listeners can use this to emit debug traces or trigger
+        ///     side effects without re-implementing completion checks.
+        /// </summary>
+        public event Action<int, int> TickCompleted;
+
+        /// <summary>
+        ///     Gets the number of ticks required to complete the current
+        ///     action.
+        /// </summary>
+        public int RequiredTicks => requiredTicks;
+
+        /// <summary>
+        ///     Gets how many ticks have elapsed for the current action.
+        /// </summary>
+        public int ProgressTicks => progressTicks;
+
+        /// <summary>
+        ///     Provides a 0..1 representation of progress for UI bindings using
+        ///     the configured tick requirement as the denominator.
+        /// </summary>
+        public float ProgressRatio
+        {
+            get
+            {
+                if (requiredTicks <= 0)
+                    return 0f;
+
+                return Mathf.Clamp01((float)progressTicks / requiredTicks);
+            }
+        }
+
+        /// <summary>
+        ///     Resets the tracker to start a new action with the supplied tick
+        ///     requirement.
+        /// </summary>
+        /// <param name="newRequiredTicks">Number of ticks needed to complete the action.</param>
+        public void Reset(int newRequiredTicks)
+        {
+            requiredTicks = Mathf.Max(0, newRequiredTicks);
+            progressTicks = 0;
+            ProgressReset?.Invoke(requiredTicks);
+        }
+
+        /// <summary>
+        ///     Advances the tracker by a single tick.
+        /// </summary>
+        /// <returns><c>true</c> when the action has reached completion.</returns>
+        public bool Advance()
+        {
+            if (requiredTicks <= 0)
+                return true;
+
+            progressTicks = Mathf.Min(progressTicks + 1, requiredTicks);
+            TickAdvanced?.Invoke(progressTicks, requiredTicks);
+
+            if (progressTicks >= requiredTicks)
+            {
+                TickCompleted?.Invoke(progressTicks, requiredTicks);
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        ///     Clears any accumulated progress without modifying the required
+        ///     tick count. Useful when cancelling actions mid-channel.
+        /// </summary>
+        public void ClearProgress()
+        {
+            progressTicks = 0;
+        }
+    }
+}
+

--- a/Assets/Scripts/Skills/Common/TickProgressTracker.cs.meta
+++ b/Assets/Scripts/Skills/Common/TickProgressTracker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4d5cb128be284644af18f044a2cbc2b6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
+++ b/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
@@ -27,7 +27,7 @@ namespace Skills.Cooking
         private SkillManager skills;
         private CookableRecipe currentRecipe;
         private int itemsRemaining;
-        private int cookProgress;
+        private readonly TickProgressTracker cookProgressTracker = new TickProgressTracker();
         private const int CookIntervalTicks = 5;
         private SkillingOutfitProgress cookingOutfit;
 
@@ -40,7 +40,17 @@ namespace Skills.Cooking
         public float Xp => skills != null ? skills.GetXp(SkillType.Cooking) : 0f;
         public CookingObject ActiveCookingObject { get; private set; }
         public bool IsCooking => currentRecipe != null && itemsRemaining > 0 && ActiveCookingObject != null;
-        public float CookProgressNormalized => CookIntervalTicks <= 1 ? 0f : (float)cookProgress / (CookIntervalTicks - 1);
+        public float CookProgressNormalized
+        {
+            get
+            {
+                int required = cookProgressTracker.RequiredTicks;
+                if (required <= 1)
+                    return 0f;
+
+                return Mathf.Clamp01((float)cookProgressTracker.ProgressTicks / (required - 1));
+            }
+        }
 
         /// <summary>
         ///     Number of OSRS-style ticks required to cook a single item.
@@ -63,6 +73,7 @@ namespace Skills.Cooking
             if (equipment == null)
                 equipment = GetComponent<Equipment>();
             skills = GetComponent<SkillManager>();
+            cookProgressTracker.TickAdvanced += HandleCookProgressAdvanced;
             cookingOutfit = new SkillingOutfitProgress(new[]
             {
                 "Chefs Hat",
@@ -76,6 +87,7 @@ namespace Skills.Cooking
         private void OnDestroy()
         {
             SaveManager.Unregister(cookingOutfit);
+            cookProgressTracker.TickAdvanced -= HandleCookProgressAdvanced;
         }
 
         /// <summary>
@@ -138,7 +150,7 @@ namespace Skills.Cooking
             ActiveCookingObject = station;
             currentRecipe = recipe;
             itemsRemaining = quantity;
-            cookProgress = 0;
+            cookProgressTracker.Reset(CookIntervalTicks);
             LogDebug($"Started cooking {recipe.cookedItemId} x{quantity}");
             OnStartCooking?.Invoke(recipe);
             return true;
@@ -153,7 +165,7 @@ namespace Skills.Cooking
 
             currentRecipe = null;
             itemsRemaining = 0;
-            cookProgress = 0;
+            cookProgressTracker.Reset(0);
             ActiveCookingObject = null;
 
             if (!hadActiveSession)
@@ -169,12 +181,12 @@ namespace Skills.Cooking
         {
             if (!IsCooking)
                 return;
-            cookProgress++;
-            LogDebug($"Cooking tick: {cookProgress}/{CookIntervalTicks}");
-            if (cookProgress >= CookIntervalTicks)
+
+            if (cookProgressTracker.Advance())
             {
-                cookProgress = 0;
                 AttemptCook();
+                if (IsCooking)
+                    cookProgressTracker.Reset(CookIntervalTicks);
             }
         }
 
@@ -302,6 +314,14 @@ namespace Skills.Cooking
                 return;
 
             Debug.Log($"[CookingSkill] {message}");
+        }
+
+        private void HandleCookProgressAdvanced(int progress, int required)
+        {
+            if (!IsCooking)
+                return;
+
+            LogDebug($"Cooking tick: {progress}/{required}");
         }
     }
 }

--- a/Assets/Scripts/Skills/Firemaking/Core/FiremakingSkill.cs
+++ b/Assets/Scripts/Skills/Firemaking/Core/FiremakingSkill.cs
@@ -53,7 +53,8 @@ namespace Skills.Firemaking
         private BonfireSession bonfireSession;
         private readonly List<FiremakingFire> activeFires = new();
         private SkillingOutfitProgress firemakingOutfit;
-        private int attemptTicksElapsed;
+        private readonly TickProgressTracker ignitionProgressTracker = new TickProgressTracker();
+        private readonly TickProgressTracker bonfireProgressTracker = new TickProgressTracker();
 
         private struct FiremakingAttempt
         {
@@ -70,7 +71,6 @@ namespace Skills.Firemaking
             public FiremakingBonfireObject bonfire;
             public FiremakingLogDefinition definition;
             public int ticksRequired;
-            public int ticksElapsed;
             public float cancelDistance;
         }
 
@@ -96,9 +96,14 @@ namespace Skills.Firemaking
         {
             get
             {
-                if (!IsLighting || currentAttempt.ticksRequired <= 0)
+                if (!IsLighting)
                     return 0f;
-                return Mathf.Clamp01((float)attemptTicksElapsed / currentAttempt.ticksRequired);
+
+                int required = currentAttempt.ticksRequired > 0 ? currentAttempt.ticksRequired : 0;
+                if (required <= 0)
+                    return 0f;
+
+                return Mathf.Clamp01((float)ignitionProgressTracker.ProgressTicks / required);
             }
         }
 
@@ -112,11 +117,13 @@ namespace Skills.Firemaking
                 if (!IsFeedingBonfire)
                     return 0f;
 
-                int required = bonfireSession.ticksRequired > 0 ? bonfireSession.ticksRequired : BonfireTicksPerLog;
+                int required = bonfireProgressTracker.RequiredTicks > 0
+                    ? bonfireProgressTracker.RequiredTicks
+                    : Mathf.Max(1, BonfireTicksPerLog);
                 if (required <= 0)
                     return 0f;
 
-                return Mathf.Clamp01((float)bonfireSession.ticksElapsed / required);
+                return Mathf.Clamp01((float)bonfireProgressTracker.ProgressTicks / required);
             }
         }
 
@@ -124,7 +131,7 @@ namespace Skills.Firemaking
         ///     Number of ticks required to add a single log to the bonfire that is currently being fueled.
         /// </summary>
         public int BonfireFeedingTicksRequired =>
-            Mathf.Max(1, bonfireSession.ticksRequired > 0 ? bonfireSession.ticksRequired : BonfireTicksPerLog);
+            Mathf.Max(1, bonfireProgressTracker.RequiredTicks > 0 ? bonfireProgressTracker.RequiredTicks : BonfireTicksPerLog);
 
         /// <summary>
         ///     World position where the current ignition attempt is centred.
@@ -220,6 +227,9 @@ namespace Skills.Firemaking
             skills = GetComponent<SkillManager>();
             logLookup = new Dictionary<string, FiremakingLogDefinition>(StringComparer.Ordinal);
             itemCache = null;
+
+            ignitionProgressTracker.TickAdvanced += HandleIgnitionProgressAdvanced;
+            bonfireProgressTracker.TickAdvanced += HandleBonfireProgressAdvanced;
 
             LoadLogDefinitions();
 
@@ -413,7 +423,7 @@ namespace Skills.Firemaking
                 ticksRequired = Mathf.Max(1, definition.GetIgnitionTicks(level)),
                 feedingExistingFire = feedingExisting
             };
-            attemptTicksElapsed = 0;
+            ignitionProgressTracker.Reset(currentAttempt.ticksRequired);
 
             IgnitionStarted?.Invoke(definition, snappedPosition);
             LogDebug($"Started lighting {definition.displayName} at {snappedPosition} (feeding existing: {feedingExisting}).");
@@ -542,9 +552,10 @@ namespace Skills.Firemaking
                 bonfire = bonfire,
                 definition = definition,
                 ticksRequired = Mathf.Max(1, BonfireTicksPerLog),
-                ticksElapsed = 0,
                 cancelDistance = cancelDistance
             };
+
+            bonfireProgressTracker.Reset(bonfireSession.ticksRequired);
 
             LogDebug($"Started feeding {definition.displayName} into bonfire '{bonfire.name}'.");
             BonfireFeedingStarted?.Invoke(bonfire, definition);
@@ -613,13 +624,11 @@ namespace Skills.Firemaking
                 return;
             }
 
-            attemptTicksElapsed++;
-            LogDebug($"Firemaking tick {attemptTicksElapsed}/{currentAttempt.ticksRequired}.");
-
-            if (attemptTicksElapsed < currentAttempt.ticksRequired)
+            if (!ignitionProgressTracker.Advance())
                 return;
 
-            attemptTicksElapsed = 0;
+            ignitionProgressTracker.Reset(currentAttempt.ticksRequired);
+
             int level = skills != null ? skills.GetLevel(SkillType.Firemaking) : 1;
             float chance = definition.GetSuccessChance(level, currentAttempt.feedingExistingFire);
             bool success = Random.value <= chance;
@@ -797,18 +806,16 @@ namespace Skills.Firemaking
             }
 
             if (session.ticksRequired <= 0)
+            {
                 session.ticksRequired = Mathf.Max(1, BonfireTicksPerLog);
+                bonfireSession = session;
+                bonfireProgressTracker.Reset(session.ticksRequired);
+            }
 
-            session.ticksElapsed++;
-            LogDebug($"Bonfire tick {session.ticksElapsed}/{session.ticksRequired} for {session.definition.displayName}.");
-
-            bonfireSession = session;
-
-            if (session.ticksElapsed < session.ticksRequired)
+            if (!bonfireProgressTracker.Advance())
                 return;
 
-            session.ticksElapsed = 0;
-            bonfireSession = session;
+            bonfireProgressTracker.Reset(session.ticksRequired);
 
             if (!inventory.RemoveItem(session.definition.logItemId))
             {
@@ -889,6 +896,7 @@ namespace Skills.Firemaking
                 anchorPosition = session.bonfire.transform.position;
 
             bonfireSession = default;
+            bonfireProgressTracker.Reset(0);
 
             if (showMessage && !string.IsNullOrEmpty(message))
                 ShowFeedback(message, anchorPosition);
@@ -1081,7 +1089,7 @@ namespace Skills.Firemaking
         private void FinishAttempt()
         {
             currentAttempt = default;
-            attemptTicksElapsed = 0;
+            ignitionProgressTracker.Reset(0);
             IgnitionStopped?.Invoke();
         }
 
@@ -1151,6 +1159,23 @@ namespace Skills.Firemaking
             }
 
             return groundItemSpawner;
+        }
+
+        private void HandleIgnitionProgressAdvanced(int progress, int required)
+        {
+            if (!IsLighting)
+                return;
+
+            LogDebug($"Firemaking tick {progress}/{required}.");
+        }
+
+        private void HandleBonfireProgressAdvanced(int progress, int required)
+        {
+            if (!IsFeedingBonfire)
+                return;
+
+            string logName = bonfireSession.definition != null ? bonfireSession.definition.displayName : "Unknown";
+            LogDebug($"Bonfire tick {progress}/{required} for {logName}.");
         }
 
         /// <summary>

--- a/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
@@ -30,8 +30,7 @@ namespace Skills.Fishing
 
         private FishableSpot currentSpot;
         private FishingToolDefinition currentTool;
-        private int catchProgress;
-        private int currentIntervalTicks;
+        private readonly TickProgressTracker catchProgressTracker = new TickProgressTracker();
         private int bycatchRollIndex;
         private int consecutiveFails;
 
@@ -48,8 +47,18 @@ namespace Skills.Fishing
         public bool IsFishing => currentSpot != null;
         public FishableSpot CurrentSpot => currentSpot;
         public FishingToolDefinition CurrentTool => currentTool;
-        public float CatchProgressNormalized => currentIntervalTicks <= 1 ? 0f : (float)catchProgress / (currentIntervalTicks - 1);
-        public int CurrentCatchIntervalTicks => currentIntervalTicks;
+        public float CatchProgressNormalized
+        {
+            get
+            {
+                int required = catchProgressTracker.RequiredTicks;
+                if (required <= 1)
+                    return 0f;
+
+                return Mathf.Clamp01((float)catchProgressTracker.ProgressTicks / (required - 1));
+            }
+        }
+        public int CurrentCatchIntervalTicks => catchProgressTracker.RequiredTicks;
 
         /// <summary>
         ///     Gets or sets the runtime flag controlling verbose debug logging for this skill.
@@ -69,6 +78,7 @@ namespace Skills.Fishing
             if (equipment == null)
                 equipment = GetComponent<Equipment>();
             skills = GetComponent<SkillManager>();
+            catchProgressTracker.TickAdvanced += HandleCatchProgressAdvanced;
             PreloadFishItems();
             fishingOutfit = new SkillingOutfitProgress(new[]
             {
@@ -149,12 +159,11 @@ namespace Skills.Fishing
                 StopFishing();
                 return;
             }
-            catchProgress++;
-            LogDebug($"Fishing tick: {catchProgress}/{currentIntervalTicks}");
-            if (catchProgress >= currentIntervalTicks)
+            if (catchProgressTracker.Advance())
             {
-                catchProgress = 0;
                 AttemptCatch();
+                if (IsFishing)
+                    catchProgressTracker.Reset(catchProgressTracker.RequiredTicks);
             }
         }
 
@@ -462,8 +471,8 @@ namespace Skills.Fishing
             }
             currentSpot = spot;
             currentTool = tool;
-            catchProgress = 0;
-            currentIntervalTicks = Mathf.Max(1, Mathf.RoundToInt(spot.def.CatchIntervalTicks / Mathf.Max(0.01f, tool.SwingSpeedMultiplier)));
+            int intervalTicks = Mathf.Max(1, Mathf.RoundToInt(spot.def.CatchIntervalTicks / Mathf.Max(0.01f, tool.SwingSpeedMultiplier)));
+            catchProgressTracker.Reset(intervalTicks);
             currentSpot.IsBusy = true;
             LogDebug($"Started fishing {spot.name} with {tool.DisplayName}");
             OnStartFishing?.Invoke(spot);
@@ -477,8 +486,7 @@ namespace Skills.Fishing
                 currentSpot.IsBusy = false;
             currentSpot = null;
             currentTool = null;
-            catchProgress = 0;
-            currentIntervalTicks = 0;
+            catchProgressTracker.Reset(0);
             LogDebug("Stopped fishing");
             OnStopFishing?.Invoke();
         }
@@ -529,6 +537,14 @@ namespace Skills.Fishing
                 return;
 
             Debug.Log($"[FishingSkill] {message}");
+        }
+
+        private void HandleCatchProgressAdvanced(int progress, int required)
+        {
+            if (!IsFishing)
+                return;
+
+            LogDebug($"Fishing tick: {progress}/{required}");
         }
     }
 }

--- a/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
@@ -30,7 +30,7 @@ namespace Skills.Mining
 
         private MineableRock currentRock;
         private PickaxeDefinition currentPickaxe;
-        private int swingProgress;
+        private readonly TickProgressTracker swingProgressTracker = new TickProgressTracker();
 
         private SkillManager skills;
         private Dictionary<string, ItemData> oreItems;
@@ -49,9 +49,16 @@ namespace Skills.Mining
         public PickaxeDefinition CurrentPickaxe => currentPickaxe;
         public int CurrentSwingSpeedTicks => currentPickaxe?.SwingSpeedTicks ?? 0;
         public float SwingProgressNormalized
-            => currentPickaxe == null || currentPickaxe.SwingSpeedTicks <= 1
-                ? 0f
-                : (float)swingProgress / (currentPickaxe.SwingSpeedTicks - 1);
+        {
+            get
+            {
+                int required = currentPickaxe != null ? Mathf.Max(1, currentPickaxe.SwingSpeedTicks) : 0;
+                if (required <= 1)
+                    return 0f;
+
+                return Mathf.Clamp01((float)swingProgressTracker.ProgressTicks / (required - 1));
+            }
+        }
 
         /// <summary>
         ///     Gets or sets the runtime flag controlling verbose debug logging for this skill.
@@ -69,6 +76,7 @@ namespace Skills.Mining
             if (equipment == null)
                 equipment = GetComponent<Equipment>();
             skills = GetComponent<SkillManager>();
+            swingProgressTracker.TickAdvanced += HandleSwingProgressAdvanced;
             PreloadOreItems();
             miningOutfit = new SkillingOutfitProgress(new[]
             {
@@ -102,12 +110,11 @@ namespace Skills.Mining
                 return;
             }
 
-            swingProgress++;
-            LogDebug($"Mining tick: {swingProgress}/{currentPickaxe?.SwingSpeedTicks ?? 0}");
-            if (swingProgress >= currentPickaxe.SwingSpeedTicks)
+            if (swingProgressTracker.Advance())
             {
-                swingProgress = 0;
                 AttemptMine();
+                if (IsMining && currentPickaxe != null)
+                    swingProgressTracker.Reset(currentPickaxe.SwingSpeedTicks);
             }
         }
 
@@ -208,7 +215,7 @@ namespace Skills.Mining
 
             currentRock = rock;
             currentPickaxe = pickaxe;
-            swingProgress = 0;
+            swingProgressTracker.Reset(Mathf.Max(1, pickaxe.SwingSpeedTicks));
             LogDebug($"Started mining {rock.name} with {pickaxe.DisplayName}");
             OnStartMining?.Invoke(rock);
         }
@@ -221,7 +228,7 @@ namespace Skills.Mining
             LogDebug("Stopped mining");
             currentRock = null;
             currentPickaxe = null;
-            swingProgress = 0;
+            swingProgressTracker.Reset(0);
             OnStopMining?.Invoke();
         }
 
@@ -274,6 +281,14 @@ namespace Skills.Mining
                 return;
 
             Debug.Log($"[MiningSkill] {message}");
+        }
+
+        private void HandleSwingProgressAdvanced(int progress, int required)
+        {
+            if (!IsMining)
+                return;
+
+            LogDebug($"Mining tick: {progress}/{required}");
         }
     }
 }

--- a/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
@@ -29,8 +29,7 @@ namespace Skills.Woodcutting
 
         private TreeNode currentTree;
         private AxeDefinition currentAxe;
-        private int chopProgress;
-        private int currentIntervalTicks;
+        private readonly TickProgressTracker chopProgressTracker = new TickProgressTracker();
 
         private SkillManager skills;
 
@@ -47,10 +46,19 @@ namespace Skills.Woodcutting
         public float Xp => skills != null ? skills.GetXp(SkillType.Woodcutting) : 0f;
         public bool IsChopping => currentTree != null;
         public TreeNode CurrentTree => currentTree;
-        public int CurrentChopIntervalTicks => currentIntervalTicks;
+        public int CurrentChopIntervalTicks => chopProgressTracker.RequiredTicks;
         public AxeDefinition CurrentAxe => currentAxe;
         public float ChopProgressNormalized
-            => currentIntervalTicks <= 1 ? 0f : (float)chopProgress / (currentIntervalTicks - 1);
+        {
+            get
+            {
+                int required = chopProgressTracker.RequiredTicks;
+                if (required <= 1)
+                    return 0f;
+
+                return Mathf.Clamp01((float)chopProgressTracker.ProgressTicks / (required - 1));
+            }
+        }
 
         /// <summary>
         ///     Gets or sets the runtime flag controlling verbose debug logging for this skill.
@@ -68,6 +76,7 @@ namespace Skills.Woodcutting
             if (equipment == null)
                 equipment = GetComponent<Equipment>();
             skills = GetComponent<SkillManager>();
+            chopProgressTracker.TickAdvanced += HandleChopProgressAdvanced;
             PreloadLogItems();
             woodcuttingOutfit = new SkillingOutfitProgress(new[]
             {
@@ -100,12 +109,11 @@ namespace Skills.Woodcutting
                 return;
             }
 
-            chopProgress++;
-            LogDebug($"Woodcutting tick: {chopProgress}/{currentIntervalTicks}");
-            if (chopProgress >= currentIntervalTicks)
+            if (chopProgressTracker.Advance())
             {
-                chopProgress = 0;
                 AttemptChop();
+                if (IsChopping)
+                    chopProgressTracker.Reset(chopProgressTracker.RequiredTicks);
             }
         }
 
@@ -202,8 +210,8 @@ namespace Skills.Woodcutting
 
             currentTree = tree;
             currentAxe = axe;
-            chopProgress = 0;
-            currentIntervalTicks = Mathf.Max(1, Mathf.RoundToInt(tree.def.ChopIntervalTicks / Mathf.Max(0.01f, axe.SwingSpeedMultiplier)));
+            int intervalTicks = Mathf.Max(1, Mathf.RoundToInt(tree.def.ChopIntervalTicks / Mathf.Max(0.01f, axe.SwingSpeedMultiplier)));
+            chopProgressTracker.Reset(intervalTicks);
             LogDebug($"Started chopping {tree.name} with {axe.DisplayName}");
             currentTree.IsBusy = true;
             OnStartChopping?.Invoke(tree);
@@ -219,8 +227,7 @@ namespace Skills.Woodcutting
                 currentTree.IsBusy = false;
             currentTree = null;
             currentAxe = null;
-            chopProgress = 0;
-            currentIntervalTicks = 0;
+            chopProgressTracker.Reset(0);
             OnStopChopping?.Invoke();
         }
 
@@ -273,6 +280,14 @@ namespace Skills.Woodcutting
                 return;
 
             Debug.Log($"[WoodcuttingSkill] {message}");
+        }
+
+        private void HandleChopProgressAdvanced(int progress, int required)
+        {
+            if (!IsChopping)
+                return;
+
+            LogDebug($"Woodcutting tick: {progress}/{required}");
         }
     }
 }

--- a/Assets/Tests/Skills.meta
+++ b/Assets/Tests/Skills.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3b1a2487230d4497915c208e73a6f143
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Skills/TickProgressTrackerTests.cs
+++ b/Assets/Tests/Skills/TickProgressTrackerTests.cs
@@ -1,0 +1,88 @@
+using NUnit.Framework;
+using Skills.Common;
+
+public class TickProgressTrackerTests
+{
+    [Test]
+    public void AdvanceCompletesAfterRequiredTicks()
+    {
+        var tracker = new TickProgressTracker();
+        tracker.Reset(3);
+
+        Assert.IsFalse(tracker.Advance(), "First tick should not complete the action.");
+        Assert.AreEqual(1, tracker.ProgressTicks);
+        Assert.IsFalse(tracker.Advance(), "Second tick should not complete the action.");
+        Assert.AreEqual(2, tracker.ProgressTicks);
+        Assert.IsTrue(tracker.Advance(), "Third tick should complete the action.");
+        Assert.AreEqual(3, tracker.ProgressTicks);
+    }
+
+    [Test]
+    public void ResetMidActionOverridesProgress()
+    {
+        var tracker = new TickProgressTracker();
+        tracker.Reset(4);
+        tracker.Advance();
+
+        tracker.Reset(2);
+
+        Assert.AreEqual(0, tracker.ProgressTicks, "Progress should reset when requirement changes mid-action.");
+        Assert.AreEqual(2, tracker.RequiredTicks, "New requirement should be cached.");
+        Assert.IsFalse(tracker.Advance(), "First tick after reset should not complete the action.");
+        Assert.IsTrue(tracker.Advance(), "Second tick after reset should complete the action.");
+    }
+
+    [Test]
+    public void EventsFireInSequence()
+    {
+        var tracker = new TickProgressTracker();
+        tracker.Reset(2);
+
+        int resets = 0;
+        int advancedCount = 0;
+        int completedCount = 0;
+        (int progress, int required) lastAdvance = default;
+        (int progress, int required) lastComplete = default;
+
+        tracker.ProgressReset += required =>
+        {
+            resets++;
+        };
+
+        tracker.TickAdvanced += (progress, required) =>
+        {
+            advancedCount++;
+            lastAdvance = (progress, required);
+        };
+
+        tracker.TickCompleted += (progress, required) =>
+        {
+            completedCount++;
+            lastComplete = (progress, required);
+        };
+
+        tracker.Advance();
+        tracker.Advance();
+
+        Assert.AreEqual(1, resets, "Reset should fire exactly once for the initial setup.");
+        Assert.AreEqual(2, advancedCount, "TickAdvanced should fire on every increment.");
+        Assert.AreEqual((2, 2), lastAdvance);
+        Assert.AreEqual(1, completedCount, "Completion event should fire exactly once.");
+        Assert.AreEqual((2, 2), lastComplete);
+    }
+
+    [Test]
+    public void ClearProgressMaintainsRequirement()
+    {
+        var tracker = new TickProgressTracker();
+        tracker.Reset(3);
+        tracker.Advance();
+
+        tracker.ClearProgress();
+
+        Assert.AreEqual(0, tracker.ProgressTicks, "ClearProgress should reset tick progress.");
+        Assert.AreEqual(3, tracker.RequiredTicks, "Requirement should remain unchanged when clearing progress.");
+        Assert.IsFalse(tracker.Advance());
+        Assert.AreEqual(1, tracker.ProgressTicks);
+    }
+}

--- a/Assets/Tests/Skills/TickProgressTrackerTests.cs.meta
+++ b/Assets/Tests/Skills/TickProgressTrackerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f9e41919dbca45aeb7d193b58cab10ea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- refactor CookingSkill to track per-item cook ticks through the shared TickProgressTracker helper
- expose normalized cooking progress from the tracker and reset it on start/stop so HUD bindings stay accurate
- route tick debug logging through the tracker event so existing enableDebugLogging traces remain intact

## Testing
- not run (Unity editor required)

------
https://chatgpt.com/codex/tasks/task_e_68dff6483cf4832e9f3e6ced715ebd5d