### PR TITLE
Prevent duplicate session log entries

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,6 +1,15 @@
 # Session Log
 This file is auto-updated by CI on every push. Times shown are Europe/London.
 
+<!-- commit:147f1af9f7ab88bb2f80c47c5ed715b2dfe4b890 -->
+## 2025-10-05T13:45:43+01:00 — Update SESSION_LOG [ci]
+
+- Author: session-log-bot <actions@github.com>
+- Changed files (1): docs/SESSION_LOG.md
+- Diff: 24 ++ / 0 --
+- Notes:
+  —
+---
 ## 2025-10-05T13:45:32+01:00 — Merge pull request #1000 from aicovergod/codex/add-server-side-session-logger
 
 - Author: aicovergod <lewisshuffle136@gmail.com>
@@ -14,14 +23,6 @@ This file is auto-updated by CI on every push. Times shown are Europe/London.
 - Author: session-log-bot <actions@github.com>
 - Changed files (1): docs/SESSION_LOG.md
 - Diff: 9 ++ / 0 --
-- Notes:
-  —
----
-## 2025-10-05T13:45:06+01:00 — Add automated session logging workflow
-
-- Author: aicovergod <lewisshuffle136@gmail.com>
-- Changed files (3): .github/workflows/session-log.yml, docs/SESSION_LOG.md, tools/ci_session_logger.py
-- Diff: 165 ++ / 0 --
 - Notes:
   —
 ---

--- a/tools/ci_session_logger.py
+++ b/tools/ci_session_logger.py
@@ -84,6 +84,20 @@ def prepend_entries(existing, entries_md):
     return entries_md + existing
 
 
+def extract_logged_commits(content):
+    """Return the set of commit SHAs already present in the session log."""
+    return set(re.findall(r"<!-- commit:([0-9a-f]{40}) -->", content))
+
+
+def extract_entry_headers(content):
+    """Return the set of entry header lines already stored in the log."""
+    return {
+        line.strip()
+        for line in content.splitlines()
+        if line.startswith("## ")
+    }
+
+
 def format_entry(commit_sha):
     subject = safe_sh(["git", "show", "-s", "--format=%s", commit_sha]) or "(no subject)"
     body = safe_sh(["git", "show", "-s", "--format=%b", commit_sha]).rstrip() or "—"
@@ -96,14 +110,16 @@ def format_entry(commit_sha):
     files_list = ", ".join(files) if files else "—"
     add, rem = parse_shortstat(safe_sh(["git", "show", "--shortstat", "--pretty=", commit_sha]))
     notes = body.replace("\n", "\n  ")
+    header = f"## {when} — {subject}"
     return (
-        f"## {when} — {subject}\n\n"
+        f"<!-- commit:{commit_sha} -->\n"
+        f"{header}\n\n"
         f"- Author: {name} <{email}>\n"
         f"- Changed files ({len(files)}): {files_list}\n"
         f"- Diff: {add} ++ / {rem} --\n"
         f"- Notes:\n  {notes}\n"
         f"---\n"
-    )
+    ), header
 
 
 def main():
@@ -118,8 +134,20 @@ def main():
     LOG.parent.mkdir(parents=True, exist_ok=True)
     existing = LOG.read_text(encoding="utf-8") if LOG.exists() else ""
     existing = ensure_header(existing)
+    seen_commits = extract_logged_commits(existing)
+    seen_headers = extract_entry_headers(existing)
 
-    new_entries = [format_entry(commit) for commit in commits]
+    new_entries = []
+    for commit in commits:
+        if commit in seen_commits:
+            continue
+        entry, header = format_entry(commit)
+        if header in seen_headers:
+            continue
+        new_entries.append(entry)
+        seen_commits.add(commit)
+        seen_headers.add(header)
+
     block = "".join(new_entries)
     updated = prepend_entries(existing, block)
     if updated != existing:


### PR DESCRIPTION
## Summary
- add commit and header tracking to the CI session logger to skip commits already present in the log
- annotate the latest recorded commit and remove a duplicated entry from docs/SESSION_LOG.md

## Testing
- python3 tools/ci_session_logger.py

------
https://chatgpt.com/codex/tasks/task_e_68e26f0fa158832ead829134125543e3