### PR TITLE
Allow diagonal NPC pathfinding with corner checks

### DIFF
--- a/Assets/Scripts/NPC/Navigation/PathfindingService.cs
+++ b/Assets/Scripts/NPC/Navigation/PathfindingService.cs
@@ -267,6 +267,11 @@ namespace NPC
         /// </summary>
         private const float HeapCostEpsilon = 0.0001f;
 
+        /// <summary>
+        /// Cost assigned to a single diagonal step. Matches the distance covered when traversing a square grid.
+        /// </summary>
+        private static readonly float DiagonalStepCost = Mathf.Sqrt(2f);
+
         private static PathfindingService instance;
 
         [Header("Grid Source")]
@@ -580,12 +585,19 @@ namespace NPC
                         continue;
                     }
 
+                    if (!HasClearDiagonal(current, neighbour, grid))
+                    {
+                        // Prevent cutting through corners by only allowing diagonal traversal when both flank tiles are free.
+                        continue;
+                    }
+
                     if (search.ClosedSet.Contains(neighbour))
                     {
                         continue;
                     }
 
-                    float tentativeG = currentRecord.GCost + 1f;
+                    float stepCost = IsDiagonalMove(current, neighbour) ? DiagonalStepCost : 1f;
+                    float tentativeG = currentRecord.GCost + stepCost;
                     if (!search.Records.TryGetValue(neighbour, out var neighbourRecord) || tentativeG < neighbourRecord.GCost)
                     {
                         neighbourRecord.GCost = tentativeG;
@@ -832,6 +844,12 @@ namespace NPC
                         continue;
                     }
 
+                    if (!HasClearDiagonal(current, neighbour, grid))
+                    {
+                        // Skip diagonals that would clip through blocked corners when looking for a fallback target.
+                        continue;
+                    }
+
                     if (!resolveVisited.Add(neighbour))
                     {
                         continue;
@@ -944,15 +962,19 @@ namespace NPC
         }
 
         /// <summary>
-        /// Manhattan distance heuristic for the 4-way grid.
+        /// Octile distance heuristic for an 8-way grid. Remains admissible when diagonal movement is allowed.
         /// </summary>
         private static float Heuristic(Vector2Int a, Vector2Int b)
         {
-            return Mathf.Abs(a.x - b.x) + Mathf.Abs(a.y - b.y);
+            int dx = Mathf.Abs(a.x - b.x);
+            int dy = Mathf.Abs(a.y - b.y);
+            int min = Mathf.Min(dx, dy);
+            int max = Mathf.Max(dx, dy);
+            return (DiagonalStepCost - 1f) * min + max;
         }
 
         /// <summary>
-        /// Enumerates the four orthogonal neighbours of a grid cell.
+        /// Enumerates the eight neighbours (four orthogonal + four diagonal) of a grid cell.
         /// </summary>
         private static IEnumerable<Vector2Int> EnumerateNeighbours(Vector2Int cell)
         {
@@ -960,6 +982,38 @@ namespace NPC
             yield return new Vector2Int(cell.x - 1, cell.y);
             yield return new Vector2Int(cell.x, cell.y + 1);
             yield return new Vector2Int(cell.x, cell.y - 1);
+            yield return new Vector2Int(cell.x + 1, cell.y + 1);
+            yield return new Vector2Int(cell.x + 1, cell.y - 1);
+            yield return new Vector2Int(cell.x - 1, cell.y + 1);
+            yield return new Vector2Int(cell.x - 1, cell.y - 1);
+        }
+
+        /// <summary>
+        /// Returns whether the move between two cells is diagonal on the grid.
+        /// </summary>
+        private static bool IsDiagonalMove(Vector2Int origin, Vector2Int target)
+        {
+            return origin.x != target.x && origin.y != target.y;
+        }
+
+        /// <summary>
+        /// Verifies that a diagonal traversal between two cells is valid by checking the orthogonal flank cells.
+        /// </summary>
+        private static bool HasClearDiagonal(Vector2Int origin, Vector2Int target, NavGridBuilder grid)
+        {
+            if (!IsDiagonalMove(origin, target))
+            {
+                return true;
+            }
+
+            if (grid == null)
+            {
+                return true;
+            }
+
+            Vector2Int horizontal = new Vector2Int(target.x, origin.y);
+            Vector2Int vertical = new Vector2Int(origin.x, target.y);
+            return grid.IsCellWalkable(horizontal) && grid.IsCellWalkable(vertical);
         }
 
         /// <summary>

--- a/Assets/Tests/NpcPathfindingServiceDiagonalTests.cs
+++ b/Assets/Tests/NpcPathfindingServiceDiagonalTests.cs
@@ -1,0 +1,152 @@
+using System.Collections.Generic;
+using System.Reflection;
+using NUnit.Framework;
+using NPC;
+using UnityEngine;
+
+/// <summary>
+/// Regression tests ensuring diagonal navigation honours blocker tiles and still reaches targets.
+/// </summary>
+public sealed class NpcPathfindingServiceDiagonalTests
+{
+    private static readonly FieldInfo AreaSizeField = typeof(NavGridBuilder)
+        .GetField("areaSize", BindingFlags.Instance | BindingFlags.NonPublic);
+
+    /// <summary>
+    /// Configures the grid dimensions before forcing a rebuild so tests can operate on compact lattices.
+    /// </summary>
+    private static void ConfigureGridSize(NavGridBuilder grid, Vector2 areaSize)
+    {
+        Assert.IsNotNull(grid, "Grid reference must be provided for pathfinding tests.");
+        Assert.IsNotNull(AreaSizeField, "NavGridBuilder.areaSize field could not be located via reflection.");
+        AreaSizeField.SetValue(grid, areaSize);
+        grid.BuildGrid();
+    }
+
+    /// <summary>
+    /// Executes a path request and advances the service manually until the mover receives a response.
+    /// </summary>
+    private static TestMover RequestAndResolve(PathfindingService service, NavGridBuilder grid, Vector2Int startCell, Vector2Int goalCell)
+    {
+        var mover = new TestMover();
+        Vector2 startWorld = grid.GetCellCenter(startCell);
+        Vector2 goalWorld = grid.GetCellCenter(goalCell);
+        int requestId = service.RequestPath(mover, startWorld, goalWorld);
+
+        for (int i = 0; i < 64 && !mover.HasResult; i++)
+        {
+            service.OnTick();
+        }
+
+        Assert.IsTrue(mover.HasResult, "Path request {0} never completed during the test.", requestId);
+        return mover;
+    }
+
+    /// <summary>
+    /// Converts returned world positions into grid coordinates for easier verification.
+    /// </summary>
+    private static List<Vector2Int> ConvertWorldPathToCells(NavGridBuilder grid, List<Vector2> worldPath)
+    {
+        var cells = new List<Vector2Int>();
+        if (worldPath == null)
+        {
+            return cells;
+        }
+
+        for (int i = 0; i < worldPath.Count; i++)
+        {
+            cells.Add(grid.WorldToCellClamped(worldPath[i]));
+        }
+
+        return cells;
+    }
+
+    [Test]
+    public void DiagonalMovement_ReachesGoalWhenClear()
+    {
+        var gridGo = new GameObject("TestNavGrid");
+        var serviceGo = new GameObject("TestPathfindingService");
+        var grid = gridGo.AddComponent<NavGridBuilder>();
+        var service = serviceGo.AddComponent<PathfindingService>();
+
+        try
+        {
+            ConfigureGridSize(grid, new Vector2(3f, 3f));
+            service.RegisterNavGrid(grid);
+
+            Vector2Int startCell = new Vector2Int(1, 1);
+            Vector2Int goalCell = new Vector2Int(2, 2);
+
+            TestMover mover = RequestAndResolve(service, grid, startCell, goalCell);
+
+            Assert.AreEqual(PathfindingService.PathStatus.Success, mover.Status, "Path request should succeed when diagonals are open.");
+
+            List<Vector2Int> cells = ConvertWorldPathToCells(grid, mover.Path);
+            Assert.AreEqual(1, cells.Count, "Direct diagonal traversal should only require a single waypoint.");
+            Assert.AreEqual(goalCell, cells[0], "Mover should step directly into the goal cell via the diagonal.");
+        }
+        finally
+        {
+            Object.DestroyImmediate(serviceGo);
+            Object.DestroyImmediate(gridGo);
+        }
+    }
+
+    [Test]
+    public void DiagonalMovement_RespectsCornerBlockers()
+    {
+        var gridGo = new GameObject("TestNavGrid");
+        var serviceGo = new GameObject("TestPathfindingService");
+        var grid = gridGo.AddComponent<NavGridBuilder>();
+        var service = serviceGo.AddComponent<PathfindingService>();
+
+        try
+        {
+            ConfigureGridSize(grid, new Vector2(3f, 3f));
+            service.RegisterNavGrid(grid);
+
+            Vector2Int startCell = new Vector2Int(1, 1);
+            Vector2Int goalCell = new Vector2Int(2, 2);
+            Vector2Int blockedFlank = new Vector2Int(2, 1);
+
+            bool overrideApplied = grid.TrySetManualOverride(blockedFlank, false);
+            Assert.IsTrue(overrideApplied, "Failed to apply manual override that simulates the corner blocker.");
+
+            TestMover mover = RequestAndResolve(service, grid, startCell, goalCell);
+
+            Assert.AreEqual(PathfindingService.PathStatus.Success, mover.Status, "Pathfinder should still reach the goal by routing around the blocker.");
+
+            List<Vector2Int> cells = ConvertWorldPathToCells(grid, mover.Path);
+            Assert.AreEqual(2, cells.Count, "The mover should take two orthogonal steps around the obstacle.");
+            Assert.AreEqual(new Vector2Int(1, 2), cells[0], "First step should move north to avoid the blocked east tile.");
+            Assert.AreEqual(goalCell, cells[1], "Second step should reach the goal after clearing the corner.");
+        }
+        finally
+        {
+            Object.DestroyImmediate(serviceGo);
+            Object.DestroyImmediate(gridGo);
+        }
+    }
+
+    /// <summary>
+    /// Lightweight mover used by the tests to capture asynchronous path results.
+    /// </summary>
+    private sealed class TestMover : IPathMoverClient
+    {
+        public bool HasResult { get; private set; }
+
+        public PathfindingService.PathStatus Status { get; private set; }
+
+        public List<Vector2> Path { get; private set; }
+
+        public Vector2 ResolvedGoal { get; private set; }
+
+        public void HandlePathResult(int requestId, PathfindingService.PathStatus status, List<Vector2> worldPath, Vector2 resolvedGoalWorld)
+        {
+            HasResult = true;
+            Status = status;
+            Path = worldPath;
+            ResolvedGoal = resolvedGoalWorld;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow the pathfinding service to consider diagonal neighbours using an octile heuristic and diagonal movement cost while guarding against corner cutting
- update nearest-walkable resolution to respect diagonal blockers and share the same safety checks
- add edit-mode regression tests that cover successful diagonal travel and blocked-corner routing

## Testing
- not run (Unity editor CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e049976074832e919526085cd72d1c