### PR TITLE
Handle child colliders in NPC ground flame and slam

### DIFF
--- a/Assets/Scripts/NPC/Combat/CombatAttacks/GoblinWarChiefSlam.cs
+++ b/Assets/Scripts/NPC/Combat/CombatAttacks/GoblinWarChiefSlam.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 using Combat;
 using Player;
@@ -15,14 +16,19 @@ namespace NPC
             var myFaction = owner.GetComponent<IFactionProvider>();
             var ownerTarget = owner.GetComponent<CombatTarget>();
             var hits = Physics2D.OverlapCircleAll(owner.transform.position, slamRange);
+            var processedTargets = new HashSet<CombatTarget>();
             foreach (var hit in hits)
             {
-                var otherTarget = hit.GetComponent<CombatTarget>();
+                // Resolve the combat target from either the collider or one of its parents so nested hitboxes are supported.
+                var otherTarget = hit.GetComponent<CombatTarget>() ?? hit.GetComponentInParent<CombatTarget>();
                 if (otherTarget == null || otherTarget == ownerTarget || !otherTarget.IsAlive)
+                    continue;
+                if (!processedTargets.Add(otherTarget))
                     continue;
                 if (myFaction != null)
                 {
-                    var otherFaction = hit.GetComponent<IFactionProvider>();
+                    // Apply the same parent-aware lookup for faction providers to respect pet/player faction settings.
+                    var otherFaction = hit.GetComponent<IFactionProvider>() ?? hit.GetComponentInParent<IFactionProvider>();
                     if (otherFaction != null && !myFaction.IsEnemy(otherFaction.Faction))
                         continue;
                 }

--- a/Assets/Scripts/NPC/Combat/Projectiles/GroundFlame.cs
+++ b/Assets/Scripts/NPC/Combat/Projectiles/GroundFlame.cs
@@ -23,16 +23,18 @@ namespace NPC
 
         private void OnTriggerEnter2D(Collider2D other)
         {
-            var tgt = other.GetComponent<CombatTarget>();
-            if (tgt != null)
-                targets.Add(tgt);
+            // Probe both the collider and its parents so characters that expose child hitboxes still register correctly.
+            var target = other.GetComponent<CombatTarget>() ?? other.GetComponentInParent<CombatTarget>();
+            if (target != null)
+                targets.Add(target);
         }
 
         private void OnTriggerExit2D(Collider2D other)
         {
-            var tgt = other.GetComponent<CombatTarget>();
-            if (tgt != null)
-                targets.Remove(tgt);
+            // Mirror the entry lookup to ensure we remove the exact tracked target instance.
+            var target = other.GetComponent<CombatTarget>() ?? other.GetComponentInParent<CombatTarget>();
+            if (target != null)
+                targets.Remove(target);
         }
 
         private IEnumerator BurnRoutine()


### PR DESCRIPTION
## Summary
- update GroundFlame to resolve combat targets from child or parent colliders so multi-part characters track correctly
- adjust GoblinWarChiefSlam to use the same lookup for combat targets and faction providers while preventing duplicate hits per slam

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e165db5ac4832ead89871385b0e305