### PR TITLE
Implement ammo allow-lists for ranged weapons

### DIFF
--- a/Assets/Resources/Combat/Ranged/Weapons/Magic Shortbow.asset
+++ b/Assets/Resources/Combat/Ranged/Weapons/Magic Shortbow.asset
@@ -29,5 +29,24 @@ MonoBehaviour:
   recoveryChanceOnHit: 0.5
   recoveryChanceOnMiss: 0.2
   spawnRecoveryAsGroundItem: 1
-  releaseSoundId: 
+  restrictAmmoByList: 1
+  allowedAmmunition:
+  - {fileID: 11400000, guid: ee7fb6b5c91aa2d45ac94429e1377b7a, type: 2}
+  - {fileID: 11400000, guid: 2147ff14e11d13747996fb66b9ba3302, type: 2}
+  - {fileID: 11400000, guid: 32fbee3b40be44d4b9948543c649124c, type: 2}
+  - {fileID: 11400000, guid: f3034fe20e173264e91f2c8f57ccecbd, type: 2}
+  - {fileID: 11400000, guid: 1f844aed9846cbc46bb44ae0885596fb, type: 2}
+  - {fileID: 11400000, guid: 13a14b417cf9bbb49a7ec67b8c19acc2, type: 2}
+  - {fileID: 11400000, guid: a5ecf981d093e2046950927df575f845, type: 2}
+  - {fileID: 11400000, guid: a8e04f45145a0884ca0842861b848e3a, type: 2}
+  - {fileID: 11400000, guid: d414ac2465f127f4f96879b2db35db85, type: 2}
+  - {fileID: 11400000, guid: b60468d07f1f0784989cd51a8de6b427, type: 2}
+  - {fileID: 11400000, guid: e1e9aaba597d3ac43b1d223b905292e8, type: 2}
+  - {fileID: 11400000, guid: dc83e672a0a18074f8b3887436f43f08, type: 2}
+  - {fileID: 11400000, guid: baa48e48c08441043aff90914d2bc7ef, type: 2}
+  - {fileID: 11400000, guid: 7ee7c95fae0aee94086a215564355a27, type: 2}
+  - {fileID: 11400000, guid: dab7e75933c9f344783e22f0d90dca32, type: 2}
+  - {fileID: 11400000, guid: 004f6eb2ece44f949a4d61122d1a2e84, type: 2}
+  blockedAmmunition: []
+  releaseSoundId:
   specialEffect: {fileID: 0}

--- a/Assets/Resources/Combat/Ranged/Weapons/Maple Shortbow.asset
+++ b/Assets/Resources/Combat/Ranged/Weapons/Maple Shortbow.asset
@@ -29,5 +29,20 @@ MonoBehaviour:
   recoveryChanceOnHit: 0.5
   recoveryChanceOnMiss: 0.2
   spawnRecoveryAsGroundItem: 1
-  releaseSoundId: 
+  restrictAmmoByList: 1
+  allowedAmmunition:
+  - {fileID: 11400000, guid: ee7fb6b5c91aa2d45ac94429e1377b7a, type: 2}
+  - {fileID: 11400000, guid: 2147ff14e11d13747996fb66b9ba3302, type: 2}
+  - {fileID: 11400000, guid: 32fbee3b40be44d4b9948543c649124c, type: 2}
+  - {fileID: 11400000, guid: f3034fe20e173264e91f2c8f57ccecbd, type: 2}
+  - {fileID: 11400000, guid: 1f844aed9846cbc46bb44ae0885596fb, type: 2}
+  - {fileID: 11400000, guid: 13a14b417cf9bbb49a7ec67b8c19acc2, type: 2}
+  - {fileID: 11400000, guid: a5ecf981d093e2046950927df575f845, type: 2}
+  - {fileID: 11400000, guid: a8e04f45145a0884ca0842861b848e3a, type: 2}
+  - {fileID: 11400000, guid: d414ac2465f127f4f96879b2db35db85, type: 2}
+  - {fileID: 11400000, guid: b60468d07f1f0784989cd51a8de6b427, type: 2}
+  - {fileID: 11400000, guid: e1e9aaba597d3ac43b1d223b905292e8, type: 2}
+  - {fileID: 11400000, guid: dc83e672a0a18074f8b3887436f43f08, type: 2}
+  blockedAmmunition: []
+  releaseSoundId:
   specialEffect: {fileID: 0}

--- a/Assets/Resources/Combat/Ranged/Weapons/Oak Shortbow.asset
+++ b/Assets/Resources/Combat/Ranged/Weapons/Oak Shortbow.asset
@@ -29,5 +29,14 @@ MonoBehaviour:
   recoveryChanceOnHit: 0.5
   recoveryChanceOnMiss: 0.2
   spawnRecoveryAsGroundItem: 1
-  releaseSoundId: 
+  restrictAmmoByList: 1
+  allowedAmmunition:
+  - {fileID: 11400000, guid: ee7fb6b5c91aa2d45ac94429e1377b7a, type: 2}
+  - {fileID: 11400000, guid: 2147ff14e11d13747996fb66b9ba3302, type: 2}
+  - {fileID: 11400000, guid: 32fbee3b40be44d4b9948543c649124c, type: 2}
+  - {fileID: 11400000, guid: f3034fe20e173264e91f2c8f57ccecbd, type: 2}
+  - {fileID: 11400000, guid: 1f844aed9846cbc46bb44ae0885596fb, type: 2}
+  - {fileID: 11400000, guid: 13a14b417cf9bbb49a7ec67b8c19acc2, type: 2}
+  blockedAmmunition: []
+  releaseSoundId:
   specialEffect: {fileID: 0}

--- a/Assets/Resources/Combat/Ranged/Weapons/Shortbow.asset
+++ b/Assets/Resources/Combat/Ranged/Weapons/Shortbow.asset
@@ -29,5 +29,12 @@ MonoBehaviour:
   recoveryChanceOnHit: 0.5
   recoveryChanceOnMiss: 0.2
   spawnRecoveryAsGroundItem: 1
-  releaseSoundId: 
+  restrictAmmoByList: 1
+  allowedAmmunition:
+  - {fileID: 11400000, guid: ee7fb6b5c91aa2d45ac94429e1377b7a, type: 2}
+  - {fileID: 11400000, guid: 2147ff14e11d13747996fb66b9ba3302, type: 2}
+  - {fileID: 11400000, guid: 32fbee3b40be44d4b9948543c649124c, type: 2}
+  - {fileID: 11400000, guid: f3034fe20e173264e91f2c8f57ccecbd, type: 2}
+  blockedAmmunition: []
+  releaseSoundId:
   specialEffect: {fileID: 0}

--- a/Assets/Resources/Combat/Ranged/Weapons/Willow Shortbow.asset
+++ b/Assets/Resources/Combat/Ranged/Weapons/Willow Shortbow.asset
@@ -29,5 +29,18 @@ MonoBehaviour:
   recoveryChanceOnHit: 0.5
   recoveryChanceOnMiss: 0.2
   spawnRecoveryAsGroundItem: 1
-  releaseSoundId: 
+  restrictAmmoByList: 1
+  allowedAmmunition:
+  - {fileID: 11400000, guid: ee7fb6b5c91aa2d45ac94429e1377b7a, type: 2}
+  - {fileID: 11400000, guid: 2147ff14e11d13747996fb66b9ba3302, type: 2}
+  - {fileID: 11400000, guid: 32fbee3b40be44d4b9948543c649124c, type: 2}
+  - {fileID: 11400000, guid: f3034fe20e173264e91f2c8f57ccecbd, type: 2}
+  - {fileID: 11400000, guid: 1f844aed9846cbc46bb44ae0885596fb, type: 2}
+  - {fileID: 11400000, guid: 13a14b417cf9bbb49a7ec67b8c19acc2, type: 2}
+  - {fileID: 11400000, guid: a5ecf981d093e2046950927df575f845, type: 2}
+  - {fileID: 11400000, guid: a8e04f45145a0884ca0842861b848e3a, type: 2}
+  - {fileID: 11400000, guid: d414ac2465f127f4f96879b2db35db85, type: 2}
+  - {fileID: 11400000, guid: b60468d07f1f0784989cd51a8de6b427, type: 2}
+  blockedAmmunition: []
+  releaseSoundId:
   specialEffect: {fileID: 0}

--- a/Assets/Resources/Combat/Ranged/Weapons/Yew Shortbow.asset
+++ b/Assets/Resources/Combat/Ranged/Weapons/Yew Shortbow.asset
@@ -29,5 +29,24 @@ MonoBehaviour:
   recoveryChanceOnHit: 0.5
   recoveryChanceOnMiss: 0.2
   spawnRecoveryAsGroundItem: 1
-  releaseSoundId: 
+  restrictAmmoByList: 1
+  allowedAmmunition:
+  - {fileID: 11400000, guid: ee7fb6b5c91aa2d45ac94429e1377b7a, type: 2}
+  - {fileID: 11400000, guid: 2147ff14e11d13747996fb66b9ba3302, type: 2}
+  - {fileID: 11400000, guid: 32fbee3b40be44d4b9948543c649124c, type: 2}
+  - {fileID: 11400000, guid: f3034fe20e173264e91f2c8f57ccecbd, type: 2}
+  - {fileID: 11400000, guid: 1f844aed9846cbc46bb44ae0885596fb, type: 2}
+  - {fileID: 11400000, guid: 13a14b417cf9bbb49a7ec67b8c19acc2, type: 2}
+  - {fileID: 11400000, guid: a5ecf981d093e2046950927df575f845, type: 2}
+  - {fileID: 11400000, guid: a8e04f45145a0884ca0842861b848e3a, type: 2}
+  - {fileID: 11400000, guid: d414ac2465f127f4f96879b2db35db85, type: 2}
+  - {fileID: 11400000, guid: b60468d07f1f0784989cd51a8de6b427, type: 2}
+  - {fileID: 11400000, guid: e1e9aaba597d3ac43b1d223b905292e8, type: 2}
+  - {fileID: 11400000, guid: dc83e672a0a18074f8b3887436f43f08, type: 2}
+  - {fileID: 11400000, guid: baa48e48c08441043aff90914d2bc7ef, type: 2}
+  - {fileID: 11400000, guid: 7ee7c95fae0aee94086a215564355a27, type: 2}
+  - {fileID: 11400000, guid: dab7e75933c9f344783e22f0d90dca32, type: 2}
+  - {fileID: 11400000, guid: 004f6eb2ece44f949a4d61122d1a2e84, type: 2}
+  blockedAmmunition: []
+  releaseSoundId:
   specialEffect: {fileID: 0}

--- a/Assets/Scripts/Combat/Ranged/RangedCombatController.cs
+++ b/Assets/Scripts/Combat/Ranged/RangedCombatController.cs
@@ -77,6 +77,8 @@ namespace Combat.Ranged
         private string currentWeaponId;
         private string currentAmmoId;
         private int currentAmmoCount;
+        private string lastRejectedAmmoId;
+        private string lastRejectedWeaponId;
         private int initialAmmoCount;
         private float nextUiRefresh;
         private float lastAmmoWarningTime;
@@ -521,19 +523,24 @@ namespace Combat.Ranged
             if (equipmentComponent != null)
                 equipmentComponent.OverrideAmmoLabel(ammoEmptyLabel, ammoDepletedColor);
 
-            if (Time.unscaledTime - lastAmmoWarningTime >= WarningCooldownSeconds)
-            {
-                FloatingText.Show("You have run out of ammo!", transform.position + Vector3.up * 0.5f, Color.white);
-                if (!string.IsNullOrEmpty(ammoDepletedSoundId))
-                    SoundManager.Instance?.PlaySfxByFileName(ammoDepletedSoundId);
-                lastAmmoWarningTime = Time.unscaledTime;
-            }
+            ShowAmmoWarning("You have run out of ammo!", true);
         }
 
         private bool HasRequiredAmmo(RangedWeaponData weapon, AmmunitionData ammo)
         {
             if (weapon == null)
                 return false;
+
+            if (ammo != null && !weapon.IsAmmoAllowed(ammo))
+            {
+                if (currentAmmo == ammo)
+                {
+                    RejectCurrentAmmo(
+                        $"Ammunition '{ammo.name}' is blocked by '{weapon.name}' restriction data.",
+                        "Your weapon cannot use that ammo.");
+                }
+                return false;
+            }
 
             if (weapon.consumesWeaponStack)
                 return currentAmmoCount > 0;
@@ -542,6 +549,45 @@ namespace Combat.Ranged
                 return true;
 
             return currentAmmoCount > 0;
+        }
+
+        private void ShowAmmoWarning(string message, bool playDepletedSound)
+        {
+            if (string.IsNullOrEmpty(message))
+                return;
+
+            if (Time.unscaledTime - lastAmmoWarningTime < WarningCooldownSeconds)
+                return;
+
+            FloatingText.Show(message, transform.position + Vector3.up * 0.5f, Color.white);
+            if (playDepletedSound && !string.IsNullOrEmpty(ammoDepletedSoundId))
+                SoundManager.Instance?.PlaySfxByFileName(ammoDepletedSoundId);
+            lastAmmoWarningTime = Time.unscaledTime;
+        }
+
+        private void RejectCurrentAmmo(string debugMessage, string playerMessage, bool playAmmoDepletedSound = false, bool refreshUi = true)
+        {
+            if (!string.IsNullOrEmpty(debugMessage))
+            {
+                Debug.LogWarning(debugMessage, this);
+                Log(debugMessage);
+            }
+
+            if (!string.IsNullOrEmpty(currentWeaponId))
+                lastRejectedWeaponId = currentWeaponId;
+            if (!string.IsNullOrEmpty(currentAmmoId))
+                lastRejectedAmmoId = currentAmmoId;
+
+            currentAmmo = null;
+            currentAmmoId = null;
+            currentAmmoCount = 0;
+
+            if (equipmentComponent != null)
+                equipmentComponent.OverrideAmmoLabel(ammoEmptyLabel, ammoDepletedColor);
+
+            ShowAmmoWarning(playerMessage, playAmmoDepletedSound);
+            if (refreshUi)
+                UpdateAmmoUi();
         }
 
         private void CacheModifierProviders()
@@ -557,8 +603,15 @@ namespace Combat.Ranged
 
             var weaponEntry = equipmentComponent.GetEquipped(EquipmentSlot.Weapon);
             string weaponId = weaponEntry.item != null ? weaponEntry.item.id : null;
-            if (force || !string.Equals(currentWeaponId, weaponId, StringComparison.Ordinal))
+            bool weaponChanged = !string.Equals(currentWeaponId, weaponId, StringComparison.Ordinal);
+            if (force || weaponChanged)
             {
+                if (weaponChanged)
+                {
+                    lastRejectedAmmoId = null;
+                    lastRejectedWeaponId = null;
+                }
+
                 currentWeaponId = weaponId;
                 currentWeapon = !string.IsNullOrEmpty(weaponId) ? ResolveWeapon(weaponId) : null;
                 if (currentWeapon == null && !string.IsNullOrEmpty(weaponId))
@@ -577,27 +630,73 @@ namespace Combat.Ranged
             }
 
             string ammoId = ammoEntry.item != null ? ammoEntry.item.id : null;
-            if (force || !string.Equals(currentAmmoId, ammoId, StringComparison.Ordinal))
+            bool ammoChanged = !string.Equals(currentAmmoId, ammoId, StringComparison.Ordinal);
+            if (force || ammoChanged)
             {
-                currentAmmoId = ammoId;
-            currentAmmo = !string.IsNullOrEmpty(ammoId) ? ResolveAmmo(ammoId) : null;
-            if (currentAmmo == null && !string.IsNullOrEmpty(ammoId) && currentWeapon != null && !currentWeapon.consumesWeaponStack)
-                Log($"No AmmunitionData found for '{ammoId}'.");
-            initialAmmoCount = ammoEntry.count;
-        }
+                if (ammoChanged && !string.Equals(ammoId, lastRejectedAmmoId, StringComparison.Ordinal))
+                {
+                    lastRejectedAmmoId = null;
+                    lastRejectedWeaponId = null;
+                }
 
-        currentAmmoCount = ammoEntry.count;
-        if (currentAmmoCount > initialAmmoCount)
-            initialAmmoCount = currentAmmoCount;
-        if (currentWeapon != null && !currentWeapon.consumesWeaponStack && currentAmmo != null && currentAmmo.category != currentWeapon.ammunitionCategory)
-        {
-            Debug.LogWarning($"Ammunition '{currentAmmo.name}' is not compatible with weapon '{currentWeapon.name}'. Expected {currentWeapon.ammunitionCategory} but received {currentAmmo.category}.");
-            currentAmmo = null;
-            currentAmmoId = null;
-            currentAmmoCount = 0;
+                currentAmmoId = ammoId;
+                currentAmmo = !string.IsNullOrEmpty(ammoId) ? ResolveAmmo(ammoId) : null;
+                if (currentAmmo == null && !string.IsNullOrEmpty(ammoId) && currentWeapon != null && !currentWeapon.consumesWeaponStack)
+                    Log($"No AmmunitionData found for '{ammoId}'.");
+                initialAmmoCount = ammoEntry.count;
+            }
+
+            currentAmmoCount = ammoEntry.count;
+            if (currentAmmoCount > initialAmmoCount)
+                initialAmmoCount = currentAmmoCount;
+
+            if (currentWeapon != null && currentAmmo != null)
+            {
+                bool alreadyRejected = string.Equals(lastRejectedWeaponId, currentWeaponId, StringComparison.Ordinal) &&
+                    string.Equals(lastRejectedAmmoId, currentAmmoId, StringComparison.Ordinal);
+
+                if (!currentWeapon.consumesWeaponStack && currentAmmo.category != currentWeapon.ammunitionCategory)
+                {
+                    if (alreadyRejected)
+                    {
+                        currentAmmo = null;
+                        currentAmmoId = null;
+                        currentAmmoCount = 0;
+                        if (equipmentComponent != null)
+                            equipmentComponent.OverrideAmmoLabel(ammoEmptyLabel, ammoDepletedColor);
+                    }
+                    else
+                    {
+                        RejectCurrentAmmo(
+                            $"Ammunition '{currentAmmo.name}' is not compatible with weapon '{currentWeapon.name}'. Expected {currentWeapon.ammunitionCategory} but received {currentAmmo.category}.",
+                            "That ammo type doesn't fit your weapon.",
+                            false,
+                            false);
+                    }
+                }
+                else if (!currentWeapon.IsAmmoAllowed(currentAmmo))
+                {
+                    if (alreadyRejected)
+                    {
+                        currentAmmo = null;
+                        currentAmmoId = null;
+                        currentAmmoCount = 0;
+                        if (equipmentComponent != null)
+                            equipmentComponent.OverrideAmmoLabel(ammoEmptyLabel, ammoDepletedColor);
+                    }
+                    else
+                    {
+                        RejectCurrentAmmo(
+                            $"Ammunition '{currentAmmo.name}' is rejected by weapon '{currentWeapon.name}' due to explicit restriction lists.",
+                            "Your weapon cannot use that ammo.",
+                            false,
+                            false);
+                    }
+                }
+            }
+
+            UpdateAmmoUi();
         }
-        UpdateAmmoUi();
-    }
 
         private void UpdateAmmoUi()
         {

--- a/Assets/Scripts/Combat/Ranged/RangedWeaponData.cs
+++ b/Assets/Scripts/Combat/Ranged/RangedWeaponData.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 using Inventory;
 
@@ -86,6 +87,14 @@ namespace Combat.Ranged
         [Tooltip("If true, recovered ammo is spawned in the world when the inventory is full.")]
         public bool spawnRecoveryAsGroundItem = true;
 
+        [Header("Ammo Restrictions")]
+        [Tooltip("When true the allowed ammunition list becomes authoritative. Only entries explicitly listed are permitted.")]
+        public bool restrictAmmoByList;
+        [Tooltip("Specific ammunition assets this weapon is allowed to fire when restriction mode is enabled.")]
+        public AmmunitionData[] allowedAmmunition = Array.Empty<AmmunitionData>();
+        [Tooltip("Ammunition definitions the weapon can never use even when restriction mode is disabled.")]
+        public AmmunitionData[] blockedAmmunition = Array.Empty<AmmunitionData>();
+
         [Header("Feedback")]
         [Tooltip("Optional sound effect identifier consumed by SoundManager when the projectile is released.")]
         public string releaseSoundId;
@@ -109,6 +118,47 @@ namespace Combat.Ranged
         /// </summary>
         public float AttackIntervalSeconds => attackSpeedTicks * CombatMath.TICK_SECONDS;
 
+        /// <summary>
+        /// Returns true when the supplied ammunition asset is considered valid for this weapon.
+        /// Restriction mode enforces an allow-list while the block list functions regardless of the toggle.
+        /// </summary>
+        /// <param name="ammo">Ammunition definition resolved from the currently equipped stack.</param>
+        public bool IsAmmoAllowed(AmmunitionData ammo)
+        {
+            if (ammo == null)
+                return true;
+
+            if (restrictAmmoByList)
+            {
+                if (allowedAmmunition == null || allowedAmmunition.Length == 0)
+                    return false;
+
+                bool found = false;
+                for (int i = 0; i < allowedAmmunition.Length; i++)
+                {
+                    if (allowedAmmunition[i] == ammo)
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found)
+                    return false;
+            }
+
+            if (blockedAmmunition != null)
+            {
+                for (int i = 0; i < blockedAmmunition.Length; i++)
+                {
+                    if (blockedAmmunition[i] == ammo)
+                        return false;
+                }
+            }
+
+            return true;
+        }
+
         private void OnValidate()
         {
             attackSpeedTicks = Mathf.Max(1, attackSpeedTicks);
@@ -117,6 +167,9 @@ namespace Combat.Ranged
             projectileSpeed = Mathf.Max(0.1f, projectileSpeed);
             accuracyMultiplier = Mathf.Max(0f, accuracyMultiplier);
             damageMultiplier = Mathf.Max(0f, damageMultiplier);
+
+            allowedAmmunition ??= Array.Empty<AmmunitionData>();
+            blockedAmmunition ??= Array.Empty<AmmunitionData>();
 
             if (weaponItem != null && string.IsNullOrWhiteSpace(weaponIdOverride))
                 weaponIdOverride = weaponItem.id;


### PR DESCRIPTION
## Summary
- add serialised ammo restriction settings and helper lookups to `RangedWeaponData`
- enforce weapon ammo allow/deny rules in `RangedCombatController` while warning the player
- populate bow weapon assets with the specific arrow definitions they accept

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e29d25fb18832e84753ce586ebe170