### PR TITLE
Add dynamic nav occupancy tracking and integrate movers

### DIFF
--- a/Assets/Scripts/NPC/Movement/NpcPathMover.cs
+++ b/Assets/Scripts/NPC/Movement/NpcPathMover.cs
@@ -70,6 +70,7 @@ namespace NPC
         private bool wandererSuspended;
         private Vector2 lastManualPosition;
         private bool hasManualPositionSample;
+        private DynamicNavOccupancyService.ReservationHandle activeReservationHandle;
 
         private const float ManualResyncTolerance = 0.01f;
         private const float ManualResyncToleranceSqr = ManualResyncTolerance * ManualResyncTolerance;
@@ -167,6 +168,7 @@ namespace NPC
                 previousStepPosition = currentStepTarget;
                 stepping = false;
                 lastProgressTimestamp = Time.time;
+                activeReservationHandle?.MarkWaypointConsumed();
                 bool advanced = TryAdvanceToNextWaypoint();
                 if (!advanced)
                 {
@@ -216,6 +218,7 @@ namespace NPC
             hasDestination = false;
             hasResolvedPathDestination = false;
             resolvedPathDestination = default;
+            ReleaseReservationHandle();
             TryAdvanceToNextWaypoint();
             UpdateMovementVisuals(Vector2.zero);
         }
@@ -282,6 +285,7 @@ namespace NPC
 
             if (status == PathfindingService.PathStatus.GoalUnreachable)
             {
+                ReleaseReservationHandle();
                 if (enableDebugLogging)
                 {
                     Debug.LogWarning($"NPC {name} path request {requestId} reached fallback -> goal unreachable.", this);
@@ -300,6 +304,7 @@ namespace NPC
 
             if (status != PathfindingService.PathStatus.Success || worldPath == null)
             {
+                ReleaseReservationHandle();
                 if (enableDebugLogging)
                 {
                     Debug.LogWarning($"NPC {name} path request {requestId} failed: {status}.", this);
@@ -558,6 +563,7 @@ namespace NPC
             {
                 if (HasClearStopLine(current, desiredDestination))
                 {
+                    ReleaseReservationHandle();
                     DestinationReached?.Invoke(this);
                     hasDestination = false;
                     hasResolvedPathDestination = false;
@@ -572,6 +578,7 @@ namespace NPC
 
                     if (atResolvedFallback)
                     {
+                        ReleaseReservationHandle();
                         if (enableDebugLogging)
                         {
                             Debug.LogWarning($"NPC {name} reached resolved fallback but cannot see desired destination. Marking goal unreachable.", this);
@@ -643,6 +650,7 @@ namespace NPC
                 return;
             }
 
+            ReleaseReservationHandle();
             if (!force && Time.time < nextAllowedRepathTime)
             {
                 return;
@@ -849,6 +857,49 @@ namespace NPC
                 wanderer.SyncToExternalPosition(syncedPosition);
                 lastManualPosition = syncedPosition;
             }
+        }
+
+        /// <summary>
+        /// Releases the current occupancy reservation so other movers can claim the freed tiles.
+        /// </summary>
+        private void ReleaseReservationHandle()
+        {
+            if (activeReservationHandle == null)
+            {
+                return;
+            }
+
+            activeReservationHandle.ReleaseAll();
+            activeReservationHandle = null;
+        }
+
+        /// <inheritdoc />
+        public int GetReservationRadius()
+        {
+            return 0;
+        }
+
+        /// <inheritdoc />
+        public int GetReservationDurationTicks()
+        {
+            float traverseTicks = tileTraverseDuration <= 0f ? 1f : tileTraverseDuration / Ticker.TickDuration;
+            return Mathf.Max(1, Mathf.CeilToInt(traverseTicks) + 1);
+        }
+
+        /// <inheritdoc />
+        public void BindReservationHandle(int requestId, DynamicNavOccupancyService.ReservationHandle handle)
+        {
+            if (handle == activeReservationHandle)
+            {
+                return;
+            }
+
+            if (activeReservationHandle != null)
+            {
+                activeReservationHandle.ReleaseAll();
+            }
+
+            activeReservationHandle = handle;
         }
 
         /// <summary>

--- a/Assets/Scripts/NPC/Navigation/DynamicNavOccupancyService.cs
+++ b/Assets/Scripts/NPC/Navigation/DynamicNavOccupancyService.cs
@@ -1,0 +1,590 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Util;
+using World;
+
+namespace NPC
+{
+    /// <summary>
+    /// Tracks lightweight cell reservations so movers can temporarily claim navigation tiles while planning
+    /// or traversing a path. Reservations expire automatically after the configured tick window which keeps
+    /// searches fair even when multiple NPCs converge on the same choke point.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public sealed class DynamicNavOccupancyService : ScenePersistentObject, ITickable
+    {
+        private struct CellReservation
+        {
+            public WeakReference<IPathMoverClient> MoverReference;
+            public int RequestId;
+            public int ExpiryTick;
+            public int ReferenceCount;
+        }
+
+        /// <summary>
+        /// Handle returned to movers so they can release reservations as they progress through a path.
+        /// </summary>
+        public sealed class ReservationHandle
+        {
+            private readonly DynamicNavOccupancyService owner;
+            private readonly WeakReference<IPathMoverClient> moverReference;
+            private readonly List<List<Vector2Int>> perStepCells;
+            private readonly int requestId;
+            private readonly int expiryTick;
+            private int nextReleaseIndex;
+            private bool released;
+
+            internal ReservationHandle(
+                DynamicNavOccupancyService owner,
+                IPathMoverClient mover,
+                int requestId,
+                List<List<Vector2Int>> perStepCells,
+                int expiryTick)
+            {
+                this.owner = owner;
+                moverReference = new WeakReference<IPathMoverClient>(mover);
+                this.requestId = requestId;
+                this.perStepCells = perStepCells ?? new List<List<Vector2Int>>();
+                this.expiryTick = expiryTick;
+                nextReleaseIndex = 0;
+                released = false;
+            }
+
+            /// <summary>
+            /// Request identifier associated with this reservation.
+            /// </summary>
+            public int RequestId => requestId;
+
+            /// <summary>
+            /// Returns true once the handle has released all reservations and is no longer valid.
+            /// </summary>
+            public bool IsReleased => released;
+
+            internal bool TryGetMover(out IPathMoverClient mover)
+            {
+                return moverReference.TryGetTarget(out mover) && mover != null;
+            }
+
+            internal IReadOnlyList<List<Vector2Int>> Footprint => perStepCells;
+
+            internal int NextReleaseIndex => nextReleaseIndex;
+
+            internal int ExpiryTick => expiryTick;
+
+            internal void AdvanceReleaseIndex()
+            {
+                nextReleaseIndex = Mathf.Min(nextReleaseIndex + 1, perStepCells.Count);
+            }
+
+            internal void MarkReleased()
+            {
+                released = true;
+            }
+
+            /// <summary>
+            /// Releases the next reservation slice, typically after the mover finishes traversing a waypoint.
+            /// </summary>
+            public void MarkWaypointConsumed()
+            {
+                if (released)
+                {
+                    return;
+                }
+
+                owner?.ReleaseNextStep(this);
+            }
+
+            /// <summary>
+            /// Releases all reservations owned by this handle.
+            /// </summary>
+            public void ReleaseAll()
+            {
+                if (released)
+                {
+                    return;
+                }
+
+                owner?.ReleaseHandle(this);
+            }
+        }
+
+        [Header("Debug")]
+        [Tooltip("Enables verbose logging for reservation claims and releases.")]
+        [SerializeField] private bool enableDebugLogging;
+
+        private readonly Dictionary<Vector2Int, CellReservation> reservations = new Dictionary<Vector2Int, CellReservation>();
+        private readonly Dictionary<IPathMoverClient, ReservationHandle> handlesByMover = new Dictionary<IPathMoverClient, ReservationHandle>();
+        private readonly List<Vector2Int> footprintBuffer = new List<Vector2Int>();
+        private readonly List<ReservationHandle> handleCleanupBuffer = new List<ReservationHandle>();
+
+        private int currentTick;
+        private bool subscribedToTicker;
+        private Coroutine tickerSubscriptionRoutine;
+
+        /// <summary>
+        /// Current navigation tick processed by the service.
+        /// </summary>
+        public int CurrentTick => currentTick;
+
+        /// <summary>
+        /// Raised whenever reservations are removed or expire so queued requests can re-evaluate.
+        /// </summary>
+        public event Action ReservationsChanged;
+
+        private void OnEnable()
+        {
+            SubscribeToTicker();
+        }
+
+        private void Start()
+        {
+            SubscribeToTicker();
+        }
+
+        private void OnDisable()
+        {
+            UnsubscribeFromTicker();
+        }
+
+        private void OnDestroy()
+        {
+            UnsubscribeFromTicker();
+            reservations.Clear();
+            handlesByMover.Clear();
+        }
+
+        /// <inheritdoc />
+        public void OnTick()
+        {
+            currentTick++;
+            CleanupOrphanedHandles();
+
+            if (PurgeExpiredReservations())
+            {
+                ReservationsChanged?.Invoke();
+            }
+        }
+
+        /// <summary>
+        /// Attempts to reserve the supplied grid cells for the mover. The reservation tracks each waypoint in order so
+        /// tiles can be released as progress is reported through <see cref="ReservationHandle.MarkWaypointConsumed"/>.
+        /// </summary>
+        /// <param name="mover">Mover requesting the reservation.</param>
+        /// <param name="requestId">Active request identifier assigned by <see cref="PathfindingService"/>.</param>
+        /// <param name="orderedCells">Ordered grid cells representing the planned route.</param>
+        /// <param name="radius">Radius (in grid cells) applied around each waypoint.</param>
+        /// <param name="durationTicks">Duration the reservation should persist without progress. Non-positive values reserve indefinitely.</param>
+        public ReservationHandle ReservePath(
+            IPathMoverClient mover,
+            int requestId,
+            IReadOnlyList<Vector2Int> orderedCells,
+            int radius,
+            int durationTicks)
+        {
+            if (mover == null || orderedCells == null || orderedCells.Count == 0)
+            {
+                return null;
+            }
+
+            ReleaseReservationsForMover(mover);
+
+            int clampedRadius = Mathf.Max(0, radius);
+            int expiryTick = durationTicks > 0 ? currentTick + durationTicks : -1;
+            var perStepCells = new List<List<Vector2Int>>(orderedCells.Count);
+            bool changed = false;
+
+            for (int i = 0; i < orderedCells.Count; i++)
+            {
+                Vector2Int coreCell = orderedCells[i];
+                BuildFootprint(coreCell, clampedRadius, footprintBuffer);
+                var stepFootprint = new List<Vector2Int>(footprintBuffer.Count);
+
+                for (int j = 0; j < footprintBuffer.Count; j++)
+                {
+                    Vector2Int footprintCell = footprintBuffer[j];
+                    if (AddReservation(footprintCell, mover, requestId, expiryTick))
+                    {
+                        changed = true;
+                    }
+
+                    stepFootprint.Add(footprintCell);
+                }
+
+                perStepCells.Add(stepFootprint);
+            }
+
+            var handle = new ReservationHandle(this, mover, requestId, perStepCells, expiryTick);
+            handlesByMover[mover] = handle;
+
+            if (changed)
+            {
+                ReservationsChanged?.Invoke();
+            }
+
+            if (enableDebugLogging)
+            {
+                Debug.Log($"{GetMoverName(mover)} reserved {orderedCells.Count} cells (radius {clampedRadius}).", this);
+            }
+
+            return handle;
+        }
+
+        /// <summary>
+        /// Returns whether the supplied cell is currently reserved by another mover.
+        /// </summary>
+        /// <param name="cell">Cell being inspected.</param>
+        /// <param name="requester">Mover attempting to use the cell.</param>
+        /// <param name="requestId">Active request identifier for the requester.</param>
+        /// <param name="expiryTick">Outputs the tick when the reservation expires. Returns -1 for indefinite reservations.</param>
+        public bool IsCellReservedForOthers(Vector2Int cell, IPathMoverClient requester, int requestId, out int expiryTick)
+        {
+            expiryTick = -1;
+            if (!reservations.TryGetValue(cell, out var reservation))
+            {
+                return false;
+            }
+
+            if (reservation.ReferenceCount <= 0)
+            {
+                reservations.Remove(cell);
+                return false;
+            }
+
+            if (!reservation.MoverReference.TryGetTarget(out var owner) || owner == null)
+            {
+                reservations.Remove(cell);
+                ReservationsChanged?.Invoke();
+                return false;
+            }
+
+            if (ReferenceEquals(owner, requester) && reservation.RequestId == requestId)
+            {
+                return false;
+            }
+
+            expiryTick = reservation.ExpiryTick;
+            return true;
+        }
+
+        /// <summary>
+        /// Releases any reservations owned by the mover. Called when movers cancel or replace their active path.
+        /// </summary>
+        public void ReleaseReservationsForMover(IPathMoverClient mover)
+        {
+            if (mover == null)
+            {
+                return;
+            }
+
+            if (handlesByMover.TryGetValue(mover, out var handle) && handle != null)
+            {
+                handle.ReleaseAll();
+            }
+        }
+
+        private bool AddReservation(Vector2Int cell, IPathMoverClient mover, int requestId, int expiryTick)
+        {
+            if (!reservations.TryGetValue(cell, out var reservation))
+            {
+                reservation = new CellReservation
+                {
+                    MoverReference = new WeakReference<IPathMoverClient>(mover),
+                    RequestId = requestId,
+                    ExpiryTick = expiryTick,
+                    ReferenceCount = 1
+                };
+
+                reservations[cell] = reservation;
+                return true;
+            }
+
+            if (!reservation.MoverReference.TryGetTarget(out var owner) || owner == null)
+            {
+                reservation.MoverReference = new WeakReference<IPathMoverClient>(mover);
+                reservation.RequestId = requestId;
+                reservation.ReferenceCount = 0;
+            }
+            else if (!ReferenceEquals(owner, mover) || reservation.RequestId != requestId)
+            {
+                // Another mover already claimed this cell. Keep the existing reservation so the caller can reconsider later.
+                return false;
+            }
+
+            reservation.ReferenceCount = Mathf.Max(0, reservation.ReferenceCount) + 1;
+            reservation.ExpiryTick = expiryTick;
+            reservations[cell] = reservation;
+            return true;
+        }
+
+        private bool ReleaseReservationCell(Vector2Int cell, ReservationHandle handle)
+        {
+            if (!reservations.TryGetValue(cell, out var reservation))
+            {
+                return false;
+            }
+
+            if (!handle.TryGetMover(out var mover) || mover == null)
+            {
+                reservations.Remove(cell);
+                return true;
+            }
+
+            if (!reservation.MoverReference.TryGetTarget(out var owner) || owner == null || !ReferenceEquals(owner, mover) ||
+                reservation.RequestId != handle.RequestId)
+            {
+                return false;
+            }
+
+            reservation.ReferenceCount = Mathf.Max(0, reservation.ReferenceCount - 1);
+            if (reservation.ReferenceCount <= 0)
+            {
+                reservations.Remove(cell);
+                return true;
+            }
+
+            reservations[cell] = reservation;
+            return false;
+        }
+
+        private void ReleaseNextStep(ReservationHandle handle)
+        {
+            if (handle == null)
+            {
+                return;
+            }
+
+            var footprint = handle.Footprint;
+            int releaseIndex = handle.NextReleaseIndex;
+            if (releaseIndex >= footprint.Count)
+            {
+                return;
+            }
+
+            bool changed = false;
+            var slice = footprint[releaseIndex];
+            for (int i = 0; i < slice.Count; i++)
+            {
+                if (ReleaseReservationCell(slice[i], handle))
+                {
+                    changed = true;
+                }
+            }
+
+            handle.AdvanceReleaseIndex();
+
+            if (changed)
+            {
+                ReservationsChanged?.Invoke();
+            }
+        }
+
+        private void ReleaseHandle(ReservationHandle handle)
+        {
+            if (handle == null)
+            {
+                return;
+            }
+
+            bool changed = false;
+            var footprint = handle.Footprint;
+            for (int i = handle.NextReleaseIndex; i < footprint.Count; i++)
+            {
+                var slice = footprint[i];
+                for (int j = 0; j < slice.Count; j++)
+                {
+                    if (ReleaseReservationCell(slice[j], handle))
+                    {
+                        changed = true;
+                    }
+                }
+            }
+
+            handle.MarkReleased();
+
+            if (handle.TryGetMover(out var mover) && mover != null)
+            {
+                handlesByMover.Remove(mover);
+            }
+
+            if (changed)
+            {
+                ReservationsChanged?.Invoke();
+            }
+        }
+
+        private void CleanupOrphanedHandles()
+        {
+            handleCleanupBuffer.Clear();
+            foreach (var entry in handlesByMover)
+            {
+                var handle = entry.Value;
+                if (!handle.TryGetMover(out var mover) || mover == null)
+                {
+                    handleCleanupBuffer.Add(handle);
+                    continue;
+                }
+
+                bool hasActiveReservation = false;
+                var footprint = handle.Footprint;
+                for (int i = handle.NextReleaseIndex; i < footprint.Count && !hasActiveReservation; i++)
+                {
+                    var slice = footprint[i];
+                    for (int j = 0; j < slice.Count; j++)
+                    {
+                        if (!reservations.TryGetValue(slice[j], out var reservation))
+                        {
+                            continue;
+                        }
+
+                        if (reservation.ReferenceCount <= 0)
+                        {
+                            continue;
+                        }
+
+                        if (!reservation.MoverReference.TryGetTarget(out var owner) || owner == null)
+                        {
+                            continue;
+                        }
+
+                        if (ReferenceEquals(owner, mover) && reservation.RequestId == handle.RequestId)
+                        {
+                            hasActiveReservation = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (!hasActiveReservation)
+                {
+                    handleCleanupBuffer.Add(handle);
+                }
+            }
+
+            if (handleCleanupBuffer.Count == 0)
+            {
+                return;
+            }
+
+            for (int i = 0; i < handleCleanupBuffer.Count; i++)
+            {
+                ReleaseHandle(handleCleanupBuffer[i]);
+            }
+
+            handleCleanupBuffer.Clear();
+        }
+
+        private bool PurgeExpiredReservations()
+        {
+            bool changed = false;
+            var keys = reservations.Keys;
+            // Copy keys to avoid modifying the dictionary during enumeration.
+            var snapshot = new List<Vector2Int>(keys);
+            for (int i = 0; i < snapshot.Count; i++)
+            {
+                Vector2Int cell = snapshot[i];
+                if (!reservations.TryGetValue(cell, out var reservation))
+                {
+                    continue;
+                }
+
+                if (reservation.ExpiryTick >= 0 && reservation.ExpiryTick <= currentTick)
+                {
+                    reservations.Remove(cell);
+                    changed = true;
+                }
+            }
+
+            return changed;
+        }
+
+        private void BuildFootprint(Vector2Int center, int radius, List<Vector2Int> buffer)
+        {
+            buffer.Clear();
+            if (radius <= 0)
+            {
+                buffer.Add(center);
+                return;
+            }
+
+            for (int dx = -radius; dx <= radius; dx++)
+            {
+                for (int dy = -radius; dy <= radius; dy++)
+                {
+                    buffer.Add(new Vector2Int(center.x + dx, center.y + dy));
+                }
+            }
+        }
+
+        private void SubscribeToTicker()
+        {
+            if (subscribedToTicker)
+            {
+                return;
+            }
+
+            if (Ticker.Instance == null)
+            {
+                if (tickerSubscriptionRoutine == null && isActiveAndEnabled)
+                {
+                    tickerSubscriptionRoutine = StartCoroutine(WaitForTicker());
+                }
+
+                return;
+            }
+
+            Ticker.Instance.Subscribe(this);
+            subscribedToTicker = true;
+        }
+
+        private void UnsubscribeFromTicker()
+        {
+            if (tickerSubscriptionRoutine != null)
+            {
+                StopCoroutine(tickerSubscriptionRoutine);
+                tickerSubscriptionRoutine = null;
+            }
+
+            if (!subscribedToTicker)
+            {
+                return;
+            }
+
+            if (Ticker.Instance != null)
+            {
+                Ticker.Instance.Unsubscribe(this);
+            }
+
+            subscribedToTicker = false;
+        }
+
+        private IEnumerator WaitForTicker()
+        {
+            while (Ticker.Instance == null)
+            {
+                yield return null;
+            }
+
+            tickerSubscriptionRoutine = null;
+
+            if (!isActiveAndEnabled)
+            {
+                yield break;
+            }
+
+            Ticker.Instance.Subscribe(this);
+            subscribedToTicker = true;
+        }
+
+        private static string GetMoverName(IPathMoverClient mover)
+        {
+            if (mover is Component component)
+            {
+                return component.name;
+            }
+
+            return mover != null ? mover.ToString() : "<null>";
+        }
+    }
+}

--- a/Assets/Scripts/NPC/Navigation/IPathMoverClient.cs
+++ b/Assets/Scripts/NPC/Navigation/IPathMoverClient.cs
@@ -17,5 +17,25 @@ namespace NPC
         /// <param name="worldPath">Resolved world-space waypoints. May be <c>null</c> on failure.</param>
         /// <param name="resolvedGoalWorld">World position considered the final destination.</param>
         void HandlePathResult(int requestId, PathfindingService.PathStatus status, List<Vector2> worldPath, Vector2 resolvedGoalWorld);
+
+        /// <summary>
+        /// Radius (in grid cells) that should be reserved around each waypoint while the mover traverses a path.
+        /// </summary>
+        int GetReservationRadius();
+
+        /// <summary>
+        /// Number of ticks a reservation should persist for when no progress is reported. Non-positive values reserve indefinitely.
+        /// </summary>
+        int GetReservationDurationTicks();
+
+        /// <summary>
+        /// Provides the mover with a handle that manages the active reservation for the supplied request.
+        /// The mover should call <see cref="DynamicNavOccupancyService.ReservationHandle.MarkWaypointConsumed"/>
+        /// whenever it advances to the next waypoint and <see cref="DynamicNavOccupancyService.ReservationHandle.ReleaseAll"/>
+        /// when the path is cancelled or completed.
+        /// </summary>
+        /// <param name="requestId">Identifier associated with the reservation.</param>
+        /// <param name="handle">Handle used to release claimed cells. May be <c>null</c> when no reservation is active.</param>
+        void BindReservationHandle(int requestId, DynamicNavOccupancyService.ReservationHandle handle);
     }
 }

--- a/Assets/Scripts/NPC/Navigation/PathfindingService.cs
+++ b/Assets/Scripts/NPC/Navigation/PathfindingService.cs
@@ -45,6 +45,8 @@ namespace NPC
             public bool Prepared;
             public bool UsedStartFallback;
             public int GridRevisionAtStart;
+            public bool WaitingOnOccupancy;
+            public int OccupancyResumeTick;
 
             public PathRequest(int id, IPathMoverClient mover, Vector2 start, Vector2 goal)
             {
@@ -285,6 +287,10 @@ namespace NPC
         [Tooltip("Maximum number of path searches stepped in parallel each tick.")]
         [SerializeField, Range(1, 16)] private int maxConcurrentRequests = 4;
 
+        [Header("Dynamic Occupancy")]
+        [Tooltip("Optional occupancy service that tracks temporary tile reservations while movers follow their paths.")]
+        [SerializeField] private DynamicNavOccupancyService occupancyService;
+
         [Header("Smoothing")]
         [Tooltip("Removes redundant intermediate cells from generated paths so movers follow cleaner corridors.")]
         [SerializeField] private bool enablePathSmoothing = true;
@@ -310,10 +316,12 @@ namespace NPC
         /// </summary>
         private readonly HashSet<Vector2Int> resolveVisited = new HashSet<Vector2Int>();
         private readonly List<PathRequest> activeRequests = new List<PathRequest>();
+        private readonly List<PathRequest> occupancyDelayedRequests = new List<PathRequest>();
         private int nextRequestId = 1;
         private bool subscribedToTicker;
         private Coroutine tickerSubscriptionRoutine;
         private int nextActiveRequestIndex;
+        private bool occupancyServiceSubscribed;
 
         /// <summary>
         /// Active singleton instance.
@@ -343,6 +351,7 @@ namespace NPC
             base.Awake();
             instance = this;
             EnsureGridReference();
+            EnsureOccupancyService();
         }
 
         private void Start()
@@ -359,11 +368,13 @@ namespace NPC
 
             SubscribeToTicker();
             EnsureGridReference();
+            EnsureOccupancyService();
         }
 
         private void OnDisable()
         {
             UnsubscribeFromTicker();
+            DetachOccupancyService();
         }
 
         private void OnDestroy()
@@ -375,6 +386,7 @@ namespace NPC
                 {
                     navGrid.GridRebuilt -= HandleGridRebuilt;
                 }
+                DetachOccupancyService();
                 instance = null;
             }
         }
@@ -458,6 +470,9 @@ namespace NPC
         {
             PruneDeadMoverReferences();
 
+            EnsureOccupancyService();
+            PromoteDelayedRequests();
+
             if (!EnsureGridReference())
             {
                 if (activeRequests.Count > 0)
@@ -524,6 +539,16 @@ namespace NPC
                     continue;
                 }
 
+                if (request.WaitingOnOccupancy)
+                {
+                    if (!occupancyDelayedRequests.Contains(request))
+                    {
+                        occupancyDelayedRequests.Add(request);
+                    }
+
+                    continue;
+                }
+
                 if (IsRequestSuperseded(request, out int supersedingId))
                 {
                     if (enableDebugLogging)
@@ -553,6 +578,8 @@ namespace NPC
                     continue;
                 }
 
+                request.WaitingOnOccupancy = false;
+                request.OccupancyResumeTick = 0;
                 request.GridRevisionAtStart = navGrid != null ? navGrid.Revision : 0;
                 activeRequests.Add(request);
                 startedAny = true;
@@ -688,11 +715,22 @@ namespace NPC
                 return 0;
             }
 
+            bool encounteredReservation = false;
+            bool encounteredIndefiniteReservation = false;
+            int earliestFiniteExpiryTick = int.MaxValue;
+
+            EnsureOccupancyService();
+
             var search = request.Search;
             var grid = navGrid;
 
             if (search.OpenSet.Count == 0)
             {
+                if (TryScheduleRequeueDueToOccupancy(request, encounteredReservation, encounteredIndefiniteReservation, earliestFiniteExpiryTick, out outcome))
+                {
+                    return 0;
+                }
+
                 CompleteRequest(request, PathStatus.GoalUnreachable, null);
                 outcome = RequestStepOutcome.Completed;
                 return 0;
@@ -703,6 +741,11 @@ namespace NPC
             {
                 if (search.OpenSet.Count == 0)
                 {
+                    if (TryScheduleRequeueDueToOccupancy(request, encounteredReservation, encounteredIndefiniteReservation, earliestFiniteExpiryTick, out outcome))
+                    {
+                        return expanded;
+                    }
+
                     CompleteRequest(request, PathStatus.GoalUnreachable, null);
                     outcome = RequestStepOutcome.Completed;
                     return expanded;
@@ -710,6 +753,11 @@ namespace NPC
 
                 if (!search.OpenSet.TryExtractMin(out var currentWrapper))
                 {
+                    if (TryScheduleRequeueDueToOccupancy(request, encounteredReservation, encounteredIndefiniteReservation, earliestFiniteExpiryTick, out outcome))
+                    {
+                        return expanded;
+                    }
+
                     CompleteRequest(request, PathStatus.GoalUnreachable, null);
                     outcome = RequestStepOutcome.Completed;
                     return expanded;
@@ -735,6 +783,26 @@ namespace NPC
 
                 if (current == search.Goal)
                 {
+                    if (occupancyService != null && occupancyService.IsCellReservedForOthers(current, mover, request.Id, out int goalExpiry))
+                    {
+                        encounteredReservation = true;
+                        if (goalExpiry < 0)
+                        {
+                            encounteredIndefiniteReservation = true;
+                        }
+                        else
+                        {
+                            earliestFiniteExpiryTick = Mathf.Min(earliestFiniteExpiryTick, goalExpiry);
+                        }
+
+                        if (TryScheduleRequeueDueToOccupancy(request, encounteredReservation, encounteredIndefiniteReservation, earliestFiniteExpiryTick, out outcome))
+                        {
+                            return expanded;
+                        }
+
+                        continue;
+                    }
+
                     if (IsRequestSuperseded(request, out int supersededDuringCompletion))
                     {
                         if (enableDebugLogging)
@@ -751,7 +819,7 @@ namespace NPC
                     var pathCells = ReconstructPath(search, current);
                     var smoothedCells = SmoothPathCells(pathCells, request.StartCell) ?? pathCells;
                     var worldPath = ConvertCellsToWorld(smoothedCells, request.StartCell);
-                    CompleteRequest(request, PathStatus.Success, worldPath);
+                    CompleteRequest(request, PathStatus.Success, worldPath, smoothedCells);
                     outcome = RequestStepOutcome.Completed;
                     return expanded;
                 }
@@ -781,6 +849,21 @@ namespace NPC
                         continue;
                     }
 
+                    if (occupancyService != null && occupancyService.IsCellReservedForOthers(neighbour, mover, request.Id, out int reservationExpiry))
+                    {
+                        encounteredReservation = true;
+                        if (reservationExpiry < 0)
+                        {
+                            encounteredIndefiniteReservation = true;
+                        }
+                        else
+                        {
+                            earliestFiniteExpiryTick = Mathf.Min(earliestFiniteExpiryTick, reservationExpiry);
+                        }
+
+                        continue;
+                    }
+
                     float stepCost = IsDiagonalMove(current, neighbour) ? DiagonalStepCost : 1f;
                     float tentativeG = currentRecord.GCost + stepCost;
                     if (!search.Records.TryGetValue(neighbour, out var neighbourRecord) || tentativeG < neighbourRecord.GCost)
@@ -799,6 +882,43 @@ namespace NPC
             return expanded;
         }
 
+        private bool TryScheduleRequeueDueToOccupancy(
+            PathRequest request,
+            bool encounteredReservation,
+            bool encounteredIndefiniteReservation,
+            int earliestFiniteExpiryTick,
+            out RequestStepOutcome outcome)
+        {
+            outcome = RequestStepOutcome.Continue;
+
+            if (request == null || !encounteredReservation)
+            {
+                return false;
+            }
+
+            if (!EnsureOccupancyService())
+            {
+                return false;
+            }
+
+            int resumeTick = occupancyService != null ? occupancyService.CurrentTick + 1 : 1;
+            if (!encounteredIndefiniteReservation && earliestFiniteExpiryTick != int.MaxValue)
+            {
+                resumeTick = Mathf.Max(resumeTick, earliestFiniteExpiryTick);
+            }
+
+            request.WaitingOnOccupancy = true;
+            request.OccupancyResumeTick = resumeTick;
+            outcome = RequestStepOutcome.Requeued;
+
+            if (enableDebugLogging)
+            {
+                Debug.Log($"Path request {request.Id} paused for occupancy until tick {resumeTick}.", this);
+            }
+
+            return true;
+        }
+
         /// <summary>
         /// Re-enqueues a request so it can restart after a grid rebuild or other interruption.
         /// </summary>
@@ -814,6 +934,16 @@ namespace NPC
             request.Search.Records.Clear();
             request.Prepared = false;
             latestQueuedRequestIdByMover[request.MoverReference] = request.Id;
+            if (request.WaitingOnOccupancy && EnsureOccupancyService())
+            {
+                if (!occupancyDelayedRequests.Contains(request))
+                {
+                    occupancyDelayedRequests.Add(request);
+                }
+
+                return;
+            }
+
             pendingRequests.Enqueue(request);
         }
 
@@ -1046,7 +1176,7 @@ namespace NPC
         /// <summary>
         /// Dispatches the resolved path back to the requesting mover.
         /// </summary>
-        private void CompleteRequest(PathRequest request, PathStatus status, List<Vector2> worldPath)
+        private void CompleteRequest(PathRequest request, PathStatus status, List<Vector2> worldPath, List<Vector2Int> cellPath = null)
         {
             if (!request.MoverReference.TryGetTarget(out var mover) || mover == null)
             {
@@ -1068,6 +1198,20 @@ namespace NPC
 
             RemoveMoverTracking(request, onlyWhenIdMatches: true);
             mover.HandlePathResult(request.Id, status, worldPath, resolvedGoalWorld);
+
+            if (status == PathStatus.Success && worldPath != null && cellPath != null && cellPath.Count > 0 && EnsureOccupancyService())
+            {
+                int radius = Mathf.Max(0, mover.GetReservationRadius());
+                int duration = mover.GetReservationDurationTicks();
+                var handle = occupancyService != null
+                    ? occupancyService.ReservePath(mover, request.Id, cellPath, radius, duration)
+                    : null;
+                mover.BindReservationHandle(request.Id, handle);
+            }
+            else
+            {
+                mover.BindReservationHandle(request.Id, null);
+            }
         }
 
         /// <summary>
@@ -1275,6 +1419,96 @@ namespace NPC
             int x = delta.x == 0 ? 0 : (delta.x > 0 ? 1 : -1);
             int y = delta.y == 0 ? 0 : (delta.y > 0 ? 1 : -1);
             return new Vector2Int(x, y);
+        }
+
+        /// <summary>
+        /// Ensures the dynamic occupancy service reference is valid and that we are subscribed to reservation change events.
+        /// </summary>
+        private bool EnsureOccupancyService()
+        {
+            if (occupancyService != null)
+            {
+                if (!occupancyServiceSubscribed)
+                {
+                    occupancyService.ReservationsChanged += HandleOccupancyChanged;
+                    occupancyServiceSubscribed = true;
+                }
+
+                return true;
+            }
+
+            var located = FindObjectOfType<DynamicNavOccupancyService>();
+            if (located == null)
+            {
+                return false;
+            }
+
+            occupancyService = located;
+            occupancyService.ReservationsChanged += HandleOccupancyChanged;
+            occupancyServiceSubscribed = true;
+            return true;
+        }
+
+        /// <summary>
+        /// Detaches the occupancy service event subscription while preserving the configured reference.
+        /// </summary>
+        private void DetachOccupancyService()
+        {
+            if (occupancyService != null && occupancyServiceSubscribed)
+            {
+                occupancyService.ReservationsChanged -= HandleOccupancyChanged;
+                occupancyServiceSubscribed = false;
+            }
+        }
+
+        /// <summary>
+        /// Reactivates any requests that were waiting on a reservation to expire.
+        /// </summary>
+        private void PromoteDelayedRequests()
+        {
+            if (occupancyDelayedRequests.Count == 0)
+            {
+                return;
+            }
+
+            if (!EnsureOccupancyService())
+            {
+                return;
+            }
+
+            int currentTick = occupancyService != null ? occupancyService.CurrentTick : 0;
+            for (int i = occupancyDelayedRequests.Count - 1; i >= 0; i--)
+            {
+                var request = occupancyDelayedRequests[i];
+                if (request == null)
+                {
+                    occupancyDelayedRequests.RemoveAt(i);
+                    continue;
+                }
+
+                if (!request.WaitingOnOccupancy)
+                {
+                    occupancyDelayedRequests.RemoveAt(i);
+                    pendingRequests.Enqueue(request);
+                    continue;
+                }
+
+                if (currentTick >= request.OccupancyResumeTick)
+                {
+                    request.WaitingOnOccupancy = false;
+                    request.OccupancyResumeTick = 0;
+                    occupancyDelayedRequests.RemoveAt(i);
+                    pendingRequests.Enqueue(request);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Called whenever the occupancy service clears reservations so pending requests can retry quickly.
+        /// </summary>
+        private void HandleOccupancyChanged()
+        {
+            PromoteDelayedRequests();
         }
 
         /// <summary>

--- a/Assets/Scripts/Pets/PetPathMover.cs
+++ b/Assets/Scripts/Pets/PetPathMover.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using NPC;
 using UnityEngine;
+using Util;
 
 namespace Pets
 {
@@ -55,6 +56,7 @@ namespace Pets
         private bool pendingWanderFailure;
         // Tracks whether we have already warned about the missing pathfinding service to avoid log spam while waiting.
         private bool hasLoggedMissingService;
+        private DynamicNavOccupancyService.ReservationHandle activeReservationHandle;
 
         private Func<Vector2> followAnchorResolver;
         private Func<Vector2> wanderDestinationResolver;
@@ -228,6 +230,7 @@ namespace Pets
             if (stepped && Vector2.Distance(nextPosition, waypoint) <= Mathf.Max(waypointTolerance, defaultWaypointTolerance))
             {
                 waypointQueue.Dequeue();
+                activeReservationHandle?.MarkWaypointConsumed();
             }
 
             if (Time.time - lastProgressTimestamp >= stuckTimeoutSeconds)
@@ -318,6 +321,7 @@ namespace Pets
             if (stepped && Vector2.Distance(nextPosition, waypoint) <= Mathf.Max(waypointTolerance, defaultWaypointTolerance))
             {
                 waypointQueue.Dequeue();
+                activeReservationHandle?.MarkWaypointConsumed();
             }
 
             if (Time.time - lastProgressTimestamp >= stuckTimeoutSeconds)
@@ -340,6 +344,7 @@ namespace Pets
 
             pendingTeleport = false;
             hasLastRequestedDestination = false;
+            ReleaseReservationHandle();
         }
 
         /// <summary>
@@ -354,6 +359,7 @@ namespace Pets
 
             pendingWanderFailure = false;
             hasLastRequestedDestination = false;
+            ReleaseReservationHandle();
         }
 
         /// <inheritdoc />
@@ -392,6 +398,7 @@ namespace Pets
 
             if (status == PathfindingService.PathStatus.GoalUnreachable)
             {
+                ReleaseReservationHandle();
                 if (currentMode == Mode.Follow)
                 {
                     teleportDestination = resolvedGoalWorld;
@@ -410,6 +417,7 @@ namespace Pets
                 return;
             }
 
+            ReleaseReservationHandle();
             if (enableDebugLogging)
             {
                 Debug.LogWarning($"{name} pet path request {requestId} failed: {status}.", this);
@@ -476,6 +484,7 @@ namespace Pets
         {
             awaitingPath = false;
             activeRequestId = -1;
+            ReleaseReservationHandle();
         }
 
         private void ForceReplan(Vector2 goal, Vector2 currentPosition, Mode mode)
@@ -505,6 +514,7 @@ namespace Pets
 
         private void ClearPathData()
         {
+            ReleaseReservationHandle();
             waypointQueue.Clear();
             awaitingPath = false;
             activeRequestId = -1;
@@ -545,6 +555,43 @@ namespace Pets
             }
 
             return true;
+        }
+
+        private void ReleaseReservationHandle()
+        {
+            if (activeReservationHandle == null)
+            {
+                return;
+            }
+
+            activeReservationHandle.ReleaseAll();
+            activeReservationHandle = null;
+        }
+
+        public int GetReservationRadius()
+        {
+            return 0;
+        }
+
+        public int GetReservationDurationTicks()
+        {
+            float durationTicks = stuckTimeoutSeconds / Mathf.Max(Ticker.TickDuration, 0.0001f);
+            return Mathf.Max(1, Mathf.CeilToInt(durationTicks));
+        }
+
+        public void BindReservationHandle(int requestId, DynamicNavOccupancyService.ReservationHandle handle)
+        {
+            if (handle == activeReservationHandle)
+            {
+                return;
+            }
+
+            if (activeReservationHandle != null)
+            {
+                activeReservationHandle.ReleaseAll();
+            }
+
+            activeReservationHandle = handle;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a DynamicNavOccupancyService to track temporary grid cell reservations per mover
- extend PathfindingService and IPathMoverClient so A* searches respect reservations and movers receive reservation handles
- update NpcPathMover and PetPathMover to claim, consume, and release occupancy reservations as they progress

## Testing
- not run (Unity-specific project)


------
https://chatgpt.com/codex/tasks/task_e_68e056c0e70c832eb54004b4a491a024