### PR TITLE
Fix TickProgressTracker event test ordering

### DIFF
--- a/Assets/Tests/Skills/TickProgressTrackerTests.cs
+++ b/Assets/Tests/Skills/TickProgressTrackerTests.cs
@@ -36,7 +36,6 @@ public class TickProgressTrackerTests
     public void EventsFireInSequence()
     {
         var tracker = new TickProgressTracker();
-        tracker.Reset(2);
 
         int resets = 0;
         int advancedCount = 0;
@@ -60,6 +59,8 @@ public class TickProgressTrackerTests
             completedCount++;
             lastComplete = (progress, required);
         };
+
+        tracker.Reset(2);
 
         tracker.Advance();
         tracker.Advance();


### PR DESCRIPTION
## Summary
- update TickProgressTrackerTests to subscribe to ProgressReset before invoking Reset so the initial reset event is observed

## Testing
- not run (tests require Unity environment)


------
https://chatgpt.com/codex/tasks/task_e_68e002a73060832e8a14de9f68fafaa5