### PR TITLE
Align ranged damage with range strength stat

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -351,7 +351,7 @@ namespace Combat
             {
                 if (weapon.combat.Magic > 0)
                     return DamageType.Magic;
-                if (weapon.combat.Range > 0)
+                if (weapon.combat.Range > 0 || weapon.combat.RangeStrength > 0)
                     return DamageType.Ranged;
             }
 
@@ -496,7 +496,7 @@ namespace Combat
                     ? CombatMath.GetEffectiveRangedStrength(attacker.RangedLevel, attacker.Style)
                     : CombatMath.GetEffectiveStrength(attacker.StrengthLevel, attacker.Style);
                 int strengthBonus = attacker.DamageType == DamageType.Ranged
-                    ? attacker.Equip.rangeStrength
+                    ? Mathf.Max(0, attacker.Equip.rangeStrength)
                     : attacker.Equip.strength;
                 maxHit = CombatMath.GetMaxHit(strEff, strengthBonus);
             }

--- a/Assets/Scripts/Combat/Ranged/RangedCombatController.cs
+++ b/Assets/Scripts/Combat/Ranged/RangedCombatController.cs
@@ -416,7 +416,12 @@ namespace Combat.Ranged
             float chanceToHit = CombatMath.ChanceToHit(attackRoll, defenceRoll);
             bool hit = UnityEngine.Random.value < chanceToHit;
 
-            int scaledMaxHit = Mathf.RoundToInt(Mathf.Max(0f, context.damageResult.maxHit) * damageScale);
+            int effectiveStrength = CombatMath.GetEffectiveRangedStrength(attackerStats.RangedLevel, attackerStats.Style);
+            int strengthBonus = Mathf.Max(0, attackerStats.Equip.rangeStrength);
+            int baseMaxHit = CombatMath.GetMaxHit(effectiveStrength, strengthBonus);
+            float damageMultiplier = Mathf.Max(0f, context.finalDamageMultiplier);
+            float scaledDamageMultiplier = Mathf.Max(0f, damageScale) * damageMultiplier;
+            int scaledMaxHit = Mathf.RoundToInt(baseMaxHit * scaledDamageMultiplier);
             if (scaledMaxHit < 0)
                 scaledMaxHit = 0;
 

--- a/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
+++ b/Assets/Scripts/NPC/Combat/BaseNpcCombat.cs
@@ -876,7 +876,7 @@ namespace NPC
                     break;
                 case DamageType.Ranged:
                     attEff = CombatMath.GetEffectiveRanged(attacker.RangedLevel, attacker.Style);
-                    attackBonus = attacker.Equip.range;
+                    attackBonus = Mathf.Max(0, attacker.Equip.range);
                     break;
                 default:
                     attEff = CombatMath.GetEffectiveAttack(attacker.AttackLevel, attacker.Style);
@@ -902,7 +902,8 @@ namespace NPC
                 case DamageType.Ranged:
                 {
                     int strEff = CombatMath.GetEffectiveRangedStrength(attacker.RangedLevel, attacker.Style);
-                    maxHit = CombatMath.GetMaxHit(strEff, attacker.Equip.rangeStrength);
+                    int strengthBonus = Mathf.Max(0, attacker.Equip.rangeStrength);
+                    maxHit = CombatMath.GetMaxHit(strEff, strengthBonus);
                     break;
                 }
                 default:

--- a/Assets/Scripts/Player/PlayerCombatLoadout.cs
+++ b/Assets/Scripts/Player/PlayerCombatLoadout.cs
@@ -119,7 +119,7 @@ namespace Player
                     if (MagicUI.ActiveSpell == null)
                         MagicUI.RestoreLastSpell();
                 }
-                else if (weapon.combat.Range > 0)
+                else if (weapon.combat.Range > 0 || weapon.combat.RangeStrength > 0)
                     damageType = DamageType.Ranged;
                 else
                 {

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,6 +1,15 @@
 # Session Log
 This file is auto-updated by CI on every push. Times shown are Europe/London.
 
+<!-- commit:5122d3d86093ceea08d71694715dbb25631ff4af -->
+## 2025-10-05T15:32:38+01:00 — Align ranged damage with range strength
+
+- Author: aicovergod <lewisshuffle136@gmail.com>
+- Changed files (4): Assets/Scripts/Combat/CombatController.cs, Assets/Scripts/Combat/Ranged/RangedCombatController.cs, Assets/Scripts/NPC/Combat/BaseNpcCombat.cs, Assets/Scripts/Player/PlayerCombatLoadout.cs
+- Diff: 12 ++ / 6 --
+- Notes:
+  —
+---
 <!-- commit:08615e5d0748696fd6dce6bccdcaeeb0e7359a91 -->
 ## 2025-10-05T15:26:44+01:00 — Merge pull request #1002 from aicovergod/codex/add-rangestrength-field-to-itemcombatstats
 


### PR DESCRIPTION
## Summary
- ensure the combat controller treats weapons as ranged when either accuracy or strength bonuses are present and clamp ranged strength when deriving max hits
- update ranged combat rolls to use ranged accuracy for hit chance while scaling primary and secondary damage from the ranged strength stat
- mirror the ranged strength usage for NPC attacks and have the player loadout recognise weapons that only supply ranged strength

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2802ebee0832e88133c1bac37067e