### PR TITLE
Add ranged strength stat and propagate through combat

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -496,7 +496,7 @@ namespace Combat
                     ? CombatMath.GetEffectiveRangedStrength(attacker.RangedLevel, attacker.Style)
                     : CombatMath.GetEffectiveStrength(attacker.StrengthLevel, attacker.Style);
                 int strengthBonus = attacker.DamageType == DamageType.Ranged
-                    ? attacker.Equip.range
+                    ? attacker.Equip.rangeStrength
                     : attacker.Equip.strength;
                 maxHit = CombatMath.GetMaxHit(strEff, strengthBonus);
             }
@@ -533,7 +533,7 @@ namespace Combat
                     RangedLevel = 1,
                     DefenceLevel = 1,
                     MagicLevel = 1,
-                    Equip = new EquipmentAggregator.CombinedStats(),
+                    Equip = new EquipmentAggregator.CombinedStats { rangeStrength = 0 },
                     Style = CombatStyle.Defensive,
                     DamageType = target != null ? target.PreferredDefenceType : incomingType
                 };

--- a/Assets/Scripts/Combat/CombatantStats.cs
+++ b/Assets/Scripts/Combat/CombatantStats.cs
@@ -52,6 +52,7 @@ namespace Combat
                     attack = 0,
                     strength = 0,
                     range = 0,
+                    rangeStrength = 0,
                     magic = 0,
                     meleeDef = profile != null ? profile.MeleeDefence : 0,
                     rangeDef = profile != null ? profile.RangeDefence : 0,

--- a/Assets/Scripts/Combat/Ranged/RangedCombatController.cs
+++ b/Assets/Scripts/Combat/Ranged/RangedCombatController.cs
@@ -233,7 +233,7 @@ namespace Combat.Ranged
             bool hit = UnityEngine.Random.value < chanceToHit;
 
             int effectiveStrength = CombatMath.GetEffectiveRangedStrength(attacker.RangedLevel, attacker.Style);
-            int strengthBonus = Mathf.Max(0, attacker.Equip.range);
+            int strengthBonus = Mathf.Max(0, attacker.Equip.rangeStrength);
             int maxHit = CombatMath.GetMaxHit(effectiveStrength, strengthBonus);
             maxHit = Mathf.RoundToInt(maxHit * Mathf.Max(0f, damageMultiplier));
             if (maxHit < 0)

--- a/Assets/Scripts/Equipment/EquipmentAggregator.cs
+++ b/Assets/Scripts/Equipment/EquipmentAggregator.cs
@@ -20,6 +20,7 @@ namespace EquipmentSystem
             public int attack;
             public int strength;
             public int range;
+            public int rangeStrength;
             public int magic;
             public int meleeDef;
             public int rangeDef;
@@ -54,6 +55,7 @@ namespace EquipmentSystem
                     result.attack += stats.Attack;
                     result.strength += stats.Strength;
                     result.range += stats.Range;
+                    result.rangeStrength += stats.RangeStrength;
                     result.magic += stats.Magic;
                     result.meleeDef += stats.MeleeDefence;
                     result.rangeDef += stats.RangeDefence;
@@ -69,6 +71,7 @@ namespace EquipmentSystem
                 result.attack += pet.attack;
                 result.strength += pet.strength;
                 result.range += pet.range;
+                result.rangeStrength += pet.rangeStrength;
                 result.magic += pet.magic;
                 result.meleeDef += pet.meleeDef;
                 result.rangeDef += pet.rangeDef;

--- a/Assets/Scripts/Items/ItemCombatStats.cs
+++ b/Assets/Scripts/Items/ItemCombatStats.cs
@@ -11,7 +11,14 @@ namespace Items
     {
         public int Attack;
         public int Strength;
+        /// <summary>
+        /// Ranged accuracy bonus used when rolling chance to hit.
+        /// </summary>
         public int Range;
+        /// <summary>
+        /// Ranged strength bonus used when calculating maximum hit rolls.
+        /// </summary>
+        public int RangeStrength;
         public int Magic;
         public int MeleeDefence;
         public int RangeDefence;
@@ -29,6 +36,7 @@ namespace Items
             Attack = 0,
             Strength = 0,
             Range = 0,
+            RangeStrength = 0,
             Magic = 0,
             MeleeDefence = 0,
             RangeDefence = 0,

--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -858,7 +858,7 @@ namespace NPC
                     AttackLevel = 1,
                     StrengthLevel = 1,
                     DefenceLevel = 1,
-                    Equip = new EquipmentAggregator.CombinedStats(),
+                    Equip = new EquipmentAggregator.CombinedStats { rangeStrength = 0 },
                     Style = CombatStyle.Defensive,
                     DamageType = target.PreferredDefenceType
                 };
@@ -902,7 +902,7 @@ namespace NPC
                 case DamageType.Ranged:
                 {
                     int strEff = CombatMath.GetEffectiveRangedStrength(attacker.RangedLevel, attacker.Style);
-                    maxHit = CombatMath.GetMaxHit(strEff, attacker.Equip.range);
+                    maxHit = CombatMath.GetMaxHit(strEff, attacker.Equip.rangeStrength);
                     break;
                 }
                 default:

--- a/Assets/Scripts/Pets/PetCombatController.cs
+++ b/Assets/Scripts/Pets/PetCombatController.cs
@@ -332,6 +332,7 @@ namespace Pets
                 {
                     attack = definition.accuracyBonus,
                     strength = definition.damageBonus,
+                    rangeStrength = definition.damageBonus,
                     attackSpeedTicks = definition.attackSpeedTicks
                 },
                 Style = CombatStyle.Accurate,
@@ -343,6 +344,7 @@ namespace Pets
             attacker.StrengthLevel = Mathf.RoundToInt(attacker.StrengthLevel * statMult);
             attacker.Equip.attack = Mathf.RoundToInt(attacker.Equip.attack * statMult);
             attacker.Equip.strength = Mathf.RoundToInt(attacker.Equip.strength * statMult);
+            attacker.Equip.rangeStrength = Mathf.RoundToInt(attacker.Equip.rangeStrength * statMult);
 
             // scale stats based on the owner's Beastmaster level
             var owner = follower != null ? follower.Player : null;
@@ -368,7 +370,7 @@ namespace Pets
                     AttackLevel = 1,
                     StrengthLevel = 1,
                     DefenceLevel = 1,
-                    Equip = new EquipmentAggregator.CombinedStats(),
+                    Equip = new EquipmentAggregator.CombinedStats { rangeStrength = 0 },
                     Style = CombatStyle.Defensive,
                     DamageType = target.PreferredDefenceType
                 };

--- a/Assets/Scripts/Pets/PetServiceAdapter.cs
+++ b/Assets/Scripts/Pets/PetServiceAdapter.cs
@@ -126,6 +126,7 @@ namespace Pets
                     {
                         attack = def.accuracyBonus,
                         strength = def.damageBonus,
+                        rangeStrength = def.damageBonus,
                         attackSpeedTicks = def.attackSpeedTicks
                     },
                     Style = CombatStyle.Accurate,
@@ -138,6 +139,7 @@ namespace Pets
                 stats.StrengthLevel = Mathf.RoundToInt(stats.StrengthLevel * mult);
                 stats.Equip.attack = Mathf.RoundToInt(stats.Equip.attack * mult);
                 stats.Equip.strength = Mathf.RoundToInt(stats.Equip.strength * mult);
+                stats.Equip.rangeStrength = Mathf.RoundToInt(stats.Equip.rangeStrength * mult);
 
                 var follower = controller.GetComponent<PetFollower>();
                 var owner = follower != null ? follower.Player : null;

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,6 +1,15 @@
 # Session Log
 This file is auto-updated by CI on every push. Times shown are Europe/London.
 
+<!-- commit:fba63de6a89a0927830728336e1ee27570453ef6 -->
+## 2025-10-05T15:26:26+01:00 — Add ranged strength stat and propagate through combat
+
+- Author: aicovergod <lewisshuffle136@gmail.com>
+- Changed files (8): Assets/Scripts/Combat/CombatController.cs, Assets/Scripts/Combat/CombatantStats.cs, Assets/Scripts/Combat/Ranged/RangedCombatController.cs, Assets/Scripts/Equipment/EquipmentAggregator.cs, Assets/Scripts/Items/ItemCombatStats.cs, Assets/Scripts/NPC/Combat/BaseNpcCombat.cs, Assets/Scripts/Pets/PetCombatController.cs, Assets/Scripts/Pets/PetServiceAdapter.cs
+- Diff: 22 ++ / 6 --
+- Notes:
+  —
+---
 <!-- commit:42490cfc2bc3ce160a7b0e2a909764686d806202 -->
 ## 2025-10-05T14:59:30+01:00 — bows
 


### PR DESCRIPTION
## Summary
- add a dedicated ranged strength bonus to item combat stats and document the accuracy split
- extend equipment aggregation and combat calculations to track and use the ranged strength bonus, including merged pet gear
- update pet combat adapters and NPC/player fallbacks so ranged strength is initialised everywhere

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e27e7bd32c832e90177d47cc4e8691