### PR TITLE
Handle diagonal pet sprite overrides

### DIFF
--- a/Assets/Scripts/Player/Visuals/PlayerSpriteController.cs
+++ b/Assets/Scripts/Player/Visuals/PlayerSpriteController.cs
@@ -94,6 +94,34 @@ namespace Player.Visuals
         }
 
         /// <inheritdoc />
+        public bool UseFlipXForDownLeft
+        {
+            get => useFlipXForDownLeft;
+            set => useFlipXForDownLeft = value;
+        }
+
+        /// <inheritdoc />
+        public bool UseFlipXForUpLeft
+        {
+            get => useFlipXForUpLeft;
+            set => useFlipXForUpLeft = value;
+        }
+
+        /// <inheritdoc />
+        public bool UseFlipXForUpRight
+        {
+            get => useFlipXForUpRight;
+            set => useFlipXForUpRight = value;
+        }
+
+        /// <inheritdoc />
+        public bool UseFlipXForDownRight
+        {
+            get => useFlipXForDownRight;
+            set => useFlipXForDownRight = value;
+        }
+
+        /// <inheritdoc />
         public bool IsPlayingConsumeAnimation => isPlayingConsume;
 
         private void Awake()
@@ -580,6 +608,18 @@ namespace Player.Visuals
 
         /// <summary>Gets or sets whether left-facing sprites should be mirrored for right facings.</summary>
         bool UseFlipXForRight { get; set; }
+
+        /// <summary>Gets or sets whether down-right facings should be mirrored for down-left facings.</summary>
+        bool UseFlipXForDownLeft { get; set; }
+
+        /// <summary>Gets or sets whether up-right facings should be mirrored for up-left facings.</summary>
+        bool UseFlipXForUpLeft { get; set; }
+
+        /// <summary>Gets or sets whether up-left facings should be mirrored for up-right facings.</summary>
+        bool UseFlipXForUpRight { get; set; }
+
+        /// <summary>Gets or sets whether down-left facings should be mirrored for down-right facings.</summary>
+        bool UseFlipXForDownRight { get; set; }
 
         /// <summary>Applies the supplied movement visuals to the animator and sprite renderer.</summary>
         void ApplyMovementVisuals(Direction8 direction, bool isMoving);

--- a/Assets/Scripts/Skills/Beastmaster/PlayerVisualBinder.cs
+++ b/Assets/Scripts/Skills/Beastmaster/PlayerVisualBinder.cs
@@ -18,11 +18,12 @@ namespace Beastmaster
 
         private RuntimeAnimatorController originalController;
         private Sprite originalSprite;
-        private Sprite origIdleDown, origIdleLeft, origIdleRight, origIdleUp;
-        private Sprite origWalkDown, origWalkLeft, origWalkRight, origWalkUp;
+        private Sprite origIdleDown, origIdleDownRight, origIdleRight, origIdleUpRight, origIdleUp, origIdleUpLeft, origIdleLeft, origIdleDownLeft;
+        private Sprite origWalkDown, origWalkDownRight, origWalkRight, origWalkUpRight, origWalkUp, origWalkUpLeft, origWalkLeft, origWalkDownLeft;
         private Vector3 origScale;
         private bool origFlipX;
         private bool origUseFlipXForLeft, origUseFlipXForRight;
+        private bool origUseFlipXForDownLeft, origUseFlipXForUpLeft, origUseFlipXForUpRight, origUseFlipXForDownRight;
 
         private void Awake()
         {
@@ -53,15 +54,27 @@ namespace Beastmaster
             if (spriteController != null)
             {
                 origIdleDown = spriteController.GetIdleSprite(Direction8.Down);
+                origIdleDownRight = spriteController.GetIdleSprite(Direction8.DownRight);
                 origIdleLeft = spriteController.GetIdleSprite(Direction8.Left);
+                origIdleUpLeft = spriteController.GetIdleSprite(Direction8.UpLeft);
                 origIdleRight = spriteController.GetIdleSprite(Direction8.Right);
+                origIdleUpRight = spriteController.GetIdleSprite(Direction8.UpRight);
                 origIdleUp = spriteController.GetIdleSprite(Direction8.Up);
+                origIdleDownLeft = spriteController.GetIdleSprite(Direction8.DownLeft);
                 origWalkDown = spriteController.GetWalkSprite(Direction8.Down);
+                origWalkDownRight = spriteController.GetWalkSprite(Direction8.DownRight);
                 origWalkLeft = spriteController.GetWalkSprite(Direction8.Left);
+                origWalkUpLeft = spriteController.GetWalkSprite(Direction8.UpLeft);
                 origWalkRight = spriteController.GetWalkSprite(Direction8.Right);
+                origWalkUpRight = spriteController.GetWalkSprite(Direction8.UpRight);
                 origWalkUp = spriteController.GetWalkSprite(Direction8.Up);
+                origWalkDownLeft = spriteController.GetWalkSprite(Direction8.DownLeft);
                 origUseFlipXForLeft = spriteController.UseFlipXForLeft;
                 origUseFlipXForRight = spriteController.UseFlipXForRight;
+                origUseFlipXForDownLeft = spriteController.UseFlipXForDownLeft;
+                origUseFlipXForUpLeft = spriteController.UseFlipXForUpLeft;
+                origUseFlipXForUpRight = spriteController.UseFlipXForUpRight;
+                origUseFlipXForDownRight = spriteController.UseFlipXForDownRight;
             }
             origScale = transform.localScale;
             origFlipX = spriteRenderer != null && spriteRenderer.flipX;
@@ -83,26 +96,46 @@ namespace Beastmaster
                 if (profile.controller == null)
                 {
                     if (profile.idleDown != null) spriteController.SetIdleSprite(Direction8.Down, profile.idleDown);
+                    spriteController.SetIdleSprite(Direction8.DownRight, profile.idleDownRight);
                     if (profile.idleLeft != null) spriteController.SetIdleSprite(Direction8.Left, profile.idleLeft);
+                    spriteController.SetIdleSprite(Direction8.UpLeft, profile.idleUpLeft);
                     if (profile.idleRight != null) spriteController.SetIdleSprite(Direction8.Right, profile.idleRight);
+                    spriteController.SetIdleSprite(Direction8.UpRight, profile.idleUpRight);
                     if (profile.idleUp != null) spriteController.SetIdleSprite(Direction8.Up, profile.idleUp);
+                    spriteController.SetIdleSprite(Direction8.DownLeft, profile.idleDownLeft);
                     if (profile.walkDown != null) spriteController.SetWalkSprite(Direction8.Down, profile.walkDown);
+                    spriteController.SetWalkSprite(Direction8.DownRight, profile.walkDownRight);
                     if (profile.walkLeft != null) spriteController.SetWalkSprite(Direction8.Left, profile.walkLeft);
+                    spriteController.SetWalkSprite(Direction8.UpLeft, profile.walkUpLeft);
                     if (profile.walkRight != null) spriteController.SetWalkSprite(Direction8.Right, profile.walkRight);
+                    spriteController.SetWalkSprite(Direction8.UpRight, profile.walkUpRight);
                     if (profile.walkUp != null) spriteController.SetWalkSprite(Direction8.Up, profile.walkUp);
+                    spriteController.SetWalkSprite(Direction8.DownLeft, profile.walkDownLeft);
                     spriteController.UseFlipXForLeft = profile.useFlipXForLeft;
                     spriteController.UseFlipXForRight = profile.useFlipXForRight;
+                    spriteController.UseFlipXForDownLeft = profile.useFlipXForDownLeft;
+                    spriteController.UseFlipXForUpLeft = profile.useFlipXForUpLeft;
+                    spriteController.UseFlipXForUpRight = profile.useFlipXForUpRight;
+                    spriteController.UseFlipXForDownRight = profile.useFlipXForDownRight;
                 }
                 else
                 {
                     spriteController.SetIdleSprite(Direction8.Down, null);
+                    spriteController.SetIdleSprite(Direction8.DownRight, null);
                     spriteController.SetIdleSprite(Direction8.Left, null);
+                    spriteController.SetIdleSprite(Direction8.UpLeft, null);
                     spriteController.SetIdleSprite(Direction8.Right, null);
+                    spriteController.SetIdleSprite(Direction8.UpRight, null);
                     spriteController.SetIdleSprite(Direction8.Up, null);
+                    spriteController.SetIdleSprite(Direction8.DownLeft, null);
                     spriteController.SetWalkSprite(Direction8.Down, null);
+                    spriteController.SetWalkSprite(Direction8.DownRight, null);
                     spriteController.SetWalkSprite(Direction8.Left, null);
+                    spriteController.SetWalkSprite(Direction8.UpLeft, null);
                     spriteController.SetWalkSprite(Direction8.Right, null);
+                    spriteController.SetWalkSprite(Direction8.UpRight, null);
                     spriteController.SetWalkSprite(Direction8.Up, null);
+                    spriteController.SetWalkSprite(Direction8.DownLeft, null);
                 }
             }
             transform.localScale = profile.localScale;
@@ -127,15 +160,27 @@ namespace Beastmaster
             if (spriteController != null)
             {
                 spriteController.SetIdleSprite(Direction8.Down, origIdleDown);
+                spriteController.SetIdleSprite(Direction8.DownRight, origIdleDownRight);
                 spriteController.SetIdleSprite(Direction8.Left, origIdleLeft);
+                spriteController.SetIdleSprite(Direction8.UpLeft, origIdleUpLeft);
                 spriteController.SetIdleSprite(Direction8.Right, origIdleRight);
+                spriteController.SetIdleSprite(Direction8.UpRight, origIdleUpRight);
                 spriteController.SetIdleSprite(Direction8.Up, origIdleUp);
+                spriteController.SetIdleSprite(Direction8.DownLeft, origIdleDownLeft);
                 spriteController.SetWalkSprite(Direction8.Down, origWalkDown);
+                spriteController.SetWalkSprite(Direction8.DownRight, origWalkDownRight);
                 spriteController.SetWalkSprite(Direction8.Left, origWalkLeft);
+                spriteController.SetWalkSprite(Direction8.UpLeft, origWalkUpLeft);
                 spriteController.SetWalkSprite(Direction8.Right, origWalkRight);
+                spriteController.SetWalkSprite(Direction8.UpRight, origWalkUpRight);
                 spriteController.SetWalkSprite(Direction8.Up, origWalkUp);
+                spriteController.SetWalkSprite(Direction8.DownLeft, origWalkDownLeft);
                 spriteController.UseFlipXForLeft = origUseFlipXForLeft;
                 spriteController.UseFlipXForRight = origUseFlipXForRight;
+                spriteController.UseFlipXForDownLeft = origUseFlipXForDownLeft;
+                spriteController.UseFlipXForUpLeft = origUseFlipXForUpLeft;
+                spriteController.UseFlipXForUpRight = origUseFlipXForUpRight;
+                spriteController.UseFlipXForDownRight = origUseFlipXForDownRight;
             }
             attackAnimator?.ClearPetLook();
         }


### PR DESCRIPTION
## Summary
- cache the player's diagonal idle/walk sprites and flip flags so pet merges can restore them cleanly
- expose diagonal flip accessors on the player sprite controller interface for binder use
- update the Beastmaster visual binder to manage diagonal overrides and flip flags for pet visuals and animator-driven merges

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e115068b5c832e9f0816e2856d83fb