### PR TITLE
Adjust pet follower navigation default behaviour

### DIFF
--- a/Assets/Scripts/Pets/PetFollower.cs
+++ b/Assets/Scripts/Pets/PetFollower.cs
@@ -42,7 +42,7 @@ namespace Pets
         [SerializeField, Min(1)] private int navigationSampleAttempts = 6;
 
         [Tooltip("When disabled the follower always relies on smooth damp instead of navigation grids.")]
-        [SerializeField] private bool useNavigationForFollowing = true;
+        [SerializeField] private bool useNavigationForFollowing = false;
 
         [SerializeField, Min(0.01f)] private float navigationWaypointArrivalThreshold = 0.05f;
         [SerializeField, Min(0.05f)] private float navigationFollowRebuildDistance = 0.75f;
@@ -91,7 +91,7 @@ namespace Pets
             respectNavigation = true;
             navigationSampleRadius = wanderRadius;
             navigationSampleAttempts = 6;
-            useNavigationForFollowing = true;
+            useNavigationForFollowing = false;
             navigationWaypointArrivalThreshold = 0.05f;
             navigationFollowRebuildDistance = 0.75f;
             navigationFollowTeleportThreshold = 3f;
@@ -114,6 +114,13 @@ namespace Pets
             {
                 pathMover.FollowAnchorResolver = () => followAnchor;
                 pathMover.WanderDestinationResolver = () => (Vector2)wanderTarget;
+            }
+
+            if (useNavigationForFollowing)
+            {
+                // Ensure legacy prefab instances adopt the smooth follow default and clear any cached path data.
+                useNavigationForFollowing = false;
+                pathMover?.ResetFollowTracking();
             }
 
             if (player != null)


### PR DESCRIPTION
## Summary
- default pet followers to smooth-damp following by disabling navigation usage on new components and prefabs
- coerce legacy instances at runtime so they reset their follow tracking when navigation-based following is disabled

## Testing
- not run (environment limitation)

------
https://chatgpt.com/codex/tasks/task_e_68e0eaf7b298832ebb9746441e622b14