### PR TITLE
Refactor skilling outfits into data-driven definitions

### DIFF
--- a/Assets/Resources/Skills.meta
+++ b/Assets/Resources/Skills.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0d2eb2ae7db04d30ab07e8d1c0232c1b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Skills/Outfits.meta
+++ b/Assets/Resources/Skills/Outfits.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3e3bd6cc1ac64769b77cc6ee68140a26
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Skills/Outfits/CookingOutfitDefinition.asset
+++ b/Assets/Resources/Skills/Outfits/CookingOutfitDefinition.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9d5c0f831e3c4b21a02407d1f6a6d385, type: 3}
+  m_Name: Cooking Outfit Definition
+  m_EditorClassIdentifier:
+  saveKey: CookingOutfitOwned
+  pieceItemIds:
+  - Chefs Hat
+  - Chefs Top
+  - Chefs Pants
+  - Chefs Boots
+  - Cooking Mittens
+  displayName: Chef Outfit
+  associatedPetId: Mr Frying Pan
+  bonusDescription: Provides stacking Cooking XP bonuses when worn.

--- a/Assets/Resources/Skills/Outfits/CookingOutfitDefinition.asset.meta
+++ b/Assets/Resources/Skills/Outfits/CookingOutfitDefinition.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1db8f384d0b94f1896f3b11d571c5824
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Skills/Outfits/FiremakingOutfitDefinition.asset
+++ b/Assets/Resources/Skills/Outfits/FiremakingOutfitDefinition.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9d5c0f831e3c4b21a02407d1f6a6d385, type: 3}
+  m_Name: Firemaking Outfit Definition
+  m_EditorClassIdentifier:
+  saveKey: FiremakingOutfitOwned
+  pieceItemIds:
+  - Pyromancer Hood
+  - Pyromancer Garb
+  - Pyromancer Robes
+  - Pyromancer Boots
+  - Pyromancer Gloves
+  displayName: Pyromancer Outfit
+  associatedPetId: Phoenix
+  bonusDescription: Provides stacking Firemaking XP bonuses and synergises with the Phoenix pet.

--- a/Assets/Resources/Skills/Outfits/FiremakingOutfitDefinition.asset.meta
+++ b/Assets/Resources/Skills/Outfits/FiremakingOutfitDefinition.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 497b3d4ad6b2453bab60ac0b74d447df
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Skills/Outfits/FishingOutfitDefinition.asset
+++ b/Assets/Resources/Skills/Outfits/FishingOutfitDefinition.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9d5c0f831e3c4b21a02407d1f6a6d385, type: 3}
+  m_Name: Fishing Outfit Definition
+  m_EditorClassIdentifier:
+  saveKey: FishingOutfitOwned
+  pieceItemIds:
+  - Fishing Helmet
+  - Fishing Top
+  - Fishing Pants
+  - Fishing Boots
+  - Fishing Gloves
+  displayName: Fishing Outfit
+  associatedPetId: Heron
+  bonusDescription: Provides stacking Fishing XP bonuses when worn.

--- a/Assets/Resources/Skills/Outfits/FishingOutfitDefinition.asset.meta
+++ b/Assets/Resources/Skills/Outfits/FishingOutfitDefinition.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0d1b5c3f6a0b42f0901a1a65573e1c1e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Skills/Outfits/MiningOutfitDefinition.asset
+++ b/Assets/Resources/Skills/Outfits/MiningOutfitDefinition.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9d5c0f831e3c4b21a02407d1f6a6d385, type: 3}
+  m_Name: Mining Outfit Definition
+  m_EditorClassIdentifier:
+  saveKey: MiningOutfitOwned
+  pieceItemIds:
+  - Mining Helmet
+  - Mining Jacket
+  - Mining Pants
+  - Mining Boots
+  - Mining Gloves
+  displayName: Prospector Outfit
+  associatedPetId: Rock Golem
+  bonusDescription: Provides stacking Mining XP bonuses when worn.

--- a/Assets/Resources/Skills/Outfits/MiningOutfitDefinition.asset.meta
+++ b/Assets/Resources/Skills/Outfits/MiningOutfitDefinition.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7fb20f9846b84a7fa9ef024a9b7b21b8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Skills/Outfits/WoodcuttingOutfitDefinition.asset
+++ b/Assets/Resources/Skills/Outfits/WoodcuttingOutfitDefinition.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9d5c0f831e3c4b21a02407d1f6a6d385, type: 3}
+  m_Name: Woodcutting Outfit Definition
+  m_EditorClassIdentifier:
+  saveKey: WoodcuttingOutfitOwned
+  pieceItemIds:
+  - Lumberjack Helmet
+  - Lumberjack Shirt
+  - Lumberjack Pants
+  - Lumberjack Boots
+  - Lumberjack Gloves
+  displayName: Lumberjack Outfit
+  associatedPetId: Beaver
+  bonusDescription: Provides stacking Woodcutting XP bonuses when worn.

--- a/Assets/Resources/Skills/Outfits/WoodcuttingOutfitDefinition.asset.meta
+++ b/Assets/Resources/Skills/Outfits/WoodcuttingOutfitDefinition.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7338c8c1dc5a4dcab05a4ac881f0d83d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Skills/AdminF2Menu.cs
+++ b/Assets/Scripts/Skills/AdminF2Menu.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using Player;
@@ -515,6 +516,8 @@ namespace Skills
                 SkillingOutfitProgress.DebugChance = !SkillingOutfitProgress.DebugChance;
             }
 
+            DrawActiveOutfitDefinitions();
+
             if (GUILayout.Button("Open Bank"))
             {
                 BankUI.Instance?.Open();
@@ -564,6 +567,66 @@ namespace Skills
                 setValue(updated);
 
             GUI.enabled = previousEnabled;
+        }
+
+        /// <summary>
+        ///     Lists the skilling outfit definitions currently registered at runtime.
+        ///     Helps QA verify which outfits are active after the move to ScriptableObjects.
+        /// </summary>
+        private void DrawActiveOutfitDefinitions()
+        {
+            GUILayout.Space(5f);
+            GUILayout.Label("Skilling Outfits");
+
+            var trackers = SkillingOutfitProgress.ActiveProgressTrackers;
+            if (trackers == null || trackers.Count == 0)
+            {
+                GUILayout.Label("  No active outfit trackers registered.");
+                return;
+            }
+
+            var seenDefinitions = new HashSet<SkillingOutfitDefinition>();
+            bool missingDefinitionReported = false;
+
+            foreach (var tracker in trackers)
+            {
+                if (tracker == null)
+                    continue;
+
+                var definition = tracker.Definition;
+                if (definition == null)
+                {
+                    if (!missingDefinitionReported)
+                    {
+                        GUILayout.Label("  Outfit tracker missing definition reference.");
+                        missingDefinitionReported = true;
+                    }
+
+                    continue;
+                }
+
+                if (!seenDefinitions.Add(definition))
+                    continue;
+
+                int ownedCount = tracker.owned != null ? tracker.owned.Count : 0;
+                int totalCount = tracker.AllPieceIds != null ? tracker.AllPieceIds.Count : 0;
+                if (totalCount <= 0 && definition.PieceItemIds != null)
+                    totalCount = definition.PieceItemIds.Count;
+
+                GUILayout.Label($"  {definition.DisplayName} ({ownedCount}/{Mathf.Max(0, totalCount)})");
+
+                if (!string.IsNullOrEmpty(definition.SaveKey))
+                    GUILayout.Label($"    Save Key: {definition.SaveKey}");
+
+                var metadataParts = new List<string>(2);
+                if (!string.IsNullOrEmpty(definition.AssociatedPetId))
+                    metadataParts.Add($"Pet: {definition.AssociatedPetId}");
+                if (!string.IsNullOrEmpty(definition.BonusDescription))
+                    metadataParts.Add(definition.BonusDescription);
+
+                if (metadataParts.Count > 0)
+                    GUILayout.Label($"    {string.Join(" • ", metadataParts)}");
+            }
         }
 
         /// <summary>

--- a/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
+++ b/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
@@ -5,7 +5,6 @@ using Util;
 using BankSystem;
 using Pets;
 using Skills.Outfits;
-using Core.Save;
 using Skills.Common;
 
 namespace Skills.Cooking
@@ -23,6 +22,10 @@ namespace Skills.Cooking
         [SerializeField] private Transform floatingTextAnchor;
         [SerializeField, Tooltip("Enables verbose debug logging for cooking actions.")]
         private bool enableDebugLogging;
+        [SerializeField, Tooltip("ScriptableObject containing the Chef outfit configuration.")]
+        private SkillingOutfitDefinition cookingOutfitDefinition;
+
+        private const string CookingOutfitResourcePath = "Skills/Outfits/CookingOutfitDefinition";
 
         private SkillManager skills;
         private CookableRecipe currentRecipe;
@@ -74,19 +77,22 @@ namespace Skills.Cooking
                 equipment = GetComponent<Equipment>();
             skills = GetComponent<SkillManager>();
             cookProgressTracker.TickAdvanced += HandleCookProgressAdvanced;
-            cookingOutfit = new SkillingOutfitProgress(new[]
+            if (cookingOutfitDefinition == null)
+                cookingOutfitDefinition = Resources.Load<SkillingOutfitDefinition>(CookingOutfitResourcePath);
+            if (cookingOutfitDefinition != null)
             {
-                "Chefs Hat",
-                "Chefs Top",
-                "Chefs Pants",
-                "Chefs Boots",
-                "Cooking Mittens"
-            }, "CookingOutfitOwned");
+                cookingOutfit = new SkillingOutfitProgress(cookingOutfitDefinition);
+            }
+            else
+            {
+                Debug.LogWarning("CookingSkill is missing a SkillingOutfitDefinition reference; outfit rewards are disabled.");
+            }
         }
 
         private void OnDestroy()
         {
-            SaveManager.Unregister(cookingOutfit);
+            SkillingOutfitProgress.Unregister(cookingOutfit);
+            cookingOutfit = null;
             cookProgressTracker.TickAdvanced -= HandleCookProgressAdvanced;
         }
 

--- a/Assets/Scripts/Skills/Firemaking/Core/FiremakingSkill.cs
+++ b/Assets/Scripts/Skills/Firemaking/Core/FiremakingSkill.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using BankSystem;
-using Core.Save;
 using Inventory;
 using MyGame.Drops;
 using Pets;
@@ -34,6 +33,10 @@ namespace Skills.Firemaking
         [SerializeField] private float maxIgniteDistance = 1.6f;
         [SerializeField, Tooltip("Enables verbose logging while diagnosing Firemaking behaviour.")]
         private bool enableDebugLogging;
+        [SerializeField, Tooltip("ScriptableObject containing the Pyromancer outfit configuration.")]
+        private SkillingOutfitDefinition firemakingOutfitDefinition;
+
+        private const string FiremakingOutfitResourcePath = "Skills/Outfits/FiremakingOutfitDefinition";
         [SerializeField] private bool allowTileSnapping = true;
         [SerializeField] private Vector2 tileSnapSize = Vector2.one;
 
@@ -233,14 +236,16 @@ namespace Skills.Firemaking
 
             LoadLogDefinitions();
 
-            firemakingOutfit = new SkillingOutfitProgress(new[]
+            if (firemakingOutfitDefinition == null)
+                firemakingOutfitDefinition = Resources.Load<SkillingOutfitDefinition>(FiremakingOutfitResourcePath);
+            if (firemakingOutfitDefinition != null)
             {
-                "Pyromancer Hood",
-                "Pyromancer Garb",
-                "Pyromancer Robes",
-                "Pyromancer Boots",
-                "Pyromancer Gloves"
-            }, "FiremakingOutfitOwned");
+                firemakingOutfit = new SkillingOutfitProgress(firemakingOutfitDefinition);
+            }
+            else
+            {
+                Debug.LogWarning("FiremakingSkill is missing a SkillingOutfitDefinition reference; outfit rewards are disabled.");
+            }
         }
 
         /// <summary>
@@ -248,7 +253,8 @@ namespace Skills.Firemaking
         /// </summary>
         private void OnDestroy()
         {
-            SaveManager.Unregister(firemakingOutfit);
+            SkillingOutfitProgress.Unregister(firemakingOutfit);
+            firemakingOutfit = null;
             ClearActiveFires();
         }
 

--- a/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
@@ -27,6 +27,10 @@ namespace Skills.Fishing
 
         [SerializeField, Tooltip("Enables verbose debug logging for fishing actions.")]
         private bool enableDebugLogging;
+        [SerializeField, Tooltip("ScriptableObject containing the Fisherman outfit configuration.")]
+        private SkillingOutfitDefinition fishingOutfitDefinition;
+
+        private const string FishingOutfitResourcePath = "Skills/Outfits/FishingOutfitDefinition";
 
         private FishableSpot currentSpot;
         private FishingToolDefinition currentTool;
@@ -80,14 +84,16 @@ namespace Skills.Fishing
             skills = GetComponent<SkillManager>();
             catchProgressTracker.TickAdvanced += HandleCatchProgressAdvanced;
             PreloadFishItems();
-            fishingOutfit = new SkillingOutfitProgress(new[]
+            if (fishingOutfitDefinition == null)
+                fishingOutfitDefinition = Resources.Load<SkillingOutfitDefinition>(FishingOutfitResourcePath);
+            if (fishingOutfitDefinition != null)
             {
-                "Fishing Helmet",
-                "Fishing Top",
-                "Fishing Pants",
-                "Fishing Boots",
-                "Fishing Gloves"
-            }, "FishingOutfitOwned");
+                fishingOutfit = new SkillingOutfitProgress(fishingOutfitDefinition);
+            }
+            else
+            {
+                Debug.LogWarning("FishingSkill is missing a SkillingOutfitDefinition reference; outfit rewards are disabled.");
+            }
             TryResolveBycatchManager();
             if (bycatchManager == null)
                 SubscribeToServicesReady();
@@ -100,7 +106,8 @@ namespace Skills.Fishing
                 GameManager.ServicesReady -= HandleGameManagerServicesReady;
                 waitingForServices = false;
             }
-            SaveManager.Unregister(fishingOutfit);
+            SkillingOutfitProgress.Unregister(fishingOutfit);
+            fishingOutfit = null;
         }
 
         protected override bool LogTickerSubscription => enableDebugLogging;

--- a/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
@@ -9,7 +9,6 @@ using Skills.Common;
 using Pets;
 using Quests;
 using BankSystem;
-using Core.Save;
 using Skills.Outfits;
 using Random = UnityEngine.Random;
 using UI;
@@ -27,6 +26,10 @@ namespace Skills.Mining
         [SerializeField] private Transform floatingTextAnchor;
         [SerializeField, Tooltip("Enables verbose debug logging for mining tick processing.")]
         private bool enableDebugLogging;
+        [SerializeField, Tooltip("ScriptableObject containing the Prospector outfit configuration.")]
+        private SkillingOutfitDefinition miningOutfitDefinition;
+
+        private const string MiningOutfitResourcePath = "Skills/Outfits/MiningOutfitDefinition";
 
         private MineableRock currentRock;
         private PickaxeDefinition currentPickaxe;
@@ -78,19 +81,22 @@ namespace Skills.Mining
             skills = GetComponent<SkillManager>();
             swingProgressTracker.TickAdvanced += HandleSwingProgressAdvanced;
             PreloadOreItems();
-            miningOutfit = new SkillingOutfitProgress(new[]
+            if (miningOutfitDefinition == null)
+                miningOutfitDefinition = Resources.Load<SkillingOutfitDefinition>(MiningOutfitResourcePath);
+            if (miningOutfitDefinition != null)
             {
-                "Mining Helmet",
-                "Mining Jacket",
-                "Mining Pants",
-                "Mining Boots",
-                "Mining Gloves"
-            }, "MiningOutfitOwned");
+                miningOutfit = new SkillingOutfitProgress(miningOutfitDefinition);
+            }
+            else
+            {
+                Debug.LogWarning("MiningSkill is missing a SkillingOutfitDefinition reference; outfit rewards are disabled.");
+            }
         }
 
         private void OnDestroy()
         {
-            SaveManager.Unregister(miningOutfit);
+            SkillingOutfitProgress.Unregister(miningOutfit);
+            miningOutfit = null;
         }
 
         /// <summary>

--- a/Assets/Scripts/Skills/Outfits/SkillingOutfitDefinition.cs
+++ b/Assets/Scripts/Skills/Outfits/SkillingOutfitDefinition.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Skills.Outfits
+{
+    /// <summary>
+    /// Defines the serializable data for a skilling outfit so skills can share
+    /// a single source of truth for the outfit piece IDs and persistence key.
+    /// </summary>
+    [CreateAssetMenu(menuName = "Skills/Outfits/Skilling Outfit Definition", fileName = "NewSkillingOutfitDefinition")]
+    public class SkillingOutfitDefinition : ScriptableObject
+    {
+        [SerializeField, Tooltip("Unique save key used to persist owned outfit pieces.")]
+        private string saveKey = string.Empty;
+
+        [SerializeField, Tooltip("Item IDs for every piece in the outfit set.")]
+        private string[] pieceItemIds = Array.Empty<string>();
+
+        [Header("Optional Metadata")]
+        [SerializeField, Tooltip("Friendly display name used by debug tooling. Defaults to the asset name when empty.")]
+        private string displayName = string.Empty;
+
+        [SerializeField, Tooltip("Optional pet identifier that synergises with this outfit. Used for debug context only.")]
+        private string associatedPetId = string.Empty;
+
+        [SerializeField, TextArea, Tooltip("Optional description of any passive bonuses granted by the outfit.")]
+        private string bonusDescription = string.Empty;
+
+        /// <summary>
+        /// Unique save key consumed by <see cref="Core.Save.SaveManager"/>.
+        /// </summary>
+        public string SaveKey => saveKey;
+
+        /// <summary>
+        /// Ordered list of outfit piece item IDs.
+        /// </summary>
+        public IReadOnlyList<string> PieceItemIds => pieceItemIds ?? Array.Empty<string>();
+
+        /// <summary>
+        /// Display name surfaced in debug tooling.
+        /// </summary>
+        public string DisplayName => string.IsNullOrWhiteSpace(displayName) ? name : displayName;
+
+        /// <summary>
+        /// Optional identifier for the pet associated with the outfit (if any).
+        /// </summary>
+        public string AssociatedPetId => associatedPetId;
+
+        /// <summary>
+        /// Optional description of passive bonuses provided by the outfit.
+        /// </summary>
+        public string BonusDescription => bonusDescription;
+    }
+}

--- a/Assets/Scripts/Skills/Outfits/SkillingOutfitDefinition.cs.meta
+++ b/Assets/Scripts/Skills/Outfits/SkillingOutfitDefinition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9d5c0f831e3c4b21a02407d1f6a6d385

--- a/Assets/Scripts/Skills/Outfits/SkillingOutfitProgress.cs
+++ b/Assets/Scripts/Skills/Outfits/SkillingOutfitProgress.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Core.Save;
+using UnityEngine;
 
 namespace Skills.Outfits
 {
@@ -15,27 +17,130 @@ namespace Skills.Outfits
         /// </summary>
         public static bool DebugChance { get; set; }
 
-        public readonly string[] allPieceIds;
-        public HashSet<string> owned;
-        public readonly string saveKey;
+        private static readonly List<SkillingOutfitProgress> activeProgressTrackers = new List<SkillingOutfitProgress>();
 
-        public SkillingOutfitProgress(string[] allPieceIds, string saveKey)
+        /// <summary>
+        /// Provides read-only access to the currently active outfit progress trackers.
+        /// Used by debug tooling to surface which outfits are registered at runtime.
+        /// </summary>
+        public static IReadOnlyList<SkillingOutfitProgress> ActiveProgressTrackers => activeProgressTrackers;
+
+        private readonly SkillingOutfitDefinition definition;
+        private readonly string[] allPieceIds;
+        private readonly string saveKey;
+
+        /// <summary>
+        /// Tracks the set of item IDs representing outfit pieces the player already owns.
+        /// </summary>
+        public HashSet<string> owned;
+
+        /// <summary>
+        /// Definition backing this progress tracker. May be null when constructed without data.
+        /// </summary>
+        public SkillingOutfitDefinition Definition => definition;
+
+        /// <summary>
+        /// Ordered list of the unique outfit piece IDs the tracker manages.
+        /// </summary>
+        public IReadOnlyList<string> AllPieceIds => allPieceIds;
+
+        /// <summary>
+        /// Save key used when persisting progress.
+        /// </summary>
+        public string SaveKey => saveKey;
+
+        /// <summary>
+        /// Constructs a new progress tracker driven by the supplied outfit definition.
+        /// </summary>
+        /// <param name="definition">ScriptableObject describing the outfit.</param>
+        public SkillingOutfitProgress(SkillingOutfitDefinition definition)
         {
-            this.allPieceIds = allPieceIds;
-            this.saveKey = saveKey;
-            owned = new HashSet<string>();
+            this.definition = definition;
+            owned = new HashSet<string>(StringComparer.Ordinal);
+
+            if (definition == null)
+            {
+                allPieceIds = Array.Empty<string>();
+                saveKey = string.Empty;
+                Debug.LogWarning("SkillingOutfitProgress constructed without a definition. Outfit rolls will be disabled.");
+            }
+            else
+            {
+                saveKey = definition.SaveKey != null ? definition.SaveKey.Trim() : string.Empty;
+                if (string.IsNullOrEmpty(saveKey))
+                    Debug.LogWarning($"SkillingOutfitDefinition '{definition.name}' is missing a save key. Progress will not persist.");
+
+                allPieceIds = definition.PieceItemIds != null
+                    ? definition.PieceItemIds
+                        .Where(id => !string.IsNullOrWhiteSpace(id))
+                        .Select(id => id.Trim())
+                        .Distinct(StringComparer.Ordinal)
+                        .ToArray()
+                    : Array.Empty<string>();
+            }
+
+            RegisterTracker(this);
             SaveManager.Register(this);
         }
 
+        /// <summary>
+        /// Loads owned outfit pieces from the save system.
+        /// </summary>
         public void Load()
         {
+            if (owned == null)
+                owned = new HashSet<string>(StringComparer.Ordinal);
+
+            if (string.IsNullOrEmpty(saveKey))
+            {
+                owned.Clear();
+                return;
+            }
+
             var saved = SaveManager.Load<string[]>(saveKey);
-            owned = saved != null ? new HashSet<string>(saved) : new HashSet<string>();
+            owned = saved != null
+                ? new HashSet<string>(
+                    saved.Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => id.Trim()),
+                    StringComparer.Ordinal)
+                : new HashSet<string>(StringComparer.Ordinal);
         }
 
+        /// <summary>
+        /// Persists the owned outfit pieces via the save system.
+        /// </summary>
         public void Save()
         {
-            SaveManager.Save(saveKey, owned.ToArray());
+            if (string.IsNullOrEmpty(saveKey) || owned == null)
+                return;
+
+            var sanitized = owned
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .Select(id => id.Trim())
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+
+            SaveManager.Save(saveKey, sanitized);
+        }
+
+        /// <summary>
+        /// Removes the supplied tracker from the save system and active registry.
+        /// </summary>
+        /// <param name="progress">Tracker that should be unregistered.</param>
+        public static void Unregister(SkillingOutfitProgress progress)
+        {
+            if (progress == null)
+                return;
+
+            SaveManager.Unregister(progress);
+            activeProgressTrackers.Remove(progress);
+        }
+
+        private static void RegisterTracker(SkillingOutfitProgress progress)
+        {
+            if (progress == null || activeProgressTrackers.Contains(progress))
+                return;
+
+            activeProgressTrackers.Add(progress);
         }
     }
 }

--- a/Assets/Scripts/Skills/Outfits/SkillingOutfitRewarder.cs
+++ b/Assets/Scripts/Skills/Outfits/SkillingOutfitRewarder.cs
@@ -49,7 +49,8 @@ namespace Skills.Outfits
             if (progress.owned == null)
                 progress.owned = new HashSet<string>();
 
-            if (progress.allPieceIds == null || progress.allPieceIds.Length == 0)
+            var piecePool = progress.AllPieceIds;
+            if (piecePool == null || piecePool.Count == 0)
             {
                 Debug.LogWarning($"[{debugSkillLabel}] Outfit roll skipped because no piece ids were supplied");
                 return false;
@@ -95,10 +96,10 @@ namespace Skills.Outfits
                 Debug.LogWarning($"[{debugSkillLabel}] Outfit reward duplicate detected for '{chosenId}'");
 
             // Sanity check to ensure owned count never exceeds the number of possible pieces.
-            if (progress.owned.Count > progress.allPieceIds.Length)
+            if (progress.owned.Count > piecePool.Count)
             {
                 Debug.LogWarning(
-                    $"[{debugSkillLabel}] Outfit owned count ({progress.owned.Count}) exceeds available piece count ({progress.allPieceIds.Length})");
+                    $"[{debugSkillLabel}] Outfit owned count ({progress.owned.Count}) exceeds available piece count ({piecePool.Count})");
             }
 
             return true;
@@ -107,8 +108,18 @@ namespace Skills.Outfits
         private static List<string> GetMissingPieces(SkillingOutfitProgress progress)
         {
             var missing = new List<string>();
-            foreach (var id in progress.allPieceIds)
+            if (progress == null)
+                return missing;
+
+            var pool = progress.AllPieceIds;
+            if (pool == null)
+                return missing;
+
+            foreach (var id in pool)
             {
+                if (string.IsNullOrWhiteSpace(id))
+                    continue;
+
                 if (!progress.owned.Contains(id))
                     missing.Add(id);
             }

--- a/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
@@ -9,7 +9,6 @@ using Skills.Common;
 using Pets;
 using Quests;
 using BankSystem;
-using Core.Save;
 using Skills.Outfits;
 using Random = UnityEngine.Random;
 
@@ -26,6 +25,10 @@ namespace Skills.Woodcutting
         [SerializeField] private Transform floatingTextAnchor;
         [SerializeField, Tooltip("Enables verbose debug logging for woodcutting actions.")]
         private bool enableDebugLogging;
+        [SerializeField, Tooltip("ScriptableObject containing the Lumberjack outfit configuration.")]
+        private SkillingOutfitDefinition woodcuttingOutfitDefinition;
+
+        private const string WoodcuttingOutfitResourcePath = "Skills/Outfits/WoodcuttingOutfitDefinition";
 
         private TreeNode currentTree;
         private AxeDefinition currentAxe;
@@ -78,19 +81,22 @@ namespace Skills.Woodcutting
             skills = GetComponent<SkillManager>();
             chopProgressTracker.TickAdvanced += HandleChopProgressAdvanced;
             PreloadLogItems();
-            woodcuttingOutfit = new SkillingOutfitProgress(new[]
+            if (woodcuttingOutfitDefinition == null)
+                woodcuttingOutfitDefinition = Resources.Load<SkillingOutfitDefinition>(WoodcuttingOutfitResourcePath);
+            if (woodcuttingOutfitDefinition != null)
             {
-                "Lumberjack Helmet",
-                "Lumberjack Shirt",
-                "Lumberjack Pants",
-                "Lumberjack Boots",
-                "Lumberjack Gloves"
-            }, "WoodcuttingOutfitOwned");
+                woodcuttingOutfit = new SkillingOutfitProgress(woodcuttingOutfitDefinition);
+            }
+            else
+            {
+                Debug.LogWarning("WoodcuttingSkill is missing a SkillingOutfitDefinition reference; outfit rewards are disabled.");
+            }
         }
 
         private void OnDestroy()
         {
-            SaveManager.Unregister(woodcuttingOutfit);
+            SkillingOutfitProgress.Unregister(woodcuttingOutfit);
+            woodcuttingOutfit = null;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- add a SkillingOutfitDefinition ScriptableObject and enhance SkillingOutfitProgress to load from definitions and expose active trackers
- point woodcutting, mining, fishing, cooking, and firemaking at shared outfit assets loaded from Resources instead of hardcoded arrays
- author outfit definition assets for each gathering skill and extend the Admin F2 menu to list the active outfits with bonus metadata

## Testing
- not run (Unity editor required)


------
https://chatgpt.com/codex/tasks/task_e_68e00cd39268832e8854e97c13070293