### PR TITLE
Add static analysis CI for Unity C# scripts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*.cs]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_readonly_field = true:warning
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_prefer_braces = when_multiline:suggestion
+dotnet_analyzer_diagnostic.category-Reliability.severity = warning
+dotnet_diagnostic.SA1600.severity = none
+dotnet_diagnostic.SA1633.severity = none
+dotnet_diagnostic.SA1309.severity = suggestion

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -1,0 +1,30 @@
+name: dotnet-format
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "Assets/**/*.cs"
+      - ".editorconfig"
+  push:
+    branches: [ main ]
+    paths:
+      - "Assets/**/*.cs"
+      - ".editorconfig"
+
+permissions:
+  contents: read
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate synthetic Unity solution
+        run: python3 tools/generate_unity_sln.py --root Assets --sln ci/UnityAnalysis.sln --csproj ci/UnityAnalysis.csproj
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with: { dotnet-version: '8.0.x' }
+      - name: Restore
+        run: dotnet restore ci/UnityAnalysis.csproj
+      - name: Verify formatting
+        run: dotnet format ci/UnityAnalysis.sln --verify-no-changes --severity info

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -1,0 +1,38 @@
+name: Qodana (C#)
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "Assets/**/*.cs"
+      - ".github/workflows/qodana.yml"
+      - "qodana.yaml"
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "Assets/**/*.cs"
+      - ".github/workflows/qodana.yml"
+      - "qodana.yaml"
+
+permissions:
+  contents: read
+  actions: read
+  security-events: write
+
+jobs:
+  qodana:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate synthetic Unity solution
+        run: python3 tools/generate_unity_sln.py --root Assets --sln ci/UnityAnalysis.sln --csproj ci/UnityAnalysis.csproj
+      - name: Run Qodana
+        uses: JetBrains/qodana-action@v2024.2
+        with:
+          linter: jetbrains/qodana-dotnet
+          args: |
+            --project=ci/UnityAnalysis.sln
+          results-dir: qodana-results
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: qodana-results/qodana.sarif.json

--- a/.github/workflows/stylecop-analyze.yml
+++ b/.github/workflows/stylecop-analyze.yml
@@ -1,0 +1,35 @@
+name: StyleCop Analyze
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "Assets/**/*.cs"
+      - ".editorconfig"
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "Assets/**/*.cs"
+      - ".editorconfig"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate synthetic Unity solution
+        run: python3 tools/generate_unity_sln.py --root Assets --sln ci/UnityAnalysis.sln --csproj ci/UnityAnalysis.csproj
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with: { dotnet-version: '8.0.x' }
+      - name: Restore
+        run: dotnet restore ci/UnityAnalysis.csproj
+      - name: Build with SARIF log
+        run: dotnet build ci/UnityAnalysis.csproj -c Debug /p:ErrorLog=ci/roslyn.sarif
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ci/roslyn.sarif

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+</Project>

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,6 +1,15 @@
 # Session Log
 This file is auto-updated by CI on every push. Times shown are Europe/London.
 
+<!-- commit:2e76b64217963322439260dfb112e2ab560116c9 -->
+## 2025-10-05T17:24:56+01:00 — Add static analysis CI for Unity C# scripts
+
+- Author: aicovergod <lewisshuffle136@gmail.com>
+- Changed files (8): .editorconfig, .github/workflows/dotnet-format.yml, .github/workflows/qodana.yml, .github/workflows/stylecop-analyze.yml, Directory.Build.props, qodana.yaml, stylecop.json, tools/generate_unity_sln.py
+- Diff: 215 ++ / 0 --
+- Notes:
+  —
+---
 <!-- commit:d40ec7e961bf85c38b0092460c84bd957be726d0 -->
 ## 2025-10-05T16:45:57+01:00 — Merge pull request #1009 from aicovergod/codex/update-itemdata-stackspriteoverrides-handling
 

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,0 +1,14 @@
+version: "1.0"
+linter: jetbrains/qodana-dotnet
+include:
+  - name: All
+exclude:
+  - name: GeneratedCode
+    paths:
+      - "Library/**"
+      - "Packages/**"
+      - "ProjectSettings/**"
+      - "Temp/**"
+      - "Build/**"
+      - "ci/**"
+failThreshold: 0

--- a/stylecop.json
+++ b/stylecop.json
@@ -1,0 +1,12 @@
+{
+  "settings": {
+    "documentationRules": {
+      "documentPrivateElements": false,
+      "documentInternalElements": false,
+      "documentExposedElements": false
+    },
+    "layoutRules": {
+      "newlineAtEndOfFile": "require"
+    }
+  }
+}

--- a/tools/generate_unity_sln.py
+++ b/tools/generate_unity_sln.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+import argparse
+from pathlib import Path
+
+SLN = """\
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 17
+Project("{00000000-0000-0000-0000-000000000001}") = "UnityAnalysis", "{csproj}", "{00000000-0000-0000-0000-000000000002}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {00000000-0000-0000-0000-000000000002}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {00000000-0000-0000-0000-000000000002}.Debug|Any CPU.Build.0 = Debug|Any CPU
+    EndGlobalSection
+EndGlobal
+"""
+
+CSPROJ = """\
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <EnableDefaultItems>false</EnableDefaultItems>
+  </PropertyGroup>
+
+  <ItemGroup>
+{items}
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" PrivateAssets="all" />
+  </ItemGroup>
+</Project>
+"""
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default="Assets")
+    ap.add_argument("--sln", default="ci/UnityAnalysis.sln")
+    ap.add_argument("--csproj", default="ci/UnityAnalysis.csproj")
+    args = ap.parse_args()
+
+    root = Path(args.root)
+    files = [p.as_posix() for p in root.rglob("*.cs")
+             if not any(seg in p.as_posix() for seg in
+                        ("/Library/", "/Packages/", "/ProjectSettings/", "/Temp/", "/Build/", "/obj/", "/bin/"))]
+
+    Path("ci").mkdir(parents=True, exist_ok=True)
+    items = "\n".join(f'    <Compile Include="{f}" />' for f in files) or "    <!-- no C# files found -->"
+    Path(args.csproj).write_text(CSPROJ.format(items=items), encoding="utf-8")
+    Path(args.sln).write_text(SLN.replace("{csproj}", Path(args.csproj).as_posix()), encoding="utf-8")
+    print(f"Generated {len(files)} files into {args.sln}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a helper script that builds a synthetic solution and project for Unity C# sources under Assets
- configure repository-level editorconfig, StyleCop, and analyzer settings shared by CI
- add GitHub Actions workflows for dotnet-format, StyleCop/Roslyn analysis, and Qodana inspections that upload SARIF results

## Testing
- python3 tools/generate_unity_sln.py

------
https://chatgpt.com/codex/tasks/task_e_68e292e6b380832e86f58359ec2fd7c4