### PR TITLE
Add pet path mover and refactor follower navigation

### DIFF
--- a/Assets/Scripts/NPC/Movement/NpcPathMover.cs
+++ b/Assets/Scripts/NPC/Movement/NpcPathMover.cs
@@ -11,7 +11,7 @@ namespace NPC
     /// </summary>
     [DisallowMultipleComponent]
     [RequireComponent(typeof(Rigidbody2D))]
-    public sealed class NpcPathMover : MonoBehaviour, ITickable
+    public sealed class NpcPathMover : MonoBehaviour, ITickable, IPathMoverClient
     {
         [Header("Movement")]
         [Tooltip("Seconds spent traversing a single tile. Defaults to the OSRS tick length for grid-accurate pacing.")]
@@ -256,7 +256,7 @@ namespace NPC
         /// <summary>
         /// Consumes the outcome of a path request issued through <see cref="PathfindingService"/>.
         /// </summary>
-        internal void HandlePathResult(int requestId, PathfindingService.PathStatus status, List<Vector2> worldPath, Vector2 resolvedGoalWorld)
+        public void HandlePathResult(int requestId, PathfindingService.PathStatus status, List<Vector2> worldPath, Vector2 resolvedGoalWorld)
         {
             if (requestId != activeRequestId)
             {

--- a/Assets/Scripts/NPC/Navigation/IPathMoverClient.cs
+++ b/Assets/Scripts/NPC/Navigation/IPathMoverClient.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace NPC
+{
+    /// <summary>
+    /// Shared interface consumed by <see cref="PathfindingService"/> so multiple mover types (NPCs, pets)
+    /// can receive asynchronous path results.
+    /// </summary>
+    public interface IPathMoverClient
+    {
+        /// <summary>
+        /// Consumes the outcome of a path request previously queued with <see cref="PathfindingService"/>.
+        /// </summary>
+        /// <param name="requestId">Identifier returned when the path was requested.</param>
+        /// <param name="status">Result returned by the navigation system.</param>
+        /// <param name="worldPath">Resolved world-space waypoints. May be <c>null</c> on failure.</param>
+        /// <param name="resolvedGoalWorld">World position considered the final destination.</param>
+        void HandlePathResult(int requestId, PathfindingService.PathStatus status, List<Vector2> worldPath, Vector2 resolvedGoalWorld);
+    }
+}

--- a/Assets/Scripts/NPC/Navigation/PathfindingService.cs
+++ b/Assets/Scripts/NPC/Navigation/PathfindingService.cs
@@ -27,7 +27,7 @@ namespace NPC
         private sealed class PathRequest
         {
             public readonly int Id;
-            public readonly WeakReference<NpcPathMover> MoverReference;
+            public readonly WeakReference<IPathMoverClient> MoverReference;
             public readonly Vector2 StartWorld;
             public readonly Vector2 GoalWorld;
 
@@ -45,21 +45,21 @@ namespace NPC
             public bool Prepared;
             public bool UsedStartFallback;
 
-            public PathRequest(int id, NpcPathMover mover, Vector2 start, Vector2 goal)
+            public PathRequest(int id, IPathMoverClient mover, Vector2 start, Vector2 goal)
             {
                 Id = id;
-                MoverReference = new WeakReference<NpcPathMover>(mover);
+                MoverReference = new WeakReference<IPathMoverClient>(mover);
                 StartWorld = start;
                 GoalWorld = goal;
                 Search = new AStarSearch();
             }
         }
 
-        private sealed class MoverReferenceComparer : IEqualityComparer<WeakReference<NpcPathMover>>
+        private sealed class MoverReferenceComparer : IEqualityComparer<WeakReference<IPathMoverClient>>
         {
             public static readonly MoverReferenceComparer Instance = new MoverReferenceComparer();
 
-            public bool Equals(WeakReference<NpcPathMover> x, WeakReference<NpcPathMover> y)
+            public bool Equals(WeakReference<IPathMoverClient> x, WeakReference<IPathMoverClient> y)
             {
                 if (ReferenceEquals(x, y))
                 {
@@ -87,7 +87,7 @@ namespace NPC
                 return false;
             }
 
-            public int GetHashCode(WeakReference<NpcPathMover> obj)
+            public int GetHashCode(WeakReference<IPathMoverClient> obj)
             {
                 if (obj == null)
                 {
@@ -281,9 +281,9 @@ namespace NPC
         [SerializeField] private bool enableDebugLogging;
 
         private readonly Queue<PathRequest> pendingRequests = new Queue<PathRequest>();
-        private readonly Dictionary<WeakReference<NpcPathMover>, int> latestQueuedRequestIdByMover =
-            new Dictionary<WeakReference<NpcPathMover>, int>(MoverReferenceComparer.Instance);
-        private readonly List<WeakReference<NpcPathMover>> moverCleanupBuffer = new List<WeakReference<NpcPathMover>>();
+        private readonly Dictionary<WeakReference<IPathMoverClient>, int> latestQueuedRequestIdByMover =
+            new Dictionary<WeakReference<IPathMoverClient>, int>(MoverReferenceComparer.Instance);
+        private readonly List<WeakReference<IPathMoverClient>> moverCleanupBuffer = new List<WeakReference<IPathMoverClient>>();
         /// <summary>
         /// Reusable frontier used when resolving the nearest walkable fallback cell so we avoid per-call queue allocations.
         /// </summary>
@@ -403,7 +403,7 @@ namespace NPC
         /// <summary>
         /// Queues a path request. The service will deliver the result asynchronously via the supplied mover.
         /// </summary>
-        public int RequestPath(NpcPathMover mover, Vector2 start, Vector2 goal)
+        public int RequestPath(IPathMoverClient mover, Vector2 start, Vector2 goal)
         {
             if (mover == null)
             {
@@ -421,7 +421,7 @@ namespace NPC
 
             if (enableDebugLogging)
             {
-                Debug.Log($"Queued path request {id} for {mover.name} -> {goal}.", this);
+                Debug.Log($"Queued path request {id} for {GetMoverName(mover)} -> {goal}.", this);
             }
 
             return id;
@@ -621,7 +621,7 @@ namespace NPC
                     if (enableDebugLogging)
                     {
                         Debug.Log(
-                            $"Discarded stale path request {request.Id} for {mover.name} because request {supersedingId} is newer.",
+                            $"Discarded stale path request {request.Id} for {GetMoverName(mover)} because request {supersedingId} is newer.",
                             this);
                     }
 
@@ -651,7 +651,7 @@ namespace NPC
             }
         }
 
-        private void RemovePendingRequestsForMover(NpcPathMover mover, int supersedingRequestId)
+        private void RemovePendingRequestsForMover(IPathMoverClient mover, int supersedingRequestId)
         {
             if (mover == null)
             {
@@ -673,7 +673,7 @@ namespace NPC
                     discard = true;
                     if (enableDebugLogging)
                     {
-                        Debug.Log($"Discarded pending path request {existing.Id} for {existingMover.name} because request {supersedingRequestId} superseded it.", this);
+                        Debug.Log($"Discarded pending path request {existing.Id} for {GetMoverName(existingMover)} because request {supersedingRequestId} superseded it.", this);
                     }
                 }
 
@@ -685,6 +685,16 @@ namespace NPC
 
                 pendingRequests.Enqueue(existing);
             }
+        }
+
+        private static string GetMoverName(IPathMoverClient mover)
+        {
+            if (mover is Component component)
+            {
+                return component.name;
+            }
+
+            return mover != null ? mover.ToString() : "<null>";
         }
 
         private void RemoveMoverTracking(PathRequest request, bool onlyWhenIdMatches)

--- a/Assets/Scripts/Pets/PetFollower.cs
+++ b/Assets/Scripts/Pets/PetFollower.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using UnityEngine;
 using Player;
 using Player.Movement;
@@ -8,13 +7,17 @@ using NPC;
 namespace Pets
 {
     /// <summary>
-    /// Smoothly follows the player with a small trailing offset.
+    /// Smoothly follows the player and transitions into short wander loops whenever the owner remains idle.
+    /// Navigation-aware movement is delegated to <see cref="PetPathMover"/> which keeps the component lightweight
+    /// while still honouring navigation grids produced by <see cref="PathfindingService"/>.
     /// </summary>
     [RequireComponent(typeof(Rigidbody2D))]
     [RequireComponent(typeof(SpriteRenderer))]
     [RequireComponent(typeof(SpriteDepth))]
+    [RequireComponent(typeof(PetPathMover))]
     public class PetFollower : MonoBehaviour
     {
+        [Header("Follow")]
         public float followRadius = 0.6f;
         public float maxDistance = 2.0f;
         public float moveSpeed = 6f;
@@ -22,66 +25,38 @@ namespace Pets
         public float offsetLerpSpeed = 5f;
         public float headingRefreshAngle = 30f;
 
+        [Header("Idle Wander")]
         public float idleThreshold = 5f;
         public float wanderRadius = 3f;
         public Vector2 wanderDelayRange = new Vector2(1f, 3f);
         public float wanderMoveSpeed = 2f;
 
-        /// <summary>
-        /// When enabled the pet will consult the active NPC navigation grid while wandering so it
-        /// never steps through blocked tiles. Disable to revert to freeform radial wandering for
-        /// scenes that do not provide nav data.
-        /// </summary>
+        [Header("Navigation")]
+        [Tooltip("When enabled the pet samples wander points that align with the active navigation grid.")]
         [SerializeField] private bool respectNavigation = true;
 
-        /// <summary>
-        /// Maximum world-space radius used when sampling wander destinations while navigation is
-        /// respected. This is clamped against <see cref="wanderRadius"/> so designers can keep both
-        /// behaviours aligned.
-        /// </summary>
+        [Tooltip("Maximum radial distance used when sampling navigation-aware wander targets.")]
         [SerializeField, Min(0.1f)] private float navigationSampleRadius = 3f;
 
-        /// <summary>
-        /// Number of times the component will attempt to locate a valid nav-aware wander destination
-        /// before falling back to the legacy random motion. Higher values increase robustness but also
-        /// add extra BFS checks.
-        /// </summary>
+        [Tooltip("Number of attempts made when trying to locate a navigation friendly wander target.")]
         [SerializeField, Min(1)] private int navigationSampleAttempts = 6;
 
-        /// <summary>
-        /// Optional toggle that allows pets to use the active navigation grid while following the
-        /// player. When disabled the component falls back to the legacy smooth-damp chase even if a
-        /// grid exists.
-        /// </summary>
+        [Tooltip("When disabled the follower always relies on smooth damp instead of navigation grids.")]
         [SerializeField] private bool useNavigationForFollowing = true;
 
-        /// <summary>
-        /// Distance in world units considered close enough to a queued navigation waypoint for it to
-        /// be consumed. This mirrors the tolerance used by <see cref="NPC.NpcWanderer"/> so pets feel
-        /// consistent with NPC motion.
-        /// </summary>
         [SerializeField, Min(0.01f)] private float navigationWaypointArrivalThreshold = 0.05f;
-
-        /// <summary>
-        /// Distance threshold that triggers a follow-path rebuild when the player travels a meaningful
-        /// distance without teleporting. Keeps the queued waypoints aligned with the player's latest
-        /// position.
-        /// </summary>
         [SerializeField, Min(0.05f)] private float navigationFollowRebuildDistance = 0.75f;
-
-        /// <summary>
-        /// Teleport detection threshold. When the player moves more than this distance between fixed
-        /// updates the queued navigation path is discarded so the pet can recover immediately.
-        /// </summary>
         [SerializeField, Min(0.5f)] private float navigationFollowTeleportThreshold = 3f;
 
         [SerializeField] private Transform player;
         [SerializeField] private int depthOffset = 1;
-        public Transform Player => player;
+
         private Vector3 offset;
         private Vector3 targetOffset;
         private Vector2 lastHeading;
         private Vector3 lastPlayerPos;
+        private Vector3 followAnchor;
+
         private Rigidbody2D body;
         private SpriteRenderer sprite;
         private SpriteDepth spriteDepth;
@@ -93,28 +68,7 @@ namespace Pets
         private Vector3 wanderTarget;
         private float wanderTimer;
         private bool wandering;
-        private bool usingNavPath;
-        private NavGridBuilder cachedWanderGrid;
-        private int cachedWanderGridRevision = -1;
-        private bool navWanderFailureLogged;
-        private Vector2 navFinalDestination;
-        private Vector2Int navFinalCell;
-        private readonly Queue<Vector2> navWanderWaypoints = new();
-        private readonly Queue<Vector2> navFollowWaypoints = new();
-        private readonly Queue<Vector2Int> navNearestFrontier = new();
-        private readonly HashSet<Vector2Int> navNearestVisited = new();
-        private readonly Queue<Vector2Int> navPathFrontier = new();
-        private readonly HashSet<Vector2Int> navPathVisited = new();
-        private readonly Dictionary<Vector2Int, Vector2Int> navPathCameFrom = new();
-        private readonly List<Vector2Int> navPathBuffer = new();
-        private bool usingNavFollowPath;
-        private Vector2 navFollowFinalDestination;
-        private Vector2Int navFollowFinalCell;
-        private Vector3 lastFollowAnchor;
-        private Vector3 lastPlayerNavSample;
-        private NavGridBuilder cachedFollowGrid;
-        private int cachedFollowGridRevision = -1;
-        private bool navFollowPathDirty = true;
+        private PetPathMover pathMover;
 
         private static readonly Vector2Int[] FourWayOffsets =
         {
@@ -123,6 +77,8 @@ namespace Pets
             new Vector2Int(0, 1),
             new Vector2Int(0, -1)
         };
+
+        public Transform Player => player;
 
         private void Reset()
         {
@@ -133,7 +89,6 @@ namespace Pets
             navigationWaypointArrivalThreshold = 0.05f;
             navigationFollowRebuildDistance = 0.75f;
             navigationFollowTeleportThreshold = 3f;
-            navFollowPathDirty = true;
         }
 
         private void Awake()
@@ -142,11 +97,24 @@ namespace Pets
             sprite = GetComponent<SpriteRenderer>();
             spriteDepth = GetComponent<SpriteDepth>();
             if (spriteDepth == null)
+            {
                 spriteDepth = gameObject.AddComponent<SpriteDepth>();
+            }
+
             spriteDepth.offset = depthOffset;
             spriteAnimator = GetComponent<PetSpriteAnimator>();
+            pathMover = GetComponent<PetPathMover>();
+            if (pathMover != null)
+            {
+                pathMover.FollowAnchorResolver = () => followAnchor;
+                pathMover.WanderDestinationResolver = () => (Vector2)wanderTarget;
+            }
+
             if (player != null)
+            {
                 SetPlayer(player);
+            }
+
             ChooseOffset(Vector2.right);
             offset = targetOffset;
         }
@@ -156,50 +124,72 @@ namespace Pets
             player = newPlayer;
             movementController = null;
             playerSprite = null;
-            navFollowWaypoints.Clear();
-            usingNavFollowPath = false;
-            navFollowPathDirty = true;
+            followAnchor = transform.position;
+
+            if (pathMover != null)
+            {
+                pathMover.ResetFollowTracking();
+                pathMover.ResetWanderTracking();
+            }
+
             if (player != null)
             {
                 lastPlayerPos = player.position;
-                lastPlayerNavSample = player.position;
-                lastFollowAnchor = lastPlayerNavSample;
                 movementController = player.GetComponent<PlayerMovementController>()
                     ?? player.GetComponent<PlayerMover>()?.MovementController;
                 playerSprite = player.GetComponent<SpriteRenderer>();
                 if (playerSprite != null && sprite != null)
+                {
                     sprite.sortingLayerID = playerSprite.sortingLayerID;
+                }
             }
         }
 
         private void ChooseOffset(Vector2 heading)
         {
             if (heading.sqrMagnitude < 0.01f)
+            {
                 heading = Vector2.right;
+            }
+
             targetOffset = (Vector3)(-heading.normalized * followRadius);
         }
 
         private void FixedUpdate()
         {
             if (player == null)
+            {
                 return;
+            }
 
             Vector3 previousPlayerPos = lastPlayerPos;
             Vector3 playerPos = player.position;
             Vector3 playerVel = (playerPos - previousPlayerPos) / Time.fixedDeltaTime;
             lastPlayerPos = playerPos;
-
             bool playerMoving = playerVel.sqrMagnitude > 0.01f;
-            NavGridBuilder activeWanderGrid = respectNavigation ? PathfindingService.Instance?.ActiveGrid : null;
-            bool activeWanderGridValid = activeWanderGrid != null && activeWanderGrid.HasGrid;
+
+            NavGridBuilder activeGrid = PathfindingService.Instance?.ActiveGrid;
+            bool navAvailable = activeGrid != null && activeGrid.HasGrid;
+
+            if (!useNavigationForFollowing)
+            {
+                pathMover?.ResetFollowTracking();
+            }
+
+            if (!respectNavigation || !navAvailable)
+            {
+                pathMover?.ResetWanderTracking();
+            }
 
             if (playerMoving)
             {
                 idleTimer = 0f;
-                wandering = false;
-                usingNavPath = false;
-                navWanderWaypoints.Clear();
-                navWanderFailureLogged = false;
+                if (wandering)
+                {
+                    wandering = false;
+                    pathMover?.ResetWanderTracking();
+                }
+
                 Vector2 heading = ((Vector2)playerVel).normalized;
                 if (lastHeading == Vector2.zero || Vector2.Angle(lastHeading, heading) > headingRefreshAngle)
                 {
@@ -215,619 +205,232 @@ namespace Pets
                     wandering = true;
                     wanderTarget = transform.position;
                     wanderTimer = Random.Range(wanderDelayRange.x, wanderDelayRange.y);
-                    usingNavPath = false;
-                    navWanderWaypoints.Clear();
-                    navWanderFailureLogged = false;
+                    pathMover?.ResetFollowTracking();
                 }
             }
-
-            if (!activeWanderGridValid)
-            {
-                if (cachedWanderGrid != null || cachedWanderGridRevision != -1)
-                {
-                    cachedWanderGrid = null;
-                    cachedWanderGridRevision = -1;
-                    navWanderWaypoints.Clear();
-                    usingNavPath = false;
-                }
-            }
-            else if (activeWanderGrid != cachedWanderGrid || activeWanderGrid.Revision != cachedWanderGridRevision)
-            {
-                cachedWanderGrid = activeWanderGrid;
-                cachedWanderGridRevision = activeWanderGrid.Revision;
-                navWanderWaypoints.Clear();
-                usingNavPath = false;
-
-                if (wandering)
-                {
-                    bool resolvedPath = TryResolveNavWanderPath(playerPos);
-                    usingNavPath = resolvedPath && navWanderWaypoints.Count > 0;
-                    if (usingNavPath)
-                    {
-                        wanderTarget = navFinalDestination;
-                    }
-                    else
-                    {
-                        HandleNavWanderFailure(playerPos, activeWanderGrid);
-                    }
-                }
-            }
-
-            Vector3 newPos;
-            Vector2 velocity;
 
             if (wandering)
             {
-                Vector3 currentPosition = transform.position;
-                if (Vector3.Distance(currentPosition, wanderTarget) < 0.1f)
-                {
-                    wanderTimer -= Time.fixedDeltaTime;
-                    if (wanderTimer <= 0f)
-                    {
-                        bool resolvedPath = TryResolveNavWanderPath(playerPos);
-                        usingNavPath = resolvedPath && navWanderWaypoints.Count > 0;
-                        if (usingNavPath)
-                        {
-                            wanderTarget = navFinalDestination;
-                            wanderTimer = Random.Range(wanderDelayRange.x, wanderDelayRange.y);
-                        }
-                        else
-                        {
-                            bool fallbackResolved = HandleNavWanderFailure(playerPos, activeWanderGridValid ? activeWanderGrid : null);
-                            if (fallbackResolved && wandering)
-                            {
-                                wanderTimer = Random.Range(wanderDelayRange.x, wanderDelayRange.y);
-                            }
-                            else
-                            {
-                                currentVelocity = Vector3.zero;
-                                if (spriteAnimator != null)
-                                    spriteAnimator.UpdateVisuals(Vector2.zero);
-                                return;
-                            }
-                        }
-                    }
-                }
-
-                if (usingNavPath)
-                {
-                    Vector2 current2D = currentPosition;
-                    NavGridBuilder grid = activeWanderGridValid ? activeWanderGrid : null;
-                    if (grid == null || !grid.HasGrid)
-                    {
-                        usingNavPath = false;
-                        navWanderWaypoints.Clear();
-                        newPos = Vector3.SmoothDamp(currentPosition, wanderTarget, ref currentVelocity, smoothTime, wanderMoveSpeed, Time.fixedDeltaTime);
-                        velocity = currentVelocity;
-                    }
-                    else
-                    {
-                        Vector2 nextPos = current2D;
-                        if (navWanderWaypoints.Count > 0)
-                        {
-                            Vector2 waypoint = navWanderWaypoints.Peek();
-                            Vector2 stepped = Vector2.MoveTowards(current2D, waypoint, wanderMoveSpeed * Time.fixedDeltaTime);
-                            Vector2Int currentCell = grid.TryGetCell(current2D, out var cell) ? cell : grid.WorldToCellClamped(current2D);
-                            Vector2Int steppedCell = grid.TryGetCell(stepped, out var steppedLookup) ? steppedLookup : grid.WorldToCellClamped(stepped);
-                            nextPos = steppedCell != currentCell ? grid.GetCellCenter(steppedCell) : stepped;
-
-                            if (Vector2.Distance(nextPos, waypoint) <= navigationWaypointArrivalThreshold)
-                            {
-                                navWanderWaypoints.Dequeue();
-                                if (navWanderWaypoints.Count == 0)
-                                {
-                                    nextPos = grid.GetCellCenter(navFinalCell);
-                                }
-                            }
-                        }
-                        else
-                        {
-                            nextPos = grid.GetCellCenter(navFinalCell);
-                        }
-
-                        newPos = new Vector3(nextPos.x, nextPos.y, currentPosition.z);
-                        velocity = (nextPos - current2D) / Mathf.Max(Time.fixedDeltaTime, 0.0001f);
-                        currentVelocity = velocity;
-                    }
-                }
-                else
-                {
-                    newPos = Vector3.SmoothDamp(currentPosition, wanderTarget, ref currentVelocity, smoothTime, wanderMoveSpeed, Time.fixedDeltaTime);
-                    velocity = currentVelocity;
-                }
-
-                body.MovePosition(newPos);
-
-                if (spriteAnimator != null)
-                    spriteAnimator.UpdateVisuals(velocity);
-                else if (sprite != null)
-                    sprite.flipX = velocity.x > 0f;
-
+                HandleWander(playerPos, activeGrid, navAvailable);
                 return;
             }
 
+            HandleFollow(playerPos, playerMoving, navAvailable);
+        }
+
+        private void HandleFollow(Vector3 playerPos, bool playerMoving, bool navAvailable)
+        {
             offset = Vector3.Lerp(offset, targetOffset, Time.fixedDeltaTime * offsetLerpSpeed);
 
             Vector3 currentPosition = transform.position;
             Vector3 desiredAnchor = playerPos + offset;
             float distanceToAnchor = Vector3.Distance(currentPosition, desiredAnchor);
-            Vector3 followTarget = distanceToAnchor > maxDistance ? playerPos : desiredAnchor;
+            followAnchor = distanceToAnchor > maxDistance ? playerPos : desiredAnchor;
 
-            bool navFollowActive = false;
-            NavGridBuilder activeGrid = useNavigationForFollowing ? PathfindingService.Instance?.ActiveGrid : null;
+            bool navUsed = false;
+            Vector2 navVelocity = Vector2.zero;
 
-            if (useNavigationForFollowing && activeGrid != null && activeGrid.HasGrid)
+            if (useNavigationForFollowing && navAvailable && pathMover != null)
             {
-                bool gridChanged = activeGrid != cachedFollowGrid || activeGrid.Revision != cachedFollowGridRevision;
-                if (gridChanged)
+                bool teleported;
+                Vector2 navNext;
+                if (pathMover.TryStepFollow(
+                        Time.fixedDeltaTime,
+                        moveSpeed,
+                        Mathf.Max(0.1f, followRadius * 0.5f),
+                        navigationWaypointArrivalThreshold,
+                        navigationFollowRebuildDistance,
+                        navigationFollowTeleportThreshold,
+                        out navNext,
+                        out navVelocity,
+                        out teleported))
                 {
-                    cachedFollowGrid = activeGrid;
-                    cachedFollowGridRevision = activeGrid.Revision;
-                    navFollowWaypoints.Clear();
-                    usingNavFollowPath = false;
-                    navFollowPathDirty = true;
-                }
-
-                float playerDisplacement = Vector3.Distance(playerPos, previousPlayerPos);
-                bool teleportDetected = playerDisplacement >= navigationFollowTeleportThreshold;
-                if (teleportDetected)
-                {
-                    navFollowWaypoints.Clear();
-                    usingNavFollowPath = false;
-                    navFollowPathDirty = true;
-                }
-
-                Vector2 followTarget2D = followTarget;
-                Vector2 current2D = currentPosition;
-                Vector2Int targetCell = activeGrid.TryGetCell(followTarget2D, out var lookupGoal)
-                    ? lookupGoal
-                    : activeGrid.WorldToCellClamped(followTarget2D);
-
-                bool destinationShifted = Vector2.Distance(followTarget2D, navFollowFinalDestination) >= navigationFollowRebuildDistance
-                    || targetCell != navFollowFinalCell;
-                bool anchorShifted = Vector3.Distance(followTarget, lastFollowAnchor) >= navigationFollowRebuildDistance;
-                bool playerShifted = Vector3.Distance(playerPos, lastPlayerNavSample) >= navigationFollowRebuildDistance;
-                bool queueExhausted = usingNavFollowPath && navFollowWaypoints.Count == 0
-                    && Vector2.Distance(current2D, navFollowFinalDestination) > navigationWaypointArrivalThreshold;
-
-                if (destinationShifted || anchorShifted || playerShifted || queueExhausted)
-                {
-                    navFollowPathDirty = true;
-                }
-
-                if (navFollowPathDirty)
-                {
-                    if (TryResolveNavFollowPath(current2D, followTarget2D, activeGrid))
+                    Vector3 navPosition3D = new Vector3(navNext.x, navNext.y, currentPosition.z);
+                    if (teleported)
                     {
-                        usingNavFollowPath = true;
-                        navFollowPathDirty = false;
+                        body.position = navPosition3D;
+                        transform.position = navPosition3D;
                     }
                     else
                     {
-                        usingNavFollowPath = false;
-                        navFollowWaypoints.Clear();
-                        navFollowFinalDestination = followTarget2D;
-                        navFollowFinalCell = targetCell;
-                        navFollowPathDirty = false;
-                    }
-                }
-
-                if (usingNavFollowPath)
-                {
-                    Vector2 nextPos = current2D;
-                    if (navFollowWaypoints.Count > 0)
-                    {
-                        Vector2 waypoint = navFollowWaypoints.Peek();
-                        Vector2 stepped = Vector2.MoveTowards(current2D, waypoint, moveSpeed * Time.fixedDeltaTime);
-                        Vector2Int currentCell = activeGrid.TryGetCell(current2D, out var currentLookup)
-                            ? currentLookup
-                            : activeGrid.WorldToCellClamped(current2D);
-                        Vector2Int steppedCell = activeGrid.TryGetCell(stepped, out var steppedLookup)
-                            ? steppedLookup
-                            : activeGrid.WorldToCellClamped(stepped);
-                        nextPos = steppedCell != currentCell ? activeGrid.GetCellCenter(steppedCell) : stepped;
-
-                        if (Vector2.Distance(nextPos, waypoint) <= navigationWaypointArrivalThreshold)
-                        {
-                            navFollowWaypoints.Dequeue();
-                            if (navFollowWaypoints.Count == 0)
-                            {
-                                nextPos = activeGrid.GetCellCenter(navFollowFinalCell);
-                            }
-                        }
-                    }
-                    else
-                    {
-                        nextPos = activeGrid.GetCellCenter(navFollowFinalCell);
-                        if (Vector2.Distance(nextPos, current2D) <= navigationWaypointArrivalThreshold)
-                        {
-                            usingNavFollowPath = false;
-                            navFollowWaypoints.Clear();
-                            nextPos = current2D;
-                        }
+                        body.MovePosition(navPosition3D);
                     }
 
-                    Vector2 delta = nextPos - current2D;
-                    velocity = delta / Mathf.Max(Time.fixedDeltaTime, 0.0001f);
-                    currentVelocity = velocity;
-                    newPos = new Vector3(nextPos.x, nextPos.y, currentPosition.z);
-                    navFollowActive = true;
+                    currentVelocity = new Vector3(navVelocity.x, navVelocity.y, 0f);
+                    navUsed = true;
                 }
             }
-            else if (useNavigationForFollowing && cachedFollowGrid != null)
-            {
-                cachedFollowGrid = null;
-                cachedFollowGridRevision = -1;
-                navFollowWaypoints.Clear();
-                usingNavFollowPath = false;
-                navFollowPathDirty = true;
-            }
 
-            if (!navFollowActive)
+            if (!navUsed)
             {
-                newPos = Vector3.SmoothDamp(currentPosition, followTarget, ref currentVelocity, smoothTime, moveSpeed, Time.fixedDeltaTime);
-                velocity = currentVelocity;
-            }
+                Vector3 smoothPosition = Vector3.SmoothDamp(
+                    currentPosition,
+                    followAnchor,
+                    ref currentVelocity,
+                    smoothTime,
+                    moveSpeed,
+                    Time.fixedDeltaTime);
 
-            body.MovePosition(newPos);
-            lastFollowAnchor = followTarget;
-            lastPlayerNavSample = playerPos;
+                body.MovePosition(smoothPosition);
+            }
 
             if (Vector3.Distance(transform.position, playerPos) < followRadius * 0.5f)
+            {
                 ChooseOffset(lastHeading);
+            }
 
+            Vector2 visualVelocity = navUsed
+                ? navVelocity
+                : new Vector2(currentVelocity.x, currentVelocity.y);
+
+            UpdateVisuals(visualVelocity, playerMoving, navUsed);
+        }
+
+        private void HandleWander(Vector3 playerPos, NavGridBuilder grid, bool navAvailable)
+        {
+            Vector3 currentPosition = transform.position;
+
+            if (Vector3.Distance(currentPosition, wanderTarget) < 0.1f)
+            {
+                wanderTimer -= Time.fixedDeltaTime;
+                if (wanderTimer <= 0f)
+                {
+                    wanderTarget = SampleWanderTarget(playerPos, navAvailable && respectNavigation ? grid : null);
+                    wanderTimer = Random.Range(wanderDelayRange.x, wanderDelayRange.y);
+                    pathMover?.ResetWanderTracking();
+                }
+            }
+
+            bool navUsed = false;
+            Vector2 navVelocity = Vector2.zero;
+
+            if (respectNavigation && navAvailable && pathMover != null)
+            {
+                Vector2 navNext;
+                if (pathMover.TryStepWander(
+                        Time.fixedDeltaTime,
+                        wanderMoveSpeed,
+                        navigationWaypointArrivalThreshold,
+                        navigationWaypointArrivalThreshold,
+                        out navNext,
+                        out navVelocity))
+                {
+                    Vector3 navPosition3D = new Vector3(navNext.x, navNext.y, currentPosition.z);
+                    body.MovePosition(navPosition3D);
+                    currentVelocity = new Vector3(navVelocity.x, navVelocity.y, 0f);
+                    navUsed = true;
+                }
+
+                if (pathMover.HasPendingWanderFailure)
+                {
+                    pathMover.ConsumePendingWanderFailure();
+                    wanderTarget = SampleWanderTarget(playerPos, grid);
+                    pathMover.ResetWanderTracking();
+                    navUsed = false;
+                }
+            }
+
+            if (!navUsed)
+            {
+                Vector3 smoothPosition = Vector3.SmoothDamp(
+                    currentPosition,
+                    wanderTarget,
+                    ref currentVelocity,
+                    smoothTime,
+                    wanderMoveSpeed,
+                    Time.fixedDeltaTime);
+
+                body.MovePosition(smoothPosition);
+            }
+
+            Vector2 visualVelocity = navUsed
+                ? navVelocity
+                : new Vector2(currentVelocity.x, currentVelocity.y);
+
+            UpdateVisuals(visualVelocity, playerMoving: false, navUsed);
+        }
+
+        private Vector3 SampleWanderTarget(Vector3 playerPos, NavGridBuilder grid)
+        {
+            Vector3 origin = transform.position;
+            float baseRadius = Mathf.Max(0.1f, wanderRadius);
+            float sampleRadius = respectNavigation && grid != null
+                ? Mathf.Min(baseRadius, navigationSampleRadius > 0f ? navigationSampleRadius : baseRadius)
+                : baseRadius;
+
+            for (int attempt = 0; attempt < navigationSampleAttempts; attempt++)
+            {
+                Vector2 randomOffset = Random.insideUnitCircle * sampleRadius;
+                Vector2 candidate = origin + (Vector3)randomOffset;
+
+                if (grid == null)
+                {
+                    return candidate;
+                }
+
+                if (grid.TryGetCell(candidate, out var cell) && grid.IsCellWalkable(cell))
+                {
+                    return grid.GetCellCenter(cell);
+                }
+
+                Vector2Int clampedCell = grid.WorldToCellClamped(candidate);
+                if (grid.IsCellWalkable(clampedCell))
+                {
+                    return grid.GetCellCenter(clampedCell);
+                }
+            }
+
+            if (grid != null)
+            {
+                Vector2Int playerCell = grid.WorldToCellClamped(playerPos);
+                if (grid.IsCellWalkable(playerCell))
+                {
+                    return grid.GetCellCenter(playerCell);
+                }
+
+                foreach (Vector2Int offset in FourWayOffsets)
+                {
+                    Vector2Int neighbour = playerCell + offset;
+                    if (grid.IsCellWithinBounds(neighbour) && grid.IsCellWalkable(neighbour))
+                    {
+                        return grid.GetCellCenter(neighbour);
+                    }
+                }
+            }
+
+            return playerPos;
+        }
+
+        private void UpdateVisuals(Vector2 velocity, bool playerMoving, bool navUsed)
+        {
             if (spriteAnimator != null)
             {
                 if (!playerMoving && movementController != null)
+                {
                     spriteAnimator.SetFacing(movementController.FacingDirection);
-                spriteAnimator.UpdateVisuals(playerMoving || navFollowActive ? velocity : Vector2.zero);
-            }
-            else if (sprite != null)
-            {
-                if (!playerMoving && !navFollowActive && movementController != null)
-                    sprite.flipX = Direction8Utility.IsFacingLeft(movementController.FacingDirection);
-                else if (navFollowActive)
-                    sprite.flipX = velocity.x > 0f;
-                else
-                    sprite.flipX = newPos.x > player.position.x;
+                }
+
+                spriteAnimator.UpdateVisuals(velocity);
+                return;
             }
 
+            if (sprite == null)
+            {
+                return;
+            }
+
+            if (!playerMoving && !navUsed && movementController != null)
+            {
+                sprite.flipX = Direction8Utility.IsFacingLeft(movementController.FacingDirection);
+            }
+            else if (navUsed)
+            {
+                sprite.flipX = velocity.x > 0f;
+            }
+            else if (player != null)
+            {
+                sprite.flipX = transform.position.x > player.position.x;
+            }
+        }
     }
-
-        /// <summary>
-        /// Attempts to build a navigation-aware wander path that keeps the pet aligned with walkable
-        /// nav grid tiles. When navigation data is unavailable the method returns <c>false</c> so the
-        /// caller can fall back to the legacy freeform wander behaviour.
-        /// </summary>
-        /// <param name="origin">World position used as the centre for sampling candidate points.</param>
-        /// <returns>True if a queued navigation path was produced.</returns>
-        private bool TryResolveNavWanderPath(Vector2 origin)
-        {
-            navWanderWaypoints.Clear();
-
-            if (!respectNavigation)
-                return false;
-
-            NavGridBuilder grid = PathfindingService.Instance?.ActiveGrid;
-            if (grid == null || !grid.HasGrid)
-                return false;
-
-            float baseRadius = Mathf.Max(0.1f, wanderRadius);
-            float navRadius = navigationSampleRadius > 0f ? navigationSampleRadius : baseRadius;
-            float sampleRadius = Mathf.Min(baseRadius, navRadius > 0f ? navRadius : baseRadius);
-            float searchRadius = Mathf.Max(navRadius, sampleRadius);
-            int maxCellRadius = Mathf.Max(1, Mathf.CeilToInt(searchRadius / Mathf.Max(grid.TileSize, 0.0001f)));
-
-            Vector2 currentPos = transform.position;
-            Vector2Int startCell = grid.TryGetCell(currentPos, out var lookupStart) ? lookupStart : grid.WorldToCellClamped(currentPos);
-            if (!grid.IsCellWalkable(startCell) && !TryFindNearestWalkableCell(startCell, grid, maxCellRadius, out startCell))
-                return false;
-
-            bool sampledCellValid = false;
-            Vector2Int lastSampledCell = startCell;
-
-            for (int attempt = 0; attempt < navigationSampleAttempts; attempt++)
-            {
-                Vector2 candidate = origin + Random.insideUnitCircle * sampleRadius;
-                Vector2Int goalCell = grid.TryGetCell(candidate, out var lookupGoal) ? lookupGoal : grid.WorldToCellClamped(candidate);
-
-                if (!grid.IsCellWalkable(goalCell))
-                {
-                    if (!TryFindNearestWalkableCell(goalCell, grid, maxCellRadius, out goalCell))
-                        continue;
-                }
-
-                sampledCellValid = true;
-                lastSampledCell = goalCell;
-
-                if (!IsWithinCellRadius(startCell, goalCell, maxCellRadius))
-                {
-                    continue;
-                }
-
-                if (!TryBuildPath(startCell, goalCell, grid, maxCellRadius, navWanderWaypoints))
-                {
-                    continue;
-                }
-
-                if (navWanderWaypoints.Count == 0)
-                {
-                    continue;
-                }
-
-                navFinalCell = goalCell;
-                navFinalDestination = grid.GetCellCenter(goalCell);
-                navWanderFailureLogged = false;
-                return true;
-            }
-
-            if (sampledCellValid)
-            {
-                Vector2Int snappedCell = lastSampledCell;
-                if (!TryFindNearestWalkableCell(snappedCell, grid, maxCellRadius, out snappedCell))
-                {
-                    navWanderWaypoints.Clear();
-                    return false;
-                }
-
-                if (snappedCell != startCell && TryBuildPath(startCell, snappedCell, grid, maxCellRadius, navWanderWaypoints) && navWanderWaypoints.Count > 0)
-                {
-                    navFinalCell = snappedCell;
-                    navFinalDestination = grid.GetCellCenter(snappedCell);
-                    navWanderFailureLogged = false;
-                    return true;
-                }
-            }
-
-            navWanderWaypoints.Clear();
-            return false;
-        }
-
-        /// <summary>
-        /// Handles navigation-aware wander failures by attempting to locate a walkable fallback cell. When
-        /// navigation is respected and no fallback exists the pet will idle until the next wander window.
-        /// </summary>
-        private bool HandleNavWanderFailure(Vector2 origin, NavGridBuilder grid)
-        {
-            usingNavPath = false;
-            navWanderWaypoints.Clear();
-
-            if (respectNavigation && grid != null && grid.HasGrid)
-            {
-                if (TryResolveFallbackWanderTarget(origin, grid, out Vector3 fallbackTarget))
-                {
-                    wanderTarget = fallbackTarget;
-                    navWanderFailureLogged = false;
-                    return true;
-                }
-
-                if (!navWanderFailureLogged)
-                {
-                    Debug.LogWarning($"[{nameof(PetFollower)}] Unable to resolve a walkable wander destination for '{name}'. Pet will remain idle until a valid nav cell is available.", this);
-                    navWanderFailureLogged = true;
-                }
-
-                wanderTarget = transform.position;
-                wandering = false;
-                idleTimer = 0f;
-                wanderTimer = 0f;
-                return false;
-            }
-
-            wanderTarget = origin + (Vector3)Random.insideUnitCircle * wanderRadius;
-            navWanderFailureLogged = false;
-            return true;
-        }
-
-        /// <summary>
-        /// Samples a walkable fallback wander destination from the navigation grid so legacy motion can still
-        /// respect blocked cells when nav-aware pathing fails.
-        /// </summary>
-        private bool TryResolveFallbackWanderTarget(Vector2 origin, NavGridBuilder grid, out Vector3 fallbackTarget)
-        {
-            fallbackTarget = transform.position;
-
-            if (grid == null || !grid.HasGrid)
-            {
-                return false;
-            }
-
-            float baseRadius = Mathf.Max(0.1f, wanderRadius);
-            float navRadius = navigationSampleRadius > 0f ? navigationSampleRadius : baseRadius;
-            float sampleRadius = Mathf.Min(baseRadius, navRadius > 0f ? navRadius : baseRadius);
-            float searchRadius = Mathf.Max(navRadius, sampleRadius);
-            int maxCellRadius = Mathf.Max(1, Mathf.CeilToInt(searchRadius / Mathf.Max(grid.TileSize, 0.0001f)));
-
-            Vector2 currentPos = transform.position;
-            Vector2Int startCell = grid.TryGetCell(currentPos, out var lookupStart) ? lookupStart : grid.WorldToCellClamped(currentPos);
-            if (!grid.IsCellWalkable(startCell) && !TryFindNearestWalkableCell(startCell, grid, maxCellRadius, out startCell))
-            {
-                return false;
-            }
-
-            for (int attempt = 0; attempt < navigationSampleAttempts; attempt++)
-            {
-                Vector2 candidate = origin + Random.insideUnitCircle * sampleRadius;
-                Vector2Int goalCell = grid.TryGetCell(candidate, out var lookupGoal) ? lookupGoal : grid.WorldToCellClamped(candidate);
-                if (!grid.IsCellWalkable(goalCell) && !TryFindNearestWalkableCell(goalCell, grid, maxCellRadius, out goalCell))
-                {
-                    continue;
-                }
-
-                if (!IsWithinCellRadius(startCell, goalCell, maxCellRadius))
-                {
-                    continue;
-                }
-
-                fallbackTarget = grid.GetCellCenter(goalCell);
-                return true;
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Mirrors the NPC wanderer helper by scanning for the nearest walkable nav cell around a
-        /// provided seed.
-        /// </summary>
-        private bool TryFindNearestWalkableCell(Vector2Int seed, NavGridBuilder grid, int maxCellRadius, out Vector2Int result)
-        {
-            Queue<Vector2Int> frontier = navNearestFrontier;
-            HashSet<Vector2Int> visited = navNearestVisited;
-            frontier.Clear();
-            visited.Clear();
-            frontier.Enqueue(seed);
-            visited.Add(seed);
-
-            while (frontier.Count > 0)
-            {
-                Vector2Int current = frontier.Dequeue();
-                if (!grid.IsCellWithinBounds(current))
-                    continue;
-
-                if (!IsWithinCellRadius(seed, current, maxCellRadius))
-                    continue;
-
-                if (grid.IsCellWalkable(current))
-                {
-                    result = current;
-                    return true;
-                }
-
-                for (int i = 0; i < FourWayOffsets.Length; i++)
-                {
-                    Vector2Int neighbour = current + FourWayOffsets[i];
-                    if (!grid.IsCellWithinBounds(neighbour))
-                        continue;
-                    if (!IsWithinCellRadius(seed, neighbour, maxCellRadius))
-                        continue;
-                    if (!visited.Add(neighbour))
-                        continue;
-
-                    frontier.Enqueue(neighbour);
-                }
-            }
-
-            result = seed;
-            return false;
-        }
-
-        /// <summary>
-        /// Builds a navigation-aware follow path from the pet's current position to the supplied goal.
-        /// When a path is produced the queued follow waypoints are populated so the FixedUpdate loop
-        /// can consume them incrementally.
-        /// </summary>
-        private bool TryResolveNavFollowPath(Vector2 startWorld, Vector2 goalWorld, NavGridBuilder grid)
-        {
-            navFollowWaypoints.Clear();
-
-            if (grid == null || !grid.HasGrid)
-            {
-                return false;
-            }
-
-            int maxCellRadius = Mathf.Max(1, Mathf.Max(grid.GridSize.x, grid.GridSize.y));
-
-            Vector2Int startCell = grid.TryGetCell(startWorld, out var lookupStart)
-                ? lookupStart
-                : grid.WorldToCellClamped(startWorld);
-            if (!grid.IsCellWalkable(startCell) && !TryFindNearestWalkableCell(startCell, grid, maxCellRadius, out startCell))
-            {
-                return false;
-            }
-
-            Vector2Int goalCell = grid.TryGetCell(goalWorld, out var lookupGoal)
-                ? lookupGoal
-                : grid.WorldToCellClamped(goalWorld);
-            if (!grid.IsCellWalkable(goalCell) && !TryFindNearestWalkableCell(goalCell, grid, maxCellRadius, out goalCell))
-            {
-                return false;
-            }
-
-            navFollowFinalCell = goalCell;
-            navFollowFinalDestination = grid.GetCellCenter(goalCell);
-
-            if (startCell == goalCell)
-            {
-                return true;
-            }
-
-            if (!TryBuildPath(startCell, goalCell, grid, maxCellRadius, navFollowWaypoints))
-            {
-                return false;
-            }
-
-            return navFollowWaypoints.Count > 0;
-        }
-
-        /// <summary>
-        /// Performs a BFS over four-way neighbours to ensure the sampled goal is reachable and populates
-        /// the provided waypoint queue when successful. Shared by the wander and follow helpers so we
-        /// reuse the cached frontier/visited collections without additional allocations.
-        /// </summary>
-        private bool TryBuildPath(Vector2Int startCell, Vector2Int goalCell, NavGridBuilder grid, int maxCellRadius, Queue<Vector2> waypointQueue)
-        {
-            if (startCell == goalCell)
-                return false;
-
-            Queue<Vector2Int> frontier = navPathFrontier;
-            HashSet<Vector2Int> visited = navPathVisited;
-            Dictionary<Vector2Int, Vector2Int> cameFrom = navPathCameFrom;
-            List<Vector2Int> buffer = navPathBuffer;
-            frontier.Clear();
-            visited.Clear();
-            cameFrom.Clear();
-            buffer.Clear();
-
-            frontier.Enqueue(startCell);
-            visited.Add(startCell);
-
-            while (frontier.Count > 0)
-            {
-                Vector2Int current = frontier.Dequeue();
-                if (current == goalCell)
-                {
-                    buffer.Add(current);
-                    while (cameFrom.TryGetValue(current, out Vector2Int parent))
-                    {
-                        buffer.Add(parent);
-                        current = parent;
-                    }
-
-                    waypointQueue.Clear();
-                    for (int i = buffer.Count - 2; i >= 0; i--)
-                    {
-                        Vector2Int cell = buffer[i];
-                        waypointQueue.Enqueue(grid.GetCellCenter(cell));
-                    }
-
-                    return waypointQueue.Count > 0;
-                }
-
-                for (int i = 0; i < FourWayOffsets.Length; i++)
-                {
-                    Vector2Int neighbour = current + FourWayOffsets[i];
-                    if (!grid.IsCellWithinBounds(neighbour))
-                        continue;
-                    if (!IsWithinCellRadius(startCell, neighbour, maxCellRadius))
-                        continue;
-                    if (!grid.IsCellWalkable(neighbour))
-                        continue;
-                    if (!visited.Add(neighbour))
-                        continue;
-
-                    cameFrom[neighbour] = current;
-                    frontier.Enqueue(neighbour);
-                }
-            }
-
-            return false;
-        }
-
-        private static bool IsWithinCellRadius(Vector2Int origin, Vector2Int candidate, int radius)
-        {
-            return Mathf.Abs(candidate.x - origin.x) <= radius && Mathf.Abs(candidate.y - origin.y) <= radius;
-        }
-
-}
 }

--- a/Assets/Scripts/Pets/PetPathMover.cs
+++ b/Assets/Scripts/Pets/PetPathMover.cs
@@ -1,0 +1,541 @@
+using System;
+using System.Collections.Generic;
+using NPC;
+using UnityEngine;
+
+namespace Pets
+{
+    /// <summary>
+    /// Lightweight navigation helper that requests pet-friendly paths from <see cref="PathfindingService"/> and
+    /// exposes the next waypoint to callers. Unlike <see cref="NPC.NpcPathMover"/> this mover does not directly
+    /// drive animation or ticker integration which keeps it lean enough for pets that primarily operate inside
+    /// <see cref="PetFollower"/>.
+    /// </summary>
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(Rigidbody2D))]
+    public sealed class PetPathMover : MonoBehaviour, IPathMoverClient
+    {
+        private enum Mode
+        {
+            None,
+            Follow,
+            Wander
+        }
+
+        [Header("Path Settings")]
+        [Tooltip("Distance considered \"close enough\" to a waypoint before the mover advances to the next entry.")]
+        [SerializeField, Min(0.005f)] private float defaultWaypointTolerance = 0.05f;
+
+        [Tooltip("Cooldown applied after a path request before another replan is permitted.")]
+        [SerializeField, Min(0.05f)] private float repathCooldownSeconds = 0.6f;
+
+        [Tooltip("If the mover fails to make progress for longer than this threshold it forces a replan.")]
+        [SerializeField, Min(0.1f)] private float stuckTimeoutSeconds = 2f;
+
+        [Tooltip("Optional logging toggle used when diagnosing navigation flow in-editor.")]
+        [SerializeField] private bool enableDebugLogging;
+
+        private readonly Queue<Vector2> waypointQueue = new Queue<Vector2>();
+
+        private PathfindingService pathService;
+        private Mode currentMode = Mode.None;
+        private bool awaitingPath;
+        private int activeRequestId = -1;
+        private Vector2 resolvedDestination;
+        private bool hasResolvedDestination;
+        private Vector2 lastRequestedDestination;
+        private bool hasLastRequestedDestination;
+        private float nextAllowedRepathTime;
+        private float lastProgressTimestamp;
+        private Vector2 lastProgressPosition;
+        private bool hasProgressSample;
+        private Vector2 currentVelocity;
+        private bool pendingTeleport;
+        private Vector2 teleportDestination;
+        private bool pendingWanderFailure;
+        private bool serviceReferenceResolved;
+
+        private Func<Vector2> followAnchorResolver;
+        private Func<Vector2> wanderDestinationResolver;
+
+        /// <summary>
+        /// Delegate used to resolve the current follow anchor. Typically assigned by <see cref="PetFollower"/>.
+        /// </summary>
+        public Func<Vector2> FollowAnchorResolver
+        {
+            get => followAnchorResolver;
+            set
+            {
+                followAnchorResolver = value;
+                hasLastRequestedDestination = false;
+            }
+        }
+
+        /// <summary>
+        /// Delegate used to resolve wander targets when a new idle path is needed.
+        /// </summary>
+        public Func<Vector2> WanderDestinationResolver
+        {
+            get => wanderDestinationResolver;
+            set
+            {
+                wanderDestinationResolver = value;
+                hasLastRequestedDestination = false;
+            }
+        }
+
+        /// <summary>
+        /// Latest velocity produced while consuming navigation waypoints. Used by <see cref="PetFollower"/> to
+        /// drive sprites.
+        /// </summary>
+        public Vector2 CurrentVelocity => currentVelocity;
+
+        /// <summary>
+        /// Returns true if the most recent wander request failed because the goal was unreachable. Call
+        /// <see cref="ConsumePendingWanderFailure"/> to clear the flag once it has been processed.
+        /// </summary>
+        public bool HasPendingWanderFailure => pendingWanderFailure;
+
+        /// <summary>
+        /// Clears the wander failure flag so it can fire again on subsequent path attempts.
+        /// </summary>
+        public void ConsumePendingWanderFailure()
+        {
+            pendingWanderFailure = false;
+        }
+
+        /// <summary>
+        /// Provides a follow step using the active navigation grid. When the grid is unavailable the method
+        /// returns <c>false</c> so callers can fall back to smooth damp behaviour.
+        /// </summary>
+        /// <param name="deltaTime">Delta time supplied by <see cref="Time.fixedDeltaTime"/>.</param>
+        /// <param name="moveSpeed">Move speed applied while traversing the path.</param>
+        /// <param name="stopDistance">Preferred stand-off distance from the anchor.</param>
+        /// <param name="waypointTolerance">Distance threshold used when consuming waypoints.</param>
+        /// <param name="replanDistance">Distance the anchor must drift before the mover will queue a new path.</param>
+        /// <param name="teleportDistance">Distance that indicates the anchor teleported, forcing a snap.</param>
+        /// <param name="nextPosition">Next world position along the path.</param>
+        /// <param name="velocity">Velocity to apply for sprite animation.</param>
+        /// <param name="teleported">True if the mover requests an instant teleport to recover.</param>
+        /// <returns>True when navigation data was used to compute movement.</returns>
+        public bool TryStepFollow(
+            float deltaTime,
+            float moveSpeed,
+            float stopDistance,
+            float waypointTolerance,
+            float replanDistance,
+            float teleportDistance,
+            out Vector2 nextPosition,
+            out Vector2 velocity,
+            out bool teleported)
+        {
+            nextPosition = transform.position;
+            velocity = Vector2.zero;
+            teleported = false;
+            currentVelocity = Vector2.zero;
+
+            if (followAnchorResolver == null)
+            {
+                ResetFollowTracking();
+                return false;
+            }
+
+            Vector2 anchor = followAnchorResolver();
+            Vector2 currentPosition = transform.position;
+
+            SwitchMode(Mode.Follow);
+
+            if (pendingTeleport)
+            {
+                pendingTeleport = false;
+                teleported = true;
+                nextPosition = teleportDestination;
+                ClearPathData();
+                return true;
+            }
+
+            if (!EnsureServiceReference())
+            {
+                ResetFollowTracking();
+                return false;
+            }
+
+            var grid = pathService.ActiveGrid;
+            if (grid == null || !grid.HasGrid)
+            {
+                ResetFollowTracking();
+                return false;
+            }
+
+            float anchorDelta = hasLastRequestedDestination
+                ? Vector2.Distance(anchor, lastRequestedDestination)
+                : float.MaxValue;
+
+            bool anchorTeleported = Vector2.Distance(currentPosition, anchor) >= teleportDistance;
+            bool anchorShifted = anchorDelta >= replanDistance;
+            bool destinationShifted = hasResolvedDestination && Vector2.Distance(resolvedDestination, anchor) >= replanDistance;
+
+            if (anchorTeleported)
+            {
+                if (enableDebugLogging)
+                {
+                    Debug.Log($"{name} detected follow anchor teleport. Snapping to {anchor}.", this);
+                }
+
+                teleportDestination = anchor;
+                pendingTeleport = true;
+                teleported = true;
+                nextPosition = teleportDestination;
+                ClearPathData();
+                return true;
+            }
+
+            if (!awaitingPath && (waypointQueue.Count == 0 || anchorShifted || destinationShifted))
+            {
+                RequestPath(currentPosition, anchor, Mode.Follow);
+            }
+            else if (awaitingPath && anchorShifted)
+            {
+                CancelOutstandingRequest();
+                RequestPath(currentPosition, anchor, Mode.Follow);
+            }
+
+            if (awaitingPath)
+            {
+                return false;
+            }
+
+            if (hasResolvedDestination)
+            {
+                float distanceToDestination = Vector2.Distance(currentPosition, resolvedDestination);
+                if (distanceToDestination <= Mathf.Max(stopDistance, waypointTolerance))
+                {
+                    ClearPathData();
+                    return false;
+                }
+            }
+
+            if (waypointQueue.Count == 0)
+            {
+                Vector2 target = hasResolvedDestination ? resolvedDestination : anchor;
+                return StepToward(target, currentPosition, moveSpeed, deltaTime, out nextPosition, out velocity, waypointTolerance, anchor);
+            }
+
+            Vector2 waypoint = waypointQueue.Peek();
+            bool stepped = StepToward(waypoint, currentPosition, moveSpeed, deltaTime, out nextPosition, out velocity, waypointTolerance, anchor);
+
+            if (stepped && Vector2.Distance(nextPosition, waypoint) <= Mathf.Max(waypointTolerance, defaultWaypointTolerance))
+            {
+                waypointQueue.Dequeue();
+            }
+
+            if (Time.time - lastProgressTimestamp >= stuckTimeoutSeconds)
+            {
+                ForceReplan(anchor, currentPosition, Mode.Follow);
+            }
+
+            return stepped;
+        }
+
+        /// <summary>
+        /// Provides a wander step when navigation data is available.
+        /// </summary>
+        public bool TryStepWander(
+            float deltaTime,
+            float moveSpeed,
+            float stopDistance,
+            float waypointTolerance,
+            out Vector2 nextPosition,
+            out Vector2 velocity)
+        {
+            nextPosition = transform.position;
+            velocity = Vector2.zero;
+            currentVelocity = Vector2.zero;
+
+            if (wanderDestinationResolver == null)
+            {
+                ResetWanderTracking();
+                return false;
+            }
+
+            Vector2 target = wanderDestinationResolver();
+            Vector2 currentPosition = transform.position;
+
+            SwitchMode(Mode.Wander);
+
+            if (!EnsureServiceReference())
+            {
+                ResetWanderTracking();
+                return false;
+            }
+
+            var grid = pathService.ActiveGrid;
+            if (grid == null || !grid.HasGrid)
+            {
+                ResetWanderTracking();
+                return false;
+            }
+
+            bool targetShifted = hasLastRequestedDestination
+                ? Vector2.Distance(target, lastRequestedDestination) >= waypointTolerance
+                : true;
+
+            if (!awaitingPath && (waypointQueue.Count == 0 || targetShifted))
+            {
+                RequestPath(currentPosition, target, Mode.Wander);
+            }
+            else if (awaitingPath && targetShifted)
+            {
+                CancelOutstandingRequest();
+                RequestPath(currentPosition, target, Mode.Wander);
+            }
+
+            if (awaitingPath)
+            {
+                return false;
+            }
+
+            if (hasResolvedDestination)
+            {
+                float distanceToDestination = Vector2.Distance(currentPosition, resolvedDestination);
+                if (distanceToDestination <= Mathf.Max(stopDistance, waypointTolerance))
+                {
+                    ClearPathData();
+                    return false;
+                }
+            }
+
+            if (waypointQueue.Count == 0)
+            {
+                Vector2 destination = hasResolvedDestination ? resolvedDestination : target;
+                return StepToward(destination, currentPosition, moveSpeed, deltaTime, out nextPosition, out velocity, waypointTolerance, target);
+            }
+
+            Vector2 waypoint = waypointQueue.Peek();
+            bool stepped = StepToward(waypoint, currentPosition, moveSpeed, deltaTime, out nextPosition, out velocity, waypointTolerance, target);
+
+            if (stepped && Vector2.Distance(nextPosition, waypoint) <= Mathf.Max(waypointTolerance, defaultWaypointTolerance))
+            {
+                waypointQueue.Dequeue();
+            }
+
+            if (Time.time - lastProgressTimestamp >= stuckTimeoutSeconds)
+            {
+                ForceReplan(target, currentPosition, Mode.Wander);
+            }
+
+            return stepped;
+        }
+
+        /// <summary>
+        /// Clears follow state and abandons any queued requests.
+        /// </summary>
+        public void ResetFollowTracking()
+        {
+            if (currentMode == Mode.Follow)
+            {
+                ClearPathData();
+            }
+
+            pendingTeleport = false;
+            hasLastRequestedDestination = false;
+        }
+
+        /// <summary>
+        /// Clears wander state and abandons pending requests.
+        /// </summary>
+        public void ResetWanderTracking()
+        {
+            if (currentMode == Mode.Wander)
+            {
+                ClearPathData();
+            }
+
+            pendingWanderFailure = false;
+            hasLastRequestedDestination = false;
+        }
+
+        /// <inheritdoc />
+        public void HandlePathResult(int requestId, PathfindingService.PathStatus status, List<Vector2> worldPath, Vector2 resolvedGoalWorld)
+        {
+            if (requestId != activeRequestId)
+            {
+                return;
+            }
+
+            awaitingPath = false;
+            activeRequestId = -1;
+            waypointQueue.Clear();
+            hasResolvedDestination = false;
+            currentVelocity = Vector2.zero;
+
+            if (status == PathfindingService.PathStatus.Success && worldPath != null)
+            {
+                hasResolvedDestination = true;
+                resolvedDestination = resolvedGoalWorld;
+
+                for (int i = 0; i < worldPath.Count; i++)
+                {
+                    waypointQueue.Enqueue(worldPath[i]);
+                }
+
+                if (enableDebugLogging)
+                {
+                    Debug.Log($"{name} received pet path with {waypointQueue.Count} waypoints ({currentMode}).", this);
+                }
+
+                pendingWanderFailure = false;
+                lastProgressTimestamp = Time.time;
+                return;
+            }
+
+            if (status == PathfindingService.PathStatus.GoalUnreachable)
+            {
+                if (currentMode == Mode.Follow)
+                {
+                    teleportDestination = resolvedGoalWorld;
+                    pendingTeleport = true;
+                }
+                else if (currentMode == Mode.Wander)
+                {
+                    pendingWanderFailure = true;
+                }
+
+                if (enableDebugLogging)
+                {
+                    Debug.LogWarning($"{name} pet path request {requestId} unreachable during {currentMode}.", this);
+                }
+
+                return;
+            }
+
+            if (enableDebugLogging)
+            {
+                Debug.LogWarning($"{name} pet path request {requestId} failed: {status}.", this);
+            }
+        }
+
+        private bool EnsureServiceReference()
+        {
+            if (serviceReferenceResolved && pathService == null)
+            {
+                return false;
+            }
+
+            if (pathService == null)
+            {
+                pathService = PathfindingService.Instance;
+                serviceReferenceResolved = true;
+            }
+
+            return pathService != null;
+        }
+
+        private void RequestPath(Vector2 start, Vector2 goal, Mode mode)
+        {
+            if (!EnsureServiceReference())
+            {
+                return;
+            }
+
+            if (Time.time < nextAllowedRepathTime)
+            {
+                return;
+            }
+
+            int requestId = pathService.RequestPath(this, start, goal);
+            if (requestId < 0)
+            {
+                return;
+            }
+
+            currentMode = mode;
+            awaitingPath = true;
+            activeRequestId = requestId;
+            lastRequestedDestination = goal;
+            hasLastRequestedDestination = true;
+            nextAllowedRepathTime = Time.time + repathCooldownSeconds;
+            lastProgressTimestamp = Time.time;
+
+            if (enableDebugLogging)
+            {
+                Debug.Log($"{name} queued pet path {requestId} -> {goal}.", this);
+            }
+        }
+
+        private void CancelOutstandingRequest()
+        {
+            awaitingPath = false;
+            activeRequestId = -1;
+        }
+
+        private void ForceReplan(Vector2 goal, Vector2 currentPosition, Mode mode)
+        {
+            if (Time.time < nextAllowedRepathTime)
+            {
+                return;
+            }
+
+            CancelOutstandingRequest();
+            RequestPath(currentPosition, goal, mode);
+        }
+
+        private void SwitchMode(Mode mode)
+        {
+            if (currentMode == mode)
+            {
+                return;
+            }
+
+            ClearPathData();
+            currentMode = mode;
+            pendingTeleport = false;
+            pendingWanderFailure = false;
+            hasLastRequestedDestination = false;
+        }
+
+        private void ClearPathData()
+        {
+            waypointQueue.Clear();
+            awaitingPath = false;
+            activeRequestId = -1;
+            hasResolvedDestination = false;
+            currentVelocity = Vector2.zero;
+            lastProgressTimestamp = Time.time;
+            hasProgressSample = false;
+        }
+
+        private bool StepToward(
+            Vector2 target,
+            Vector2 currentPosition,
+            float moveSpeed,
+            float deltaTime,
+            out Vector2 nextPosition,
+            out Vector2 velocity,
+            float waypointTolerance,
+            Vector2 goalForReplan)
+        {
+            float maxDistance = Mathf.Max(0.0001f, moveSpeed * Mathf.Max(deltaTime, 0.0001f));
+            Vector2 stepped = Vector2.MoveTowards(currentPosition, target, maxDistance);
+            velocity = (stepped - currentPosition) / Mathf.Max(deltaTime, 0.0001f);
+            nextPosition = stepped;
+            currentVelocity = velocity;
+
+            if (velocity.sqrMagnitude > 0.0001f)
+            {
+                lastProgressTimestamp = Time.time;
+                lastProgressPosition = stepped;
+                hasProgressSample = true;
+            }
+            else if (hasProgressSample && Vector2.Distance(stepped, lastProgressPosition) <= waypointTolerance)
+            {
+                if (Time.time - lastProgressTimestamp >= stuckTimeoutSeconds)
+                {
+                    ForceReplan(goalForReplan, currentPosition, currentMode);
+                }
+            }
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce an IPathMoverClient interface so PathfindingService can service both NPC and pet path movers
- add a PetPathMover component that handles follow and wander path queues with stuck/teleport recovery
- refactor PetFollower to drive navigation through the new mover with smooth-damp fallback when grids are unavailable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e043cac858832e9a669a4a1680c058