### PR TITLE
Keep pets stationary while waiting for wander paths

### DIFF
--- a/Assets/Scripts/Pets/PetFollower.cs
+++ b/Assets/Scripts/Pets/PetFollower.cs
@@ -371,9 +371,11 @@ namespace Pets
             }
 
             bool navUsed = false;
+            bool waitingOnNavigation = false;
             Vector2 navVelocity = Vector2.zero;
+            bool navigationEligible = respectNavigation && navAvailable && pathMover != null;
 
-            if (respectNavigation && navAvailable && pathMover != null)
+            if (navigationEligible)
             {
                 Vector2 navNext;
                 if (pathMover.TryStepWander(
@@ -391,17 +393,31 @@ namespace Pets
                     resolvedPosition = navPosition3D;
                     positionApplied = true;
                 }
+                else
+                {
+                    // Navigation is active but still resolving (e.g. awaiting a path), so pause in place.
+                    waitingOnNavigation = true;
+                    currentVelocity = Vector3.zero;
+                    pathMover.ResetCachedVelocity();
+                    body.velocity = Vector2.zero;
+                }
 
                 if (pathMover.HasPendingWanderFailure)
                 {
                     pathMover.ConsumePendingWanderFailure();
                     wanderTarget = SampleWanderTarget(playerPos, grid);
                     pathMover.ResetWanderTracking();
-                    navUsed = false;
+                    waitingOnNavigation = true;
+                    if (!navUsed)
+                    {
+                        currentVelocity = Vector3.zero;
+                        pathMover.ResetCachedVelocity();
+                        body.velocity = Vector2.zero;
+                    }
                 }
             }
 
-            if (!navUsed)
+            if (!navUsed && !navigationEligible)
             {
                 Vector3 smoothPosition = Vector3.SmoothDamp(
                     currentPosition,
@@ -427,12 +443,13 @@ namespace Pets
                 }
             }
 
+            bool zeroForWaiting = waitingOnNavigation;
             bool zeroForDeadZone = visualVelocity.sqrMagnitude <= MovementDeadZoneSqr;
-            if (zeroForDeadZone)
+            if (zeroForDeadZone || zeroForWaiting)
             {
                 visualVelocity = Vector2.zero;
 
-                if (!positionApplied)
+                if (!positionApplied || zeroForWaiting)
                 {
                     currentVelocity = Vector3.zero;
                     pathMover?.ResetCachedVelocity();


### PR DESCRIPTION
## Summary
- prevent pets from using SmoothDamp wander fallback when navigation is available but a path is pending
- ensure idle wander waits in place with zero velocity until the navigation step succeeds or retries
- keep animator velocity at zero while paused so pets visually idle instead of sliding

## Testing
- not run (Unity editor unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0f0a2995c832ea2ab41ec94181580