### PR TITLE
Reset pet movement after melee attacks

### DIFF
--- a/Assets/Scripts/Pets/PetCombatController.cs
+++ b/Assets/Scripts/Pets/PetCombatController.cs
@@ -292,6 +292,15 @@ namespace Pets
 
                     ApplyVisualVelocity(visualVelocity);
                     ResolveAttack(currentTarget);
+
+                    // Reset any residual velocity so the pet remains parked next to the target while waiting for the next swing.
+                    movementVelocity = Vector2.zero;
+                    visualVelocity = Vector2.zero;
+
+                    if (hasRigidbody2D)
+                        petRigidbody.velocity = Vector2.zero;
+
+                    ApplyVisualVelocity(visualVelocity);
                     nextAttackTime = Time.time + definition.attackSpeedTicks * CombatMath.TICK_SECONDS;
                     int waitTicks = definition.attackSpeedTicks;
                     if (currentTarget == null || !currentTarget.IsAlive)


### PR DESCRIPTION
## Summary
- reset the pet combat controller's chase velocity after resolving an attack so pets stay beside their targets
- zero any rigidbody velocity and refresh the animator with a stationary vector during attack cooldowns

## Testing
- not run (Play Mode validation required in the Unity editor)


------
https://chatgpt.com/codex/tasks/task_e_68e10f0b3e9c832eb083ab16e08cdb4b