### PR TITLE
Scale skilling outfit roll odds by skill level

### DIFF
--- a/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
+++ b/Assets/Scripts/Skills/Cooking/Core/CookingSkill.cs
@@ -307,7 +307,8 @@ namespace Skills.Cooking
                 UnityEngine.Random.Range,
                 "Cooking",
                 "You've received a piece of cooking outfit",
-                "A piece of cooking outfit has been added to your bank");
+                "A piece of cooking outfit has been added to your bank",
+                Level);
         }
 
         /// <summary>

--- a/Assets/Scripts/Skills/Firemaking/Core/FiremakingSkill.cs
+++ b/Assets/Scripts/Skills/Firemaking/Core/FiremakingSkill.cs
@@ -974,7 +974,8 @@ namespace Skills.Firemaking
                 Random.Range,
                 "Firemaking",
                 "You receive a piece of the pyromancer outfit.",
-                "A pyromancer outfit piece has been sent to your bank.");
+                "A pyromancer outfit piece has been sent to your bank.",
+                skills != null ? skills.GetLevel(SkillType.Firemaking) : 1);
         }
 
         /// <summary>

--- a/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
+++ b/Assets/Scripts/Skills/Fishing/Core/FishingSkill.cs
@@ -526,7 +526,8 @@ namespace Skills.Fishing
                 UnityEngine.Random.Range,
                 "Fishing",
                 "You've received a piece of fishing outfit",
-                "A piece of fishing outfit has been added to your bank");
+                "A piece of fishing outfit has been added to your bank",
+                Level);
         }
 
         private void PreloadFishItems()

--- a/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
+++ b/Assets/Scripts/Skills/Mining/Core/MiningSkill.cs
@@ -269,7 +269,8 @@ namespace Skills.Mining
                 Random.Range,
                 "Mining",
                 "You've received a piece of mining outfit",
-                "A piece of mining outfit has been added to your bank");
+                "A piece of mining outfit has been added to your bank",
+                Level);
         }
 
         private void PreloadOreItems()

--- a/Assets/Scripts/Skills/Outfits/SkillingOutfitRewarder.cs
+++ b/Assets/Scripts/Skills/Outfits/SkillingOutfitRewarder.cs
@@ -26,6 +26,7 @@ namespace Skills.Outfits
         /// <param name="debugSkillLabel">Label used when logging debug roll information.</param>
         /// <param name="successToast">Toast text displayed when the item enters the inventory.</param>
         /// <param name="bankToast">Toast text displayed when the reward is routed to the bank.</param>
+        /// <param name="skillLevel">Caller supplied skill level used to scale the roll odds.</param>
         /// <param name="rollRange">Exclusive upper bound for the roll check. Defaults to 2500.</param>
         /// <param name="winningRoll">The integer result that indicates success. Defaults to 0.</param>
         /// <returns>True if a piece was awarded, otherwise false.</returns>
@@ -37,6 +38,7 @@ namespace Skills.Outfits
             string debugSkillLabel,
             string successToast,
             string bankToast,
+            int skillLevel,
             int rollRange = DefaultRollRange,
             int winningRoll = DefaultWinningRoll)
         {
@@ -57,10 +59,16 @@ namespace Skills.Outfits
             }
 
             var rollFunc = rng ?? UnityEngine.Random.Range;
-            int roll = rollFunc(0, Mathf.Max(1, rollRange));
+            int clampedLevel = Mathf.Clamp(skillLevel, 1, 99);
+            float normalizedLevel = Mathf.InverseLerp(1f, 99f, clampedLevel);
+            int effectiveRollRange = Mathf.Max(1, Mathf.RoundToInt(Mathf.Lerp(5000f, rollRange, normalizedLevel)));
+            int roll = rollFunc(0, effectiveRollRange);
 
             if (SkillingOutfitProgress.DebugChance)
-                Debug.Log($"[{debugSkillLabel}] Skilling outfit roll: {roll} (chance 1 in {Mathf.Max(1, rollRange)})");
+            {
+                Debug.Log(
+                    $"[{debugSkillLabel}] Skilling outfit roll: {roll} (level {clampedLevel}, chance 1 in {effectiveRollRange})");
+            }
 
             if (roll != winningRoll)
                 return false;

--- a/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
+++ b/Assets/Scripts/Skills/Woodcutting/Core/WoodcuttingSkill.cs
@@ -268,7 +268,8 @@ namespace Skills.Woodcutting
                 Random.Range,
                 "Woodcutting",
                 "You've received a piece of woodcutting outfit",
-                "A piece of woodcutting outfit has been added to your bank");
+                "A piece of woodcutting outfit has been added to your bank",
+                Level);
         }
 
         private void PreloadLogItems()


### PR DESCRIPTION
## Summary
- extend `SkillingOutfitRewarder.TryAwardPiece` to accept the caller's level and derive a level-scaled roll range
- update woodcutting, mining, fishing, cooking, and firemaking outfit hooks to pass their live skill levels so debug logs reflect the new scaling

## Testing
- not run (Unity editor required)


------
https://chatgpt.com/codex/tasks/task_e_68e01b70a9f0832e896d68d6cd8bc759