### PR TITLE
Handle two-handed equipment conflicts before equipping

### DIFF
--- a/Assets/Scripts/Inventory/Equipment.cs
+++ b/Assets/Scripts/Inventory/Equipment.cs
@@ -321,13 +321,14 @@ namespace Inventory
             if (slot == EquipmentSlot.None)
                 return false;
 
+            Transform anchor = floatingTextAnchor != null ? floatingTextAnchor : transform;
+
             if (entry.item != null && skillManager != null && entry.item.skillRequirements != null)
             {
                 foreach (var req in entry.item.skillRequirements)
                 {
                     if (skillManager.GetLevel(req.skill) < req.level)
                     {
-                        Transform anchor = floatingTextAnchor != null ? floatingTextAnchor : transform;
                         FloatingText.Show($"You need {req.level} {req.skill} to wield this", anchor.position);
                         return false;
                     }
@@ -338,11 +339,72 @@ namespace Inventory
             if (index < 0 || index >= equipped.Length)
                 return false;
 
+            // Handle mutually exclusive weapon/shield pairing before mutating any slots.
+            if (slot == EquipmentSlot.Weapon && entry.item != null && entry.item.isTwoHanded)
+            {
+                int shieldIndex = SlotIndex(EquipmentSlot.Shield);
+                if (shieldIndex >= 0 && shieldIndex < equipped.Length)
+                {
+                    var shieldEntry = equipped[shieldIndex];
+                    if (shieldEntry.item != null)
+                    {
+                        if (inventory == null || !inventory.CanAddItem(shieldEntry.item, shieldEntry.count))
+                        {
+                            FloatingText.Show("Your inventory is full", anchor.position);
+                            return false;
+                        }
+
+                        if (!inventory.AddItem(shieldEntry.item, shieldEntry.count))
+                        {
+                            FloatingText.Show("Your inventory is full", anchor.position);
+                            return false;
+                        }
+
+                        equipped[shieldIndex] = default;
+                        UpdateSlotVisual(EquipmentSlot.Shield);
+                        UpdateBonuses();
+                        OnEquipmentChanged?.Invoke(EquipmentSlot.Shield);
+                        ItemUseResolver.NotifyItemUsed(gameObject, shieldEntry.item, ItemUseType.Unequipped);
+                    }
+                }
+            }
+            else if (slot == EquipmentSlot.Shield)
+            {
+                int weaponIndex = SlotIndex(EquipmentSlot.Weapon);
+                if (weaponIndex >= 0 && weaponIndex < equipped.Length)
+                {
+                    var weaponEntry = equipped[weaponIndex];
+                    if (weaponEntry.item != null && weaponEntry.item.isTwoHanded)
+                    {
+                        if (inventory == null || !inventory.CanAddItem(weaponEntry.item, weaponEntry.count))
+                        {
+                            FloatingText.Show("Your inventory is full", anchor.position);
+                            return false;
+                        }
+
+                        if (!inventory.AddItem(weaponEntry.item, weaponEntry.count))
+                        {
+                            FloatingText.Show("Your inventory is full", anchor.position);
+                            return false;
+                        }
+
+                        equipped[weaponIndex] = default;
+                        UpdateSlotVisual(EquipmentSlot.Weapon);
+                        UpdateBonuses();
+                        OnEquipmentChanged?.Invoke(EquipmentSlot.Weapon);
+                        ItemUseResolver.NotifyItemUsed(gameObject, weaponEntry.item, ItemUseType.Unequipped);
+                    }
+                }
+            }
+
             var current = equipped[index];
             if (current.item != null)
             {
                 if (inventory != null && !inventory.AddItem(current.item, current.count))
+                {
+                    FloatingText.Show("Your inventory is full", anchor.position);
                     return false;
+                }
                 ItemUseResolver.NotifyItemUsed(gameObject, current.item, ItemUseType.Unequipped);
             }
 

--- a/Assets/Scripts/Inventory/ItemData.cs
+++ b/Assets/Scripts/Inventory/ItemData.cs
@@ -131,6 +131,9 @@ namespace Inventory
         [Tooltip("If true, this item cannot be dropped.")]
         public bool isUndroppable = false;
 
+        [Tooltip("If true, this weapon occupies both the weapon and shield slots.")]
+        public bool isTwoHanded = false;
+
         [Header("Consumable")]
         [Tooltip("Hitpoints restored when this item is consumed.")]
         public int healAmount = 0;

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,6 +1,15 @@
 # Session Log
 This file is auto-updated by CI on every push. Times shown are Europe/London.
 
+<!-- commit:460e86a8a3b5ff4c9c3350d2f316078fc5316b69 -->
+## 2025-10-05T15:47:07+01:00 — Handle two-handed weapon equipment conflicts
+
+- Author: aicovergod <lewisshuffle136@gmail.com>
+- Changed files (2): Assets/Scripts/Inventory/Equipment.cs, Assets/Scripts/Inventory/ItemData.cs
+- Diff: 66 ++ / 1 --
+- Notes:
+  —
+---
 <!-- commit:334777bfe9393a7e459c3f7eefb4a6906ebc0b8b -->
 ## 2025-10-05T15:32:56+01:00 — Merge pull request #1003 from aicovergod/codex/update-ranged-combat-calculations-and-detection
 


### PR DESCRIPTION
## Summary
- add an inspector flag so item definitions can mark two-handed weapons
- update Equipment.Equip to check inventory space, auto-unequip conflicting slots, and show feedback when equipping two-handed weapons or shields

## Testing
- not run (Unity editor tests not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e282ef4040832ebf462c1970b0b64d