### PR TITLE
Extend pet animation data with diagonal sprites and FPS overrides

### DIFF
--- a/Assets/Game/Items/Beaver.asset
+++ b/Assets/Game/Items/Beaver.asset
@@ -21,28 +21,48 @@ MonoBehaviour:
   evolutionTiers: []
   animationClips: []
   attackSprite: {fileID: 0}
-  hitUp: []
   hitDown: []
-  hitLeft: []
+  hitDownRight: []
   hitRight: []
-  idleUp:
-  - {fileID: 21300000, guid: 9ac97a4d867e9b04b8ff48ec0bd0992d, type: 3}
-  walkUp:
-  - {fileID: 21300000, guid: 9ac97a4d867e9b04b8ff48ec0bd0992d, type: 3}
+  hitUpRight: []
+  hitUp: []
+  hitUpLeft: []
+  hitLeft: []
+  hitDownLeft: []
   idleDown:
   - {fileID: 21300000, guid: 9f67e1cc5aedbc74eb9622630446cfd7, type: 3}
-  walkDown:
-  - {fileID: 21300000, guid: 9f67e1cc5aedbc74eb9622630446cfd7, type: 3}
-  idleLeft:
-  - {fileID: 21300000, guid: e505d21705048c44998604f330607fa6, type: 3}
-  walkLeft:
-  - {fileID: 21300000, guid: e505d21705048c44998604f330607fa6, type: 3}
+  idleDownRight: []
   idleRight:
   - {fileID: 21300000, guid: 3fd0b1d69ceeb0646a22491615b68e56, type: 3}
+  idleUpRight: []
+  idleUp:
+  - {fileID: 21300000, guid: 9ac97a4d867e9b04b8ff48ec0bd0992d, type: 3}
+  idleUpLeft: []
+  idleLeft:
+  - {fileID: 21300000, guid: e505d21705048c44998604f330607fa6, type: 3}
+  idleDownLeft: []
+  walkDown:
+  - {fileID: 21300000, guid: 9f67e1cc5aedbc74eb9622630446cfd7, type: 3}
+  walkDownRight: []
   walkRight:
   - {fileID: 21300000, guid: 3fd0b1d69ceeb0646a22491615b68e56, type: 3}
+  walkUpRight: []
+  walkUp:
+  - {fileID: 21300000, guid: 9ac97a4d867e9b04b8ff48ec0bd0992d, type: 3}
+  walkUpLeft: []
+  walkLeft:
+  - {fileID: 21300000, guid: e505d21705048c44998604f330607fa6, type: 3}
+  walkDownLeft: []
   useRightSpritesForLeft: 0
   useLeftSpritesForRight: 0
+  useRightSpritesForDownLeft: 0
+  useLeftSpritesForDownRight: 0
+  useRightSpritesForUpLeft: 0
+  useLeftSpritesForUpRight: 0
+  baseAnimationFPS: 6
+  idleAnimationFPS: 0
+  walkAnimationFPS: 0
+  hitAnimationFPS: 0
   canFight: 0
   petAttackLevel: 1
   petStrengthLevel: 1

--- a/Assets/Game/Items/Phoenix.asset
+++ b/Assets/Game/Items/Phoenix.asset
@@ -21,26 +21,46 @@ MonoBehaviour:
   evolutionTiers: []
   animationClips: []
   attackSprite: {fileID: 6666414941200281703, guid: 22d9a71bef5d9ec4283f7ca895561c02, type: 3}
-  hitUp: []
   hitDown: []
-  hitLeft: []
+  hitDownRight: []
   hitRight: []
-  idleUp:
-  - {fileID: 21300000, guid: c6d85a396d438034cb27e906ab88f84b, type: 3}
-  walkUp:
-  - {fileID: 21300000, guid: c6d85a396d438034cb27e906ab88f84b, type: 3}
+  hitUpRight: []
+  hitUp: []
+  hitUpLeft: []
+  hitLeft: []
+  hitDownLeft: []
   idleDown:
   - {fileID: 21300000, guid: d67f5f8dc921e5f489e398af97faa2f9, type: 3}
-  walkDown:
-  - {fileID: 21300000, guid: d67f5f8dc921e5f489e398af97faa2f9, type: 3}
-  idleLeft: []
-  walkLeft: []
+  idleDownRight: []
   idleRight:
   - {fileID: 21300000, guid: 721f9d69e32794243957606cc7df8855, type: 3}
+  idleUpRight: []
+  idleUp:
+  - {fileID: 21300000, guid: c6d85a396d438034cb27e906ab88f84b, type: 3}
+  idleUpLeft: []
+  idleLeft: []
+  idleDownLeft: []
+  walkDown:
+  - {fileID: 21300000, guid: d67f5f8dc921e5f489e398af97faa2f9, type: 3}
+  walkDownRight: []
   walkRight:
   - {fileID: 21300000, guid: 721f9d69e32794243957606cc7df8855, type: 3}
+  walkUpRight: []
+  walkUp:
+  - {fileID: 21300000, guid: c6d85a396d438034cb27e906ab88f84b, type: 3}
+  walkUpLeft: []
+  walkLeft: []
+  walkDownLeft: []
   useRightSpritesForLeft: 1
   useLeftSpritesForRight: 0
+  useRightSpritesForDownLeft: 1
+  useLeftSpritesForDownRight: 0
+  useRightSpritesForUpLeft: 1
+  useLeftSpritesForUpRight: 0
+  baseAnimationFPS: 6
+  idleAnimationFPS: 0
+  walkAnimationFPS: 0
+  hitAnimationFPS: 0
   canFight: 1
   petAttackLevel: 0
   petStrengthLevel: 0

--- a/Assets/Scripts/Pets/IPetService.cs
+++ b/Assets/Scripts/Pets/IPetService.cs
@@ -46,6 +46,10 @@ namespace Pets
         public bool useFlipXForUpRight;
         public bool useFlipXForDownRight;
         public Vector3 localScale = Vector3.one;
+        public float animationFPS = 6f;
+        public float idleAnimationFPS;
+        public float walkAnimationFPS;
+        public float hitAnimationFPS;
     }
 
     /// <summary>

--- a/Assets/Scripts/Pets/PetDefinition.cs
+++ b/Assets/Scripts/Pets/PetDefinition.cs
@@ -50,48 +50,110 @@ namespace Pets
         [Tooltip("Sprite used when attacking if no Animator is present.")]
         public Sprite attackSprite;
 
-        [Tooltip("Frames for hit animation when facing up.")]
-        public Sprite[] hitUp;
-
         [Tooltip("Frames for hit animation when facing down.")]
         public Sprite[] hitDown;
 
-        [Tooltip("Frames for hit animation when facing left.")]
-        public Sprite[] hitLeft;
+        [Tooltip("Frames for hit animation when facing down-right.")]
+        public Sprite[] hitDownRight;
 
         [Tooltip("Frames for hit animation when facing right.")]
         public Sprite[] hitRight;
 
+        [Tooltip("Frames for hit animation when facing up-right.")]
+        public Sprite[] hitUpRight;
+
+        [Tooltip("Frames for hit animation when facing up.")]
+        public Sprite[] hitUp;
+
+        [Tooltip("Frames for hit animation when facing up-left.")]
+        public Sprite[] hitUpLeft;
+
+        [Tooltip("Frames for hit animation when facing left.")]
+        public Sprite[] hitLeft;
+
+        [Tooltip("Frames for hit animation when facing down-left.")]
+        public Sprite[] hitDownLeft;
+
         [Header("Frame-based Sprites")]
-        [Tooltip("Frames for idle animation when facing up.")]
-        public Sprite[] idleUp;
-
-        [Tooltip("Frames for walking animation when facing up.")]
-        public Sprite[] walkUp;
-
         [Tooltip("Frames for idle animation when facing down.")]
         public Sprite[] idleDown;
 
-        [Tooltip("Frames for walking animation when facing down.")]
-        public Sprite[] walkDown;
-
-        [Tooltip("Frames for idle animation when facing left.")]
-        public Sprite[] idleLeft;
-
-        [Tooltip("Frames for walking animation when facing left.")]
-        public Sprite[] walkLeft;
+        [Tooltip("Frames for idle animation when facing down-right.")]
+        public Sprite[] idleDownRight;
 
         [Tooltip("Frames for idle animation when facing right.")]
         public Sprite[] idleRight;
 
+        [Tooltip("Frames for idle animation when facing up-right.")]
+        public Sprite[] idleUpRight;
+
+        [Tooltip("Frames for idle animation when facing up.")]
+        public Sprite[] idleUp;
+
+        [Tooltip("Frames for idle animation when facing up-left.")]
+        public Sprite[] idleUpLeft;
+
+        [Tooltip("Frames for idle animation when facing left.")]
+        public Sprite[] idleLeft;
+
+        [Tooltip("Frames for idle animation when facing down-left.")]
+        public Sprite[] idleDownLeft;
+
+        [Tooltip("Frames for walking animation when facing down.")]
+        public Sprite[] walkDown;
+
+        [Tooltip("Frames for walking animation when facing down-right.")]
+        public Sprite[] walkDownRight;
+
         [Tooltip("Frames for walking animation when facing right.")]
         public Sprite[] walkRight;
 
-        [Tooltip("If true, flip right-facing sprites to use for left-facing animations (idle/walk/hit).")] 
+        [Tooltip("Frames for walking animation when facing up-right.")]
+        public Sprite[] walkUpRight;
+
+        [Tooltip("Frames for walking animation when facing up.")]
+        public Sprite[] walkUp;
+
+        [Tooltip("Frames for walking animation when facing up-left.")]
+        public Sprite[] walkUpLeft;
+
+        [Tooltip("Frames for walking animation when facing left.")]
+        public Sprite[] walkLeft;
+
+        [Tooltip("Frames for walking animation when facing down-left.")]
+        public Sprite[] walkDownLeft;
+
+        [Header("Sprite Mirroring")]
+        [Tooltip("If true, flip right-facing sprites to use for left-facing animations (idle/walk/hit).")]
         public bool useRightSpritesForLeft = true;
 
-        [Tooltip("If true, flip left-facing sprites to use for right-facing animations (idle/walk/hit).")] 
+        [Tooltip("If true, flip left-facing sprites to use for right-facing animations (idle/walk/hit).")]
         public bool useLeftSpritesForRight = false;
+
+        [Tooltip("If true, flip down-right sprites to use for down-left animations (idle/walk/hit).")]
+        public bool useRightSpritesForDownLeft = true;
+
+        [Tooltip("If true, flip down-left sprites to use for down-right animations (idle/walk/hit).")]
+        public bool useLeftSpritesForDownRight = false;
+
+        [Tooltip("If true, flip up-right sprites to use for up-left animations (idle/walk/hit).")]
+        public bool useRightSpritesForUpLeft = true;
+
+        [Tooltip("If true, flip up-left sprites to use for up-right animations (idle/walk/hit).")]
+        public bool useLeftSpritesForUpRight = false;
+
+        [Header("Frame Animation Settings")]
+        [Tooltip("Base frames per second used for sprite animations when state overrides are not provided.")]
+        public float baseAnimationFPS = 6f;
+
+        [Tooltip("Frames per second to use for idle animations. Set to 0 or lower to fall back to Base Animation FPS.")]
+        public float idleAnimationFPS = 0f;
+
+        [Tooltip("Frames per second to use for walk animations. Set to 0 or lower to fall back to Base Animation FPS.")]
+        public float walkAnimationFPS = 0f;
+
+        [Tooltip("Frames per second to use for hit animations. Set to 0 or lower to fall back to Base Animation FPS.")]
+        public float hitAnimationFPS = 0f;
 
         [Header("Combat")]
         [Tooltip("If true, this pet can participate in combat.")]

--- a/Assets/Scripts/Pets/PetServiceAdapter.cs
+++ b/Assets/Scripts/Pets/PetServiceAdapter.cs
@@ -85,6 +85,10 @@ namespace Pets
                     profile.useFlipXForUpLeft = psa.useFlipXForUpLeft;
                     profile.useFlipXForUpRight = psa.useFlipXForUpRight;
                     profile.useFlipXForDownRight = psa.useFlipXForDownRight;
+                    profile.animationFPS = psa.animationFPS;
+                    profile.idleAnimationFPS = psa.idleAnimationFPS;
+                    profile.walkAnimationFPS = psa.walkAnimationFPS;
+                    profile.hitAnimationFPS = psa.hitAnimationFPS;
                 }
             }
             return profile;

--- a/Assets/Scripts/Pets/PetSpawner.cs
+++ b/Assets/Scripts/Pets/PetSpawner.cs
@@ -45,12 +45,20 @@ namespace Pets
             {
                 if (def.idleDown != null && def.idleDown.Length > 0) sr.sprite = def.idleDown[0];
                 else if (def.walkDown != null && def.walkDown.Length > 0) sr.sprite = def.walkDown[0];
+                else if (def.idleDownRight != null && def.idleDownRight.Length > 0) sr.sprite = def.idleDownRight[0];
+                else if (def.walkDownRight != null && def.walkDownRight.Length > 0) sr.sprite = def.walkDownRight[0];
                 else if (def.idleRight != null && def.idleRight.Length > 0) sr.sprite = def.idleRight[0];
                 else if (def.walkRight != null && def.walkRight.Length > 0) sr.sprite = def.walkRight[0];
+                else if (def.idleUpRight != null && def.idleUpRight.Length > 0) sr.sprite = def.idleUpRight[0];
+                else if (def.walkUpRight != null && def.walkUpRight.Length > 0) sr.sprite = def.walkUpRight[0];
                 else if (def.idleUp != null && def.idleUp.Length > 0) sr.sprite = def.idleUp[0];
                 else if (def.walkUp != null && def.walkUp.Length > 0) sr.sprite = def.walkUp[0];
+                else if (def.idleUpLeft != null && def.idleUpLeft.Length > 0) sr.sprite = def.idleUpLeft[0];
+                else if (def.walkUpLeft != null && def.walkUpLeft.Length > 0) sr.sprite = def.walkUpLeft[0];
                 else if (def.idleLeft != null && def.idleLeft.Length > 0) sr.sprite = def.idleLeft[0];
                 else if (def.walkLeft != null && def.walkLeft.Length > 0) sr.sprite = def.walkLeft[0];
+                else if (def.idleDownLeft != null && def.idleDownLeft.Length > 0) sr.sprite = def.idleDownLeft[0];
+                else if (def.walkDownLeft != null && def.walkDownLeft.Length > 0) sr.sprite = def.walkDownLeft[0];
             }
             if (sr.sprite != null && sr.sprite.texture != null)
                 sr.sprite.texture.filterMode = FilterMode.Point;
@@ -64,37 +72,70 @@ namespace Pets
             }
 
             bool hasFrameSprites =
-                (def.idleUp != null && def.idleUp.Length > 0) ||
-                (def.walkUp != null && def.walkUp.Length > 0) ||
                 (def.idleDown != null && def.idleDown.Length > 0) ||
                 (def.walkDown != null && def.walkDown.Length > 0) ||
-                (def.idleLeft != null && def.idleLeft.Length > 0) ||
-                (def.walkLeft != null && def.walkLeft.Length > 0) ||
+                (def.idleDownRight != null && def.idleDownRight.Length > 0) ||
+                (def.walkDownRight != null && def.walkDownRight.Length > 0) ||
                 (def.idleRight != null && def.idleRight.Length > 0) ||
                 (def.walkRight != null && def.walkRight.Length > 0) ||
-                (def.hitUp != null && def.hitUp.Length > 0) ||
+                (def.idleUpRight != null && def.idleUpRight.Length > 0) ||
+                (def.walkUpRight != null && def.walkUpRight.Length > 0) ||
+                (def.idleUp != null && def.idleUp.Length > 0) ||
+                (def.walkUp != null && def.walkUp.Length > 0) ||
+                (def.idleUpLeft != null && def.idleUpLeft.Length > 0) ||
+                (def.walkUpLeft != null && def.walkUpLeft.Length > 0) ||
+                (def.idleLeft != null && def.idleLeft.Length > 0) ||
+                (def.walkLeft != null && def.walkLeft.Length > 0) ||
+                (def.idleDownLeft != null && def.idleDownLeft.Length > 0) ||
+                (def.walkDownLeft != null && def.walkDownLeft.Length > 0) ||
                 (def.hitDown != null && def.hitDown.Length > 0) ||
+                (def.hitDownRight != null && def.hitDownRight.Length > 0) ||
+                (def.hitRight != null && def.hitRight.Length > 0) ||
+                (def.hitUpRight != null && def.hitUpRight.Length > 0) ||
+                (def.hitUp != null && def.hitUp.Length > 0) ||
+                (def.hitUpLeft != null && def.hitUpLeft.Length > 0) ||
                 (def.hitLeft != null && def.hitLeft.Length > 0) ||
-                (def.hitRight != null && def.hitRight.Length > 0);
+                (def.hitDownLeft != null && def.hitDownLeft.Length > 0);
 
             if (hasFrameSprites && (def.animationClips == null || def.animationClips.Length == 0))
             {
                 var spriteAnim = go.AddComponent<PetSpriteAnimator>();
                 spriteAnim.spriteRenderer = sr;
-                spriteAnim.idleUp = def.idleUp;
-                spriteAnim.walkUp = def.walkUp;
                 spriteAnim.idleDown = def.idleDown;
-                spriteAnim.walkDown = def.walkDown;
-                spriteAnim.idleLeft = def.idleLeft;
-                spriteAnim.walkLeft = def.walkLeft;
+                spriteAnim.idleDownRight = def.idleDownRight;
                 spriteAnim.idleRight = def.idleRight;
+                spriteAnim.idleUpRight = def.idleUpRight;
+                spriteAnim.idleUp = def.idleUp;
+                spriteAnim.idleUpLeft = def.idleUpLeft;
+                spriteAnim.idleLeft = def.idleLeft;
+                spriteAnim.idleDownLeft = def.idleDownLeft;
+                spriteAnim.walkDown = def.walkDown;
+                spriteAnim.walkDownRight = def.walkDownRight;
                 spriteAnim.walkRight = def.walkRight;
-                spriteAnim.hitUp = def.hitUp;
+                spriteAnim.walkUpRight = def.walkUpRight;
+                spriteAnim.walkUp = def.walkUp;
+                spriteAnim.walkUpLeft = def.walkUpLeft;
+                spriteAnim.walkLeft = def.walkLeft;
+                spriteAnim.walkDownLeft = def.walkDownLeft;
                 spriteAnim.hitDown = def.hitDown;
-                spriteAnim.hitLeft = def.hitLeft;
+                spriteAnim.hitDownRight = def.hitDownRight;
                 spriteAnim.hitRight = def.hitRight;
+                spriteAnim.hitUpRight = def.hitUpRight;
+                spriteAnim.hitUp = def.hitUp;
+                spriteAnim.hitUpLeft = def.hitUpLeft;
+                spriteAnim.hitLeft = def.hitLeft;
+                spriteAnim.hitDownLeft = def.hitDownLeft;
                 spriteAnim.useFlipXForLeft = def.useRightSpritesForLeft;
                 spriteAnim.useFlipXForRight = def.useLeftSpritesForRight;
+                spriteAnim.useFlipXForDownLeft = def.useRightSpritesForDownLeft;
+                spriteAnim.useFlipXForDownRight = def.useLeftSpritesForDownRight;
+                spriteAnim.useFlipXForUpLeft = def.useRightSpritesForUpLeft;
+                spriteAnim.useFlipXForUpRight = def.useLeftSpritesForUpRight;
+                if (def.baseAnimationFPS > 0f)
+                    spriteAnim.animationFPS = def.baseAnimationFPS;
+                spriteAnim.idleAnimationFPS = def.idleAnimationFPS;
+                spriteAnim.walkAnimationFPS = def.walkAnimationFPS;
+                spriteAnim.hitAnimationFPS = def.hitAnimationFPS;
             }
 
             if (def.animationClips != null && def.animationClips.Length > 0)

--- a/Assets/Scripts/Pets/PetSpriteAnimator.cs
+++ b/Assets/Scripts/Pets/PetSpriteAnimator.cs
@@ -62,6 +62,15 @@ namespace Pets
         [Tooltip("Frames per second for the sprite swapping animation.")]
         public float animationFPS = 6f;
 
+        [Tooltip("Override frames per second while idle. Values <= 0 fall back to Animation FPS.")]
+        public float idleAnimationFPS = 0f;
+
+        [Tooltip("Override frames per second while walking. Values <= 0 fall back to Animation FPS.")]
+        public float walkAnimationFPS = 0f;
+
+        [Tooltip("Override frames per second while playing hit animations. Values <= 0 fall back to Animation FPS.")]
+        public float hitAnimationFPS = 0f;
+
         private Direction8 _currentDir = Direction8.Down;
         private bool _currentlyMoving = false;
         private float _animClock = 0f;
@@ -92,7 +101,7 @@ namespace Pets
             if (spriteRenderer == null)
                 return;
 
-            float fps = Mathf.Max(0.01f, animationFPS);
+            float fps = ResolveAnimationFps(_currentlyMoving ? walkAnimationFPS : idleAnimationFPS);
             _animClock += Time.deltaTime * fps;
             Sprite[] set = SelectSpriteSet(_currentlyMoving, _currentDir, out int frames, out bool flip);
 
@@ -124,7 +133,7 @@ namespace Pets
 
             _overridePlaying = true;
             _currentDir = dir;
-            float fps = Mathf.Max(0.01f, animationFPS);
+            float fps = ResolveAnimationFps(hitAnimationFPS);
             for (int i = 0; i < frames; i++)
             {
                 spriteRenderer.sprite = set[i];
@@ -290,6 +299,14 @@ namespace Pets
         private bool ShouldMirrorHit(Direction8 dir)
         {
             return ShouldMirrorMovement(dir);
+        }
+
+        /// <summary>Resolves the effective FPS taking per-state overrides into account.</summary>
+        private float ResolveAnimationFps(float overrideFps)
+        {
+            float baseFps = animationFPS > 0f ? animationFPS : 6f;
+            float resolved = overrideFps > 0f ? overrideFps : baseFps;
+            return Mathf.Max(0.01f, resolved);
         }
     }
 }

--- a/Assets/Scripts/Skills/Beastmaster/MergedPetAttackAnimator.cs
+++ b/Assets/Scripts/Skills/Beastmaster/MergedPetAttackAnimator.cs
@@ -79,6 +79,10 @@ namespace Beastmaster
             spriteAnimator.useFlipXForUpLeft = profile.useFlipXForUpLeft;
             spriteAnimator.useFlipXForUpRight = profile.useFlipXForUpRight;
             spriteAnimator.useFlipXForDownRight = profile.useFlipXForDownRight;
+            spriteAnimator.animationFPS = profile.animationFPS > 0f ? profile.animationFPS : 6f;
+            spriteAnimator.idleAnimationFPS = profile.idleAnimationFPS;
+            spriteAnimator.walkAnimationFPS = profile.walkAnimationFPS;
+            spriteAnimator.hitAnimationFPS = profile.hitAnimationFPS;
         }
 
         public void ClearPetLook()
@@ -93,6 +97,10 @@ namespace Beastmaster
             spriteAnimator.hitUpRight = null;
             spriteAnimator.hitUpLeft = null;
             spriteAnimator.hitDownLeft = null;
+            spriteAnimator.animationFPS = 6f;
+            spriteAnimator.idleAnimationFPS = 0f;
+            spriteAnimator.walkAnimationFPS = 0f;
+            spriteAnimator.hitAnimationFPS = 0f;
         }
 
         private void HandleAttack()

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This project currently targets **Unity 6000.2.3f1**.
 - `Assets/Scripts/World` – Manages persistent objects, scene transitions, respawn markers, minimap/popup text systems, and screen fades.
 - `Assets/Scripts/UI` – Centralises OSRS-style UI shells (`UIManager`, `InterfaceTabButtons`, `PersistentEventSystem`, `MagicUI`, HUD widgets).
 - `Assets/Scripts/Status` – Contains `BuffTimerService`, `BuffEvents`, antifire/freeze/poison controllers, and save bridges.
-- `Assets/Scripts/Pets` & `Assets/Scripts/Drops` – Run pet followers/storage, pet XP, drop tables (`DropResolver`, `GroundItemSpawner`), and pet drop UI.
+- `Assets/Scripts/Pets` & `Assets/Scripts/Drops` – Run pet followers/storage, pet XP, drop tables (`DropResolver`, `GroundItemSpawner`), and pet drop UI. `PetDefinition` exposes eight-direction idle/walk/hit sprite arrays, per-state FPS overrides, and mirroring toggles so pet art can be sourced from single-sided sheets.
 - `Assets/Scripts/Audio` – Provides `SoundManager` and the `SoundEffect` enum for SFX/music routing.
 - `Assets/Scripts/Books`, `Assets/Scripts/Dialogue`, `Assets/Scripts/Quests` – Supply lore ScriptableObjects, dialogue UI/data, and quest management/definitions.
 - `Assets/Scripts/Environment` & `Assets/Scripts/Util` – Offer environmental helpers like `FenceColliderFoot` and cross-cutting utilities (`Ticker`, `SpriteDepth`, `ITickable`).


### PR DESCRIPTION
## Summary
- add diagonal sprite arrays, mirroring toggles, and per-state FPS fields to `PetDefinition`
- hydrate the new data when spawning pets and inside the sprite animator, including per-state FPS overrides
- surface the new fields through service adapters, merged attack visuals, and representative pet ScriptableObjects

## Testing
- not run (Unity editor required)

------
https://chatgpt.com/codex/tasks/task_e_68e01d39d308832eafa3c091432e64c9