### PR TITLE
Improve pet attack pathing

### DIFF
--- a/Assets/Scripts/Pets/PetCombatController.cs
+++ b/Assets/Scripts/Pets/PetCombatController.cs
@@ -43,6 +43,9 @@ namespace Pets
         private PetSpriteAnimator spriteAnimator;
         private Sprite defaultSprite;
         private Coroutine spriteSwapRoutine;
+        private PetPathMover pathMover;
+        private Rigidbody2D petRigidbody;
+        private bool hasRigidbody2D;
         private CombatTarget currentTarget;
         private Coroutine attackRoutine;
         private float nextAttackTime;
@@ -88,6 +91,7 @@ namespace Pets
         private void Awake()
         {
             follower = GetComponent<PetFollower>();
+            pathMover = GetComponent<PetPathMover>();
             animator = GetComponent<Animator>();
             spriteRenderer = GetComponent<SpriteRenderer>() ?? GetComponentInChildren<SpriteRenderer>();
             spriteAnimator = GetComponent<PetSpriteAnimator>();
@@ -97,6 +101,10 @@ namespace Pets
                 col.isTrigger = true;
             if (TryGetComponent<Collider2D>(out var col2d))
                 col2d.isTrigger = true;
+            if (TryGetComponent(out petRigidbody))
+            {
+                hasRigidbody2D = true;
+            }
 
             EnsureHitSplatLibrary();
 
@@ -148,30 +156,116 @@ namespace Pets
         private IEnumerator AttackRoutine()
         {
             follower.enabled = false;
+            pathMover?.ResetAttackTracking();
             hasLastNonZeroChaseVelocity = false;
             hasPreviousTargetPosition = false;
             while (currentTarget != null && currentTarget.IsAlive)
             {
                 float deltaTime = Mathf.Max(Time.deltaTime, Mathf.Epsilon);
-                Vector3 pos = transform.position;
-                Vector3 targetPos = currentTarget.transform.position;
-                Vector3 targetDelta = Vector3.zero;
-                if (hasPreviousTargetPosition)
-                    targetDelta = targetPos - previousTargetPosition;
-                previousTargetPosition = targetPos;
+                Vector3 startingPosition = transform.position;
+                Vector3 currentTargetPosition = currentTarget.transform.position;
+                Vector3 targetDelta = hasPreviousTargetPosition ? currentTargetPosition - previousTargetPosition : Vector3.zero;
+                previousTargetPosition = currentTargetPosition;
                 hasPreviousTargetPosition = true;
-                Vector3 newPos = Vector3.MoveTowards(pos, targetPos, moveSpeed * deltaTime);
-                Vector2 velocity = (newPos - pos) / deltaTime;
-                bool hasChaseVelocity = velocity.sqrMagnitude > 0.0001f;
+
+                Vector2 movementVelocity = Vector2.zero;
+                bool hasChaseVelocity = false;
+                Vector2 visualVelocity;
+                bool navigationStepTaken = false;
+                bool goalUnreachable;
+
+                if (pathMover != null && pathMover.isActiveAndEnabled)
+                {
+                    bool teleported;
+                    Vector2 nextPosition;
+                    Vector2 navVelocity;
+                    navigationStepTaken = pathMover.TryStepAttack(
+                        deltaTime,
+                        moveSpeed,
+                        CombatMath.MELEE_RANGE * 0.5f,
+                        0.1f,
+                        ResolveAttackTargetPosition,
+                        CombatMath.MELEE_RANGE * 0.75f,
+                        CombatMath.MELEE_RANGE * 6f,
+                        out nextPosition,
+                        out navVelocity,
+                        out teleported,
+                        out goalUnreachable);
+
+                    if (goalUnreachable)
+                    {
+                        ApplyVisualVelocity(Vector2.zero);
+                        break;
+                    }
+
+                    if (navigationStepTaken)
+                    {
+                        if (hasRigidbody2D)
+                        {
+                            if (teleported)
+                            {
+                                petRigidbody.position = nextPosition;
+                                petRigidbody.velocity = Vector2.zero;
+                            }
+                            else
+                            {
+                                petRigidbody.MovePosition(nextPosition);
+                                petRigidbody.velocity = navVelocity;
+                            }
+                        }
+                        else
+                        {
+                            transform.position = nextPosition;
+                        }
+
+                        movementVelocity = navVelocity;
+                        hasChaseVelocity = movementVelocity.sqrMagnitude > 0.0001f;
+                    }
+                }
+                else
+                {
+                    goalUnreachable = false;
+                }
+
+                bool navigationUnavailable = pathMover == null || !pathMover.isActiveAndEnabled || !pathMover.HasActiveNavigationGrid;
+
+                if (!navigationStepTaken && navigationUnavailable)
+                {
+                    Vector3 fallbackTargetPosition = currentTarget.transform.position;
+                    Vector3 newPos = Vector3.MoveTowards(startingPosition, fallbackTargetPosition, moveSpeed * deltaTime);
+                    movementVelocity = (newPos - startingPosition) / deltaTime;
+
+                    if (hasRigidbody2D)
+                    {
+                        petRigidbody.MovePosition(newPos);
+                        petRigidbody.velocity = movementVelocity;
+                    }
+                    else
+                    {
+                        transform.position = newPos;
+                    }
+
+                    hasChaseVelocity = movementVelocity.sqrMagnitude > 0.0001f;
+                }
+
+                if (!navigationStepTaken && !navigationUnavailable)
+                {
+                    movementVelocity = Vector2.zero;
+                    if (hasRigidbody2D)
+                    {
+                        petRigidbody.velocity = Vector2.zero;
+                    }
+                }
+
                 if (hasChaseVelocity)
                 {
-                    lastNonZeroChaseVelocity = velocity;
+                    lastNonZeroChaseVelocity = movementVelocity;
                     hasLastNonZeroChaseVelocity = true;
                 }
-                Vector2 visualVelocity = velocity;
+
+                visualVelocity = movementVelocity;
                 bool targetMovedWhileWaiting = targetDelta.sqrMagnitude > 0.0001f;
                 Vector2 targetMovementVelocity = targetMovedWhileWaiting ? (Vector2)(targetDelta / deltaTime) : Vector2.zero;
-                transform.position = newPos;
 
                 float dist = Vector2.Distance(transform.position, currentTarget.transform.position);
                 if (dist <= CombatMath.MELEE_RANGE)
@@ -412,6 +506,13 @@ namespace Pets
             hasPreviousTargetPosition = false;
             lastNonZeroChaseVelocity = Vector2.zero;
             previousTargetPosition = Vector3.zero;
+            pathMover?.ResetAttackTracking();
+            pathMover?.ResetCachedVelocity();
+
+            if (hasRigidbody2D)
+            {
+                petRigidbody.velocity = Vector2.zero;
+            }
 
             if (spriteSwapRoutine != null)
             {
@@ -442,6 +543,16 @@ namespace Pets
                 spriteAnimator.UpdateVisuals(velocity);
             else if (spriteRenderer != null)
                 spriteRenderer.flipX = velocity.x > 0f;
+        }
+
+        private Vector2 ResolveAttackTargetPosition()
+        {
+            if (currentTarget == null)
+            {
+                return transform.position;
+            }
+
+            return currentTarget.transform.position;
         }
     }
 }

--- a/Assets/Scripts/Pets/PetPathMover.cs
+++ b/Assets/Scripts/Pets/PetPathMover.cs
@@ -20,6 +20,7 @@ namespace Pets
         {
             None,
             Follow,
+            Attack,
             Wander
         }
 
@@ -54,6 +55,7 @@ namespace Pets
         private bool pendingTeleport;
         private Vector2 teleportDestination;
         private bool pendingWanderFailure;
+        private bool pendingAttackFailure;
         // Tracks whether we have already warned about the missing pathfinding service to avoid log spam while waiting.
         private bool hasLoggedMissingService;
         private DynamicNavOccupancyService.ReservationHandle activeReservationHandle;
@@ -92,6 +94,18 @@ namespace Pets
         /// drive sprites.
         /// </summary>
         public Vector2 CurrentVelocity => currentVelocity;
+
+        /// <summary>
+        /// Indicates whether the mover currently has an active navigation grid available. Callers can use this
+        /// to decide when to fall back to direct movement.
+        /// </summary>
+        public bool HasActiveNavigationGrid
+        {
+            get
+            {
+                return pathService != null && pathService.ActiveGrid != null && pathService.ActiveGrid.HasGrid;
+            }
+        }
 
         /// <summary>
         /// Returns true if the most recent wander request failed because the goal was unreachable. Call
@@ -250,6 +264,152 @@ namespace Pets
         }
 
         /// <summary>
+        /// Provides an attack step mirroring the follow logic while allowing callers to
+        /// supply a bespoke resolver for the target position. This keeps combat code free
+        /// from navigation concerns while ensuring pets correctly path around obstacles to
+        /// reach NPCs.
+        /// </summary>
+        /// <param name="deltaTime">Frame delta used when advancing along the path.</param>
+        /// <param name="moveSpeed">Movement speed applied while pursuing the target.</param>
+        /// <param name="stopDistance">Preferred distance to stop from the resolved goal.</param>
+        /// <param name="waypointTolerance">Tolerance applied when consuming waypoints.</param>
+        /// <param name="targetResolver">Resolver that returns the target position each frame.</param>
+        /// <param name="replanDistance">Distance the target must move before forcing a replan.</param>
+        /// <param name="teleportDistance">Distance that indicates the target teleported.</param>
+        /// <param name="nextPosition">Next world position produced by the path.</param>
+        /// <param name="velocity">Velocity to forward to movement/animation systems.</param>
+        /// <param name="teleported">True if the mover should snap directly to the goal.</param>
+        /// <param name="goalUnreachable">True if the pathfinder reported the goal as unreachable.</param>
+        /// <returns>True when navigation data produced a movement step.</returns>
+        public bool TryStepAttack(
+            float deltaTime,
+            float moveSpeed,
+            float stopDistance,
+            float waypointTolerance,
+            Func<Vector2> targetResolver,
+            float replanDistance,
+            float teleportDistance,
+            out Vector2 nextPosition,
+            out Vector2 velocity,
+            out bool teleported,
+            out bool goalUnreachable)
+        {
+            nextPosition = transform.position;
+            velocity = Vector2.zero;
+            teleported = false;
+            goalUnreachable = pendingAttackFailure;
+            currentVelocity = Vector2.zero;
+
+            if (pendingAttackFailure)
+            {
+                return false;
+            }
+
+            if (targetResolver == null)
+            {
+                ResetAttackTracking();
+                return false;
+            }
+
+            Vector2 target = targetResolver();
+            Vector2 currentPosition = transform.position;
+
+            SwitchMode(Mode.Attack);
+
+            if (pendingTeleport)
+            {
+                pendingTeleport = false;
+                teleported = true;
+                nextPosition = teleportDestination;
+                ClearPathData();
+                return true;
+            }
+
+            if (!EnsureServiceReference())
+            {
+                ResetAttackTracking();
+                return false;
+            }
+
+            var grid = pathService.ActiveGrid;
+            if (grid == null || !grid.HasGrid)
+            {
+                ResetAttackTracking();
+                return false;
+            }
+
+            float targetDelta = hasLastRequestedDestination
+                ? Vector2.Distance(target, lastRequestedDestination)
+                : float.MaxValue;
+
+            bool targetTeleported = Vector2.Distance(currentPosition, target) >= teleportDistance;
+            bool targetShifted = targetDelta >= replanDistance;
+            bool destinationShifted = hasResolvedDestination && Vector2.Distance(resolvedDestination, target) >= replanDistance;
+
+            if (targetTeleported)
+            {
+                if (enableDebugLogging)
+                {
+                    Debug.Log($"{name} detected attack target teleport. Snapping to {target}.", this);
+                }
+
+                teleportDestination = target;
+                pendingTeleport = true;
+                teleported = true;
+                nextPosition = teleportDestination;
+                ClearPathData();
+                return true;
+            }
+
+            if (!awaitingPath && (waypointQueue.Count == 0 || targetShifted || destinationShifted))
+            {
+                RequestPath(currentPosition, target, Mode.Attack);
+            }
+            else if (awaitingPath && targetShifted)
+            {
+                CancelOutstandingRequest();
+                RequestPath(currentPosition, target, Mode.Attack);
+            }
+
+            if (awaitingPath)
+            {
+                return false;
+            }
+
+            if (hasResolvedDestination)
+            {
+                float distanceToDestination = Vector2.Distance(currentPosition, resolvedDestination);
+                if (distanceToDestination <= Mathf.Max(stopDistance, waypointTolerance))
+                {
+                    ClearPathData();
+                    return false;
+                }
+            }
+
+            if (waypointQueue.Count == 0)
+            {
+                Vector2 destination = hasResolvedDestination ? resolvedDestination : target;
+                return StepToward(destination, currentPosition, moveSpeed, deltaTime, out nextPosition, out velocity, waypointTolerance, target);
+            }
+
+            Vector2 waypoint = waypointQueue.Peek();
+            bool stepped = StepToward(waypoint, currentPosition, moveSpeed, deltaTime, out nextPosition, out velocity, waypointTolerance, target);
+
+            if (stepped && Vector2.Distance(nextPosition, waypoint) <= Mathf.Max(waypointTolerance, defaultWaypointTolerance))
+            {
+                waypointQueue.Dequeue();
+                activeReservationHandle?.MarkWaypointConsumed();
+            }
+
+            if (Time.time - lastProgressTimestamp >= stuckTimeoutSeconds)
+            {
+                ForceReplan(target, currentPosition, Mode.Attack);
+            }
+
+            return stepped;
+        }
+
+        /// <summary>
         /// Provides a wander step when navigation data is available.
         /// </summary>
         public bool TryStepWander(
@@ -356,6 +516,22 @@ namespace Pets
         }
 
         /// <summary>
+        /// Clears attack state so future engagements start with a clean navigation slate.
+        /// </summary>
+        public void ResetAttackTracking()
+        {
+            if (currentMode == Mode.Attack)
+            {
+                ClearPathData();
+            }
+
+            pendingTeleport = false;
+            pendingAttackFailure = false;
+            hasLastRequestedDestination = false;
+            ReleaseReservationHandle();
+        }
+
+        /// <summary>
         /// Clears wander state and abandons pending requests.
         /// </summary>
         public void ResetWanderTracking()
@@ -400,6 +576,7 @@ namespace Pets
                 }
 
                 pendingWanderFailure = false;
+                pendingAttackFailure = false;
                 lastProgressTimestamp = Time.time;
                 return;
             }
@@ -415,6 +592,10 @@ namespace Pets
                 else if (currentMode == Mode.Wander)
                 {
                     pendingWanderFailure = true;
+                }
+                else if (currentMode == Mode.Attack)
+                {
+                    pendingAttackFailure = true;
                 }
 
                 if (enableDebugLogging)
@@ -517,6 +698,7 @@ namespace Pets
             currentMode = mode;
             pendingTeleport = false;
             pendingWanderFailure = false;
+            pendingAttackFailure = false;
             hasLastRequestedDestination = false;
         }
 


### PR DESCRIPTION
## Summary
- add an attack navigation mode to `PetPathMover` so pets can request combat paths and track unreachable NPCs
- update `PetCombatController` to move via `PetPathMover` when possible, caching required components and resetting attack navigation on cancel

## Testing
- Not run (Unity editor unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0f308b4dc832eb5280f24c0dad9d9