### PR TITLE
Fix DamageResult accessibility for ranged combat

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -443,7 +443,11 @@ namespace Combat
             attackRoutine = null;
         }
 
-        internal struct DamageResult
+        /// <summary>
+        /// Represents the outcome of a combat damage roll so that other combat systems like
+        /// ranged projectiles can forward the result without duplicating the calculation logic.
+        /// </summary>
+        public struct DamageResult
         {
             public int damage;
             public bool hit;


### PR DESCRIPTION
## Summary
- make CombatController.DamageResult public so ranged combat systems can accept it
- document the struct to clarify its purpose for shared combat systems

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e233020d28832ebe05fcf57fac067b