### PR TITLE
Fix ranged NPC attack calculations

### DIFF
--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -875,7 +875,7 @@ namespace NPC
                     attackBonus = attacker.Equip.magic;
                     break;
                 case DamageType.Ranged:
-                    attEff = CombatMath.GetEffectiveAttack(attacker.AttackLevel, attacker.Style);
+                    attEff = CombatMath.GetEffectiveRanged(attacker.RangedLevel, attacker.Style);
                     attackBonus = attacker.Equip.range;
                     break;
                 default:
@@ -901,7 +901,7 @@ namespace NPC
                     break;
                 case DamageType.Ranged:
                 {
-                    int strEff = CombatMath.GetEffectiveStrength(attacker.StrengthLevel, attacker.Style);
+                    int strEff = CombatMath.GetEffectiveRangedStrength(attacker.RangedLevel, attacker.Style);
                     maxHit = CombatMath.GetMaxHit(strEff, attacker.Equip.range);
                     break;
                 }


### PR DESCRIPTION
## Summary
- update NPC ranged attack calculations to use ranged effective attack and strength values
- ensure max hit rolls for ranged NPCs rely on their ranged level

## Testing
- not run (Unity editor required)

------
https://chatgpt.com/codex/tasks/task_e_68e182848f24832eacc827d1d8e67da8