### PR TITLE
Adjust pet follower velocity resets to avoid idle jitter

### DIFF
--- a/Assets/Scripts/Pets/PetFollower.cs
+++ b/Assets/Scripts/Pets/PetFollower.cs
@@ -334,8 +334,12 @@ namespace Pets
             if (zeroForIdle || zeroForDeadZone)
             {
                 visualVelocity = Vector2.zero;
-                currentVelocity = Vector3.zero;
-                pathMover?.ResetCachedVelocity();
+
+                if (!positionApplied || navTeleported)
+                {
+                    currentVelocity = Vector3.zero;
+                    pathMover?.ResetCachedVelocity();
+                }
             }
 
             UpdateVisuals(visualVelocity, playerMoving, navUsed);
@@ -420,8 +424,12 @@ namespace Pets
             if (zeroForDeadZone)
             {
                 visualVelocity = Vector2.zero;
-                currentVelocity = Vector3.zero;
-                pathMover?.ResetCachedVelocity();
+
+                if (!positionApplied)
+                {
+                    currentVelocity = Vector3.zero;
+                    pathMover?.ResetCachedVelocity();
+                }
             }
 
             UpdateVisuals(visualVelocity, playerMoving: false, navUsed);


### PR DESCRIPTION
## Summary
- gate follow velocity resets so cached navigation velocity persists when a step occurred
- apply the same guard while wandering so pets keep smooth movement after each tick

## Testing
- Not run (Unity editor not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e0e7b55464832ebc0801782af1e8d9