### PR TITLE
Implement stack-dependent item sprite overrides

### DIFF
--- a/Assets/Scripts/Bank/BankUI.cs
+++ b/Assets/Scripts/Bank/BankUI.cs
@@ -377,7 +377,10 @@ namespace BankSystem
 
             if (hasItem)
             {
-                image.sprite = entry.item.icon;
+                Sprite sprite = entry.item.GetIconForCount(entry.count);
+                if (sprite == null)
+                    sprite = entry.item.icon;
+                image.sprite = sprite;
                 image.type = Image.Type.Simple;
                 image.color = Color.white;
 
@@ -500,7 +503,10 @@ namespace BankSystem
             draggingIcon.transform.SetParent(uiRoot.transform, false);
             var img = draggingIcon.GetComponent<Image>();
             img.raycastTarget = false;
-            img.sprite = entry.item.icon;
+            Sprite sprite = entry.item.GetIconForCount(entry.count);
+            if (sprite == null)
+                sprite = entry.item.icon;
+            img.sprite = sprite;
             img.color = Color.white;
             var rect = draggingIcon.GetComponent<RectTransform>();
             rect.sizeDelta = slotSize;

--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -742,7 +742,14 @@ namespace Inventory
             var item = entry.item;
             if (item != null)
             {
-                slotImages[index].sprite = item.icon ? item.icon : slotFrameSprite;
+                Sprite sprite = item.GetIconForCount(entry.count);
+                if (sprite == null)
+                    sprite = item.icon != null ? item.icon : slotFrameSprite;
+
+                if (sprite == null)
+                    sprite = slotFrameSprite;
+
+                slotImages[index].sprite = sprite;
                 slotImages[index].type = (slotImages[index].sprite == slotFrameSprite && slotFrameSprite != null)
                     ? Image.Type.Sliced : Image.Type.Simple;
                 slotImages[index].color = Color.white;
@@ -1398,7 +1405,12 @@ namespace Inventory
             draggingIcon.transform.SetAsLastSibling();
             var img = draggingIcon.GetComponent<Image>();
             img.raycastTarget = false;
-            img.sprite = item.icon ? item.icon : slotFrameSprite;
+            Sprite dragSprite = item.GetIconForCount(entry.count);
+            if (dragSprite == null)
+                dragSprite = item.icon != null ? item.icon : slotFrameSprite;
+            if (dragSprite == null)
+                dragSprite = slotFrameSprite;
+            img.sprite = dragSprite;
             img.color = Color.white;
             var rect = draggingIcon.GetComponent<RectTransform>();
             rect.sizeDelta = slotSize;

--- a/Assets/Scripts/Inventory/ItemData.cs
+++ b/Assets/Scripts/Inventory/ItemData.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 using Items;
 using Skills;
@@ -13,6 +14,47 @@ namespace Inventory
     {
         public SkillType skill;
         public int level;
+    }
+
+    /// <summary>
+    /// Defines an alternate sprite that should be shown once an item stack
+    /// reaches the configured minimum quantity. Designers configure these
+    /// overrides directly on <see cref="ItemData"/> assets in the inspector.
+    /// </summary>
+    [Serializable]
+    public struct StackSpriteOverride
+    {
+        [SerializeField]
+        [Tooltip("Minimum stack count required before this sprite is used.")]
+        private int minStack;
+
+        [SerializeField]
+        [Tooltip("Sprite displayed when the minimum stack count is met.")]
+        private Sprite variantSprite;
+
+        /// <summary>
+        /// Minimum stack size required before the override sprite is applied.
+        /// </summary>
+        public int MinStack => minStack;
+
+        /// <summary>
+        /// Sprite shown when <see cref="MinStack"/> is satisfied.
+        /// </summary>
+        public Sprite VariantSprite => variantSprite;
+
+        /// <summary>
+        /// Ensures the minimum stack value stored in the inspector never drops
+        /// below one so runtime lookups behave predictably.
+        /// </summary>
+        public void ClampMinStack()
+        {
+            minStack = Mathf.Max(1, minStack);
+        }
+
+        /// <summary>
+        /// Returns true when a sprite has been assigned for this override.
+        /// </summary>
+        public bool HasSprite => variantSprite != null;
     }
 
     /// <summary>
@@ -48,6 +90,15 @@ namespace Inventory
 
         [Header("Display")] public string itemName;
         public Sprite icon;
+
+        [Header("Stack Sprites")]
+        [SerializeField]
+        private StackSpriteOverride[] stackSpriteOverrides = Array.Empty<StackSpriteOverride>();
+
+        /// <summary>
+        /// Ordered list of stack sprite overrides exposed for editor tooling.
+        /// </summary>
+        public IReadOnlyList<StackSpriteOverride> StackSpriteOverrides => stackSpriteOverrides;
 
         [Header("Description")] [TextArea] public string description;
 
@@ -90,6 +141,66 @@ namespace Inventory
         {
             // Keep the serialized value in sync for inspector visibility.
             maxStack = stackable ? OSRS_MAX_STACK : 1;
+
+            if (stackSpriteOverrides == null)
+            {
+                stackSpriteOverrides = Array.Empty<StackSpriteOverride>();
+                return;
+            }
+
+            if (stackSpriteOverrides.Length == 0)
+                return;
+
+            var sanitized = new List<StackSpriteOverride>(stackSpriteOverrides.Length);
+            for (int i = 0; i < stackSpriteOverrides.Length; i++)
+            {
+                var spriteOverride = stackSpriteOverrides[i];
+                spriteOverride.ClampMinStack();
+                if (!spriteOverride.HasSprite)
+                    continue;
+
+                sanitized.Add(spriteOverride);
+            }
+
+            if (sanitized.Count == 0)
+            {
+                stackSpriteOverrides = Array.Empty<StackSpriteOverride>();
+                return;
+            }
+
+            sanitized.Sort((a, b) => a.MinStack.CompareTo(b.MinStack));
+            stackSpriteOverrides = sanitized.ToArray();
+        }
+
+        /// <summary>
+        /// Returns the sprite that should represent this item for the provided
+        /// stack count. The base icon is used when no overrides match, the item
+        /// is not stackable, or the stack count is zero/negative.
+        /// </summary>
+        /// <param name="stackCount">Current quantity of this item in the stack.</param>
+        /// <returns>The sprite that should be displayed for this stack size.</returns>
+        public Sprite GetIconForCount(int stackCount)
+        {
+            if (!stackable || stackCount <= 0)
+                return icon;
+
+            if (stackSpriteOverrides == null || stackSpriteOverrides.Length == 0)
+                return icon;
+
+            Sprite chosen = icon;
+            for (int i = 0; i < stackSpriteOverrides.Length; i++)
+            {
+                var spriteOverride = stackSpriteOverrides[i];
+                if (!spriteOverride.HasSprite)
+                    continue;
+
+                if (stackCount >= spriteOverride.MinStack)
+                    chosen = spriteOverride.VariantSprite;
+                else
+                    break;
+            }
+
+            return chosen;
         }
 
         [Header("Equipment")] [Tooltip("Slot this item can be equipped to. Use None for non-equippable items.")]

--- a/Assets/Scripts/Shop/ShopUI.cs
+++ b/Assets/Scripts/Shop/ShopUI.cs
@@ -360,7 +360,12 @@ namespace ShopSystem
                     var entry = currentShop.stock[i];
                     if (entry.item != null && entry.quantity > 0)
                     {
-                        img.sprite = entry.item.icon != null ? entry.item.icon : slotFrameSprite;
+                        Sprite sprite = entry.item.GetIconForCount(entry.quantity);
+                        if (sprite == null)
+                            sprite = entry.item.icon != null ? entry.item.icon : slotFrameSprite;
+                        if (sprite == null)
+                            sprite = slotFrameSprite;
+                        img.sprite = sprite;
                         img.color = Color.white;
                         img.enabled = true;
                         // Display only the quantity in the slot, not the price


### PR DESCRIPTION
## Summary
- add serialized stack sprite override support on ItemData with validation and helpers
- switch inventory, bank, and shop UIs to resolve sprites via the new stack-aware helper
- ensure drag previews and highlights mirror the selected stack sprite

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e21d2608a0832e99c1085dbed4e631