### PR TITLE
Fix remaining ammo variable initialization in ranged controller

### DIFF
--- a/Assets/Scripts/Combat/Ranged/RangedCombatController.cs
+++ b/Assets/Scripts/Combat/Ranged/RangedCombatController.cs
@@ -266,7 +266,7 @@ namespace Combat.Ranged
                 attackCooldownTicks = currentWeapon.attackSpeedTicks;
 
             bool consumeAmmo = ammoConsumptionMultiplier > 0f && (ammo == null || !ammo.infinite);
-            int remaining;
+            int remaining = currentAmmoCount;
             if (consumeAmmo && !ConsumeAmmo(currentWeapon, ammo, out remaining))
             {
                 HandleNoAmmo();


### PR DESCRIPTION
## Summary
- initialize the remaining ammo count before consumption to satisfy C# definite assignment rules

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e233fddf94832e9850cd38e8ceae74