### PR TITLE
Improve path smoothing and waypoint handling

### DIFF
--- a/Assets/Scripts/NPC/Movement/NpcPathMover.cs
+++ b/Assets/Scripts/NPC/Movement/NpcPathMover.cs
@@ -56,6 +56,7 @@ namespace NPC
         private Vector2 currentStepTarget;
         private Vector2 previousStepPosition;
         private float stepTimer;
+        private float currentStepDuration = Ticker.TickDuration;
         private float lastProgressTimestamp;
         private float nextAllowedRepathTime;
         private float lastDestinationUpdate;
@@ -154,7 +155,7 @@ namespace NPC
             }
 
             stepTimer += Time.deltaTime;
-            float duration = Mathf.Max(0.01f, tileTraverseDuration);
+            float duration = Mathf.Max(0.01f, currentStepDuration);
             float progress = Mathf.Clamp01(stepTimer / duration);
             Vector2 interpolated = Vector2.Lerp(currentStepStart, currentStepTarget, progress);
             ApplyPosition(interpolated, snapToGrid: false);
@@ -211,6 +212,7 @@ namespace NPC
             debugPath.Clear();
             stepping = false;
             activeRequestId = -1;
+            currentStepDuration = Mathf.Max(0.01f, tileTraverseDuration);
             hasDestination = false;
             hasResolvedPathDestination = false;
             resolvedPathDestination = default;
@@ -340,18 +342,60 @@ namespace NPC
             stepTimer = 0f;
             stepping = true;
             lastProgressTimestamp = Time.time;
+            currentStepDuration = ResolveStepDuration(currentStepStart, currentStepTarget);
 
             Vector2 direction = currentStepTarget - currentStepStart;
             if (direction.sqrMagnitude > Mathf.Epsilon)
             {
                 facing?.FaceDirection(direction);
-                float duration = Mathf.Max(0.0001f, tileTraverseDuration);
+                float duration = Mathf.Max(0.0001f, currentStepDuration);
                 UpdateMovementVisuals(direction / duration);
             }
             else
             {
                 UpdateMovementVisuals(Vector2.zero);
             }
+        }
+
+        /// <summary>
+        /// Calculates how long the mover should spend traversing the current segment based on grid distance.
+        /// </summary>
+        private float ResolveStepDuration(Vector2 start, Vector2 target)
+        {
+            float baseDuration = Mathf.Max(0.01f, tileTraverseDuration);
+            var grid = pathService != null ? pathService.ActiveGrid : PathfindingService.Instance?.ActiveGrid;
+
+            if (grid != null && grid.HasGrid)
+            {
+                if (grid.TryGetCell(start, out var startCell) && grid.TryGetCell(target, out var targetCell))
+                {
+                    int dx = Mathf.Abs(targetCell.x - startCell.x);
+                    int dy = Mathf.Abs(targetCell.y - startCell.y);
+                    int steps = Mathf.Max(dx, dy);
+                    if (steps <= 0)
+                    {
+                        return baseDuration;
+                    }
+
+                    return baseDuration * steps;
+                }
+
+                float approxSteps = Vector2.Distance(start, target) / Mathf.Max(0.0001f, grid.TileSize);
+                if (approxSteps > 1f)
+                {
+                    return baseDuration * approxSteps;
+                }
+
+                return baseDuration;
+            }
+
+            float worldDistance = Vector2.Distance(start, target);
+            if (worldDistance <= Mathf.Epsilon)
+            {
+                return baseDuration;
+            }
+
+            return baseDuration * Mathf.Max(1f, worldDistance);
         }
 
         /// <summary>
@@ -667,44 +711,7 @@ namespace NPC
                 return true;
             }
 
-            int x = startCell.x;
-            int y = startCell.y;
-            int endX = goalCell.x;
-            int endY = goalCell.y;
-
-            int dx = Mathf.Abs(endX - x);
-            int dy = Mathf.Abs(endY - y);
-            int stepX = x < endX ? 1 : (x > endX ? -1 : 0);
-            int stepY = y < endY ? 1 : (y > endY ? -1 : 0);
-            int error = dx - dy;
-
-            while (true)
-            {
-                if (!grid.IsCellWalkable(new Vector2Int(x, y)))
-                {
-                    return false;
-                }
-
-                if (x == endX && y == endY)
-                {
-                    break;
-                }
-
-                int error2 = error * 2;
-                if (error2 > -dy)
-                {
-                    error -= dy;
-                    x += stepX;
-                }
-
-                if (error2 < dx)
-                {
-                    error += dx;
-                    y += stepY;
-                }
-            }
-
-            return true;
+            return grid.HasClearLineBetweenCells(startCell, goalCell);
         }
 
         /// <summary>

--- a/Assets/Scripts/NPC/Navigation/PathfindingService.cs
+++ b/Assets/Scripts/NPC/Navigation/PathfindingService.cs
@@ -281,6 +281,13 @@ namespace NPC
         [Tooltip("Maximum number of nodes expanded per tick. Lower values spread work across more ticks at the cost of latency.")]
         [SerializeField, Range(4, 512)] private int maxNodesPerTick = 128;
 
+        [Header("Smoothing")]
+        [Tooltip("Removes redundant intermediate cells from generated paths so movers follow cleaner corridors.")]
+        [SerializeField] private bool enablePathSmoothing = true;
+
+        [Tooltip("Attempts to merge straight corridors whenever a clear line exists between cell endpoints.")]
+        [SerializeField] private bool useLineOfSightForSmoothing = true;
+
         [Header("Debug")]
         [Tooltip("Writes verbose logging for path requests and failures.")]
         [SerializeField] private bool enableDebugLogging;
@@ -564,7 +571,8 @@ namespace NPC
                     }
 
                     var pathCells = ReconstructPath(search, current);
-                    var worldPath = ConvertCellsToWorld(pathCells, activeRequest.StartCell);
+                    var smoothedCells = SmoothPathCells(pathCells, activeRequest.StartCell) ?? pathCells;
+                    var worldPath = ConvertCellsToWorld(smoothedCells, activeRequest.StartCell);
                     CompleteRequest(activeRequest, PathStatus.Success, worldPath);
                     activeRequest = null;
                     TryBeginNextRequest();
@@ -942,20 +950,27 @@ namespace NPC
         {
             var grid = instance?.navGrid;
             var path = new List<Vector2>();
-            if (grid == null)
+            if (grid == null || cells == null || cells.Count == 0)
             {
                 return path;
             }
 
+            Vector2Int? lastAddedCell = null;
             for (int i = 0; i < cells.Count; i++)
             {
                 Vector2Int cell = cells[i];
-                if (cell == startCell)
+                if (cell == startCell && !lastAddedCell.HasValue)
+                {
+                    continue;
+                }
+
+                if (lastAddedCell.HasValue && lastAddedCell.Value == cell)
                 {
                     continue;
                 }
 
                 path.Add(grid.GetCellCenter(cell));
+                lastAddedCell = cell;
             }
 
             return path;
@@ -1033,6 +1048,106 @@ namespace NPC
 
             path.Reverse();
             return path;
+        }
+
+        /// <summary>
+        /// Collapses redundant cells from the reconstructed path so movers receive the minimal set of bends.
+        /// Optionally applies a line-of-sight pass that merges straight corridors when nothing blocks the route.
+        /// </summary>
+        private List<Vector2Int> SmoothPathCells(List<Vector2Int> pathCells, Vector2Int startCell)
+        {
+            if (!enablePathSmoothing || pathCells == null || pathCells.Count <= 2)
+            {
+                return pathCells;
+            }
+
+            var collapsed = new List<Vector2Int>(pathCells.Count)
+            {
+                pathCells[0]
+            };
+
+            if (pathCells[0] != startCell)
+            {
+                collapsed.Insert(0, startCell);
+            }
+
+            if (pathCells.Count > 1)
+            {
+                Vector2Int previousDirection = NormalizeDirection(pathCells[1] - pathCells[0]);
+                for (int i = 1; i < pathCells.Count; i++)
+                {
+                    Vector2Int previous = pathCells[i - 1];
+                    Vector2Int current = pathCells[i];
+                    Vector2Int direction = NormalizeDirection(current - previous);
+
+                    if (i > 1 && direction != previousDirection)
+                    {
+                        Vector2Int turnCell = previous;
+                        if (collapsed[collapsed.Count - 1] != turnCell)
+                        {
+                            collapsed.Add(turnCell);
+                        }
+
+                        previousDirection = direction;
+                    }
+                    else if (i == 1)
+                    {
+                        previousDirection = direction;
+                    }
+
+                    if (i == pathCells.Count - 1)
+                    {
+                        if (collapsed[collapsed.Count - 1] != current)
+                        {
+                            collapsed.Add(current);
+                        }
+                    }
+                }
+            }
+
+            if (!useLineOfSightForSmoothing || navGrid == null || !navGrid.HasGrid || collapsed.Count <= 2)
+            {
+                return collapsed;
+            }
+
+            var optimised = new List<Vector2Int>(collapsed.Count)
+            {
+                collapsed[0]
+            };
+
+            int anchorIndex = 0;
+            while (anchorIndex < collapsed.Count - 1)
+            {
+                int nextIndex = anchorIndex + 1;
+                for (int i = collapsed.Count - 1; i > anchorIndex; i--)
+                {
+                    if (navGrid.HasClearLineBetweenCells(collapsed[anchorIndex], collapsed[i]))
+                    {
+                        nextIndex = i;
+                        break;
+                    }
+                }
+
+                Vector2Int nextCell = collapsed[nextIndex];
+                if (optimised[optimised.Count - 1] != nextCell)
+                {
+                    optimised.Add(nextCell);
+                }
+
+                anchorIndex = nextIndex;
+            }
+
+            return optimised;
+        }
+
+        /// <summary>
+        /// Normalises a grid-space delta so each axis is clamped to -1, 0, or 1 for direction comparisons.
+        /// </summary>
+        private static Vector2Int NormalizeDirection(Vector2Int delta)
+        {
+            int x = delta.x == 0 ? 0 : (delta.x > 0 ? 1 : -1);
+            int y = delta.y == 0 ? 0 : (delta.y > 0 ? 1 : -1);
+            return new Vector2Int(x, y);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- add configurable path smoothing that collapses collinear segments and optionally merges clear corridors before generating world waypoints
- adjust NPC mover timing and stop-line checks so longer smoothed segments keep consistent speed and respect the navigation grid

## Testing
- not run (Unity editor play mode required)

------
https://chatgpt.com/codex/tasks/task_e_68e04d3a22c8832eb43866ce374f1ac1