### PR TITLE
Allow ammunition to override projectile visuals

### DIFF
--- a/Assets/Resources/Combat/Ranged/Ammunition/Adamant Arrow (p).asset
+++ b/Assets/Resources/Combat/Ranged/Ammunition/Adamant Arrow (p).asset
@@ -19,6 +19,8 @@ MonoBehaviour:
   accuracyMultiplier: 1
   damageMultiplier: 1
   rangeBonusTiles: 0
+  projectilePrefab: {fileID: 6111494187698877684, guid: 49d88a32b9d0c42409a40613d1ff07bd, type: 3}
+  projectileSpeedOverride: 0
   specialEffect: {fileID: 0}
   appliesPoison: 1
   poisonApplyChance: 0.25

--- a/Assets/Resources/Combat/Ranged/Ammunition/Adamant Arrow.asset
+++ b/Assets/Resources/Combat/Ranged/Ammunition/Adamant Arrow.asset
@@ -19,6 +19,8 @@ MonoBehaviour:
   accuracyMultiplier: 1
   damageMultiplier: 1
   rangeBonusTiles: 0
+  projectilePrefab: {fileID: 6111494187698877684, guid: 278fab5ddd4096c48b76003521dbf85c, type: 3}
+  projectileSpeedOverride: 0
   specialEffect: {fileID: 0}
   appliesPoison: 0
   poisonApplyChance: 0.25

--- a/Assets/Resources/Combat/Ranged/Ammunition/Black Arrow (p).asset
+++ b/Assets/Resources/Combat/Ranged/Ammunition/Black Arrow (p).asset
@@ -19,6 +19,8 @@ MonoBehaviour:
   accuracyMultiplier: 1
   damageMultiplier: 1
   rangeBonusTiles: 0
+  projectilePrefab: {fileID: 6111494187698877684, guid: 0e6818b3131ec6b4c94015651ec980ab, type: 3}
+  projectileSpeedOverride: 0
   specialEffect: {fileID: 0}
   appliesPoison: 1
   poisonApplyChance: 0.25

--- a/Assets/Resources/Combat/Ranged/Ammunition/Black Arrow.asset
+++ b/Assets/Resources/Combat/Ranged/Ammunition/Black Arrow.asset
@@ -19,6 +19,8 @@ MonoBehaviour:
   accuracyMultiplier: 1
   damageMultiplier: 1
   rangeBonusTiles: 0
+  projectilePrefab: {fileID: 6111494187698877684, guid: e3ccb48718900fb4c981f2675db328d6, type: 3}
+  projectileSpeedOverride: 0
   specialEffect: {fileID: 0}
   appliesPoison: 0
   poisonApplyChance: 0.25

--- a/Assets/Resources/Combat/Ranged/Ammunition/Bronze Arrow (p).asset
+++ b/Assets/Resources/Combat/Ranged/Ammunition/Bronze Arrow (p).asset
@@ -19,6 +19,8 @@ MonoBehaviour:
   accuracyMultiplier: 1
   damageMultiplier: 1
   rangeBonusTiles: 0
+  projectilePrefab: {fileID: 6111494187698877684, guid: 6d07780d82752db4c90addfc374ee76f, type: 3}
+  projectileSpeedOverride: 0
   specialEffect: {fileID: 0}
   appliesPoison: 1
   poisonApplyChance: 0.25

--- a/Assets/Resources/Combat/Ranged/Ammunition/Bronze Arrow.asset
+++ b/Assets/Resources/Combat/Ranged/Ammunition/Bronze Arrow.asset
@@ -19,6 +19,8 @@ MonoBehaviour:
   accuracyMultiplier: 1
   damageMultiplier: 1
   rangeBonusTiles: 0
+  projectilePrefab: {fileID: 6111494187698877684, guid: bb966b9337954ad409e85664bc0679d9, type: 3}
+  projectileSpeedOverride: 0
   specialEffect: {fileID: 0}
   appliesPoison: 0
   poisonApplyChance: 0.25

--- a/Assets/Resources/Combat/Ranged/Ammunition/Iron Arrow (p).asset
+++ b/Assets/Resources/Combat/Ranged/Ammunition/Iron Arrow (p).asset
@@ -19,6 +19,8 @@ MonoBehaviour:
   accuracyMultiplier: 1
   damageMultiplier: 1
   rangeBonusTiles: 0
+  projectilePrefab: {fileID: 6111494187698877684, guid: d86ada79c03a37842b3cbacad0f96ca2, type: 3}
+  projectileSpeedOverride: 0
   specialEffect: {fileID: 0}
   appliesPoison: 1
   poisonApplyChance: 0.25

--- a/Assets/Resources/Combat/Ranged/Ammunition/Iron Arrow.asset
+++ b/Assets/Resources/Combat/Ranged/Ammunition/Iron Arrow.asset
@@ -19,6 +19,8 @@ MonoBehaviour:
   accuracyMultiplier: 1
   damageMultiplier: 1
   rangeBonusTiles: 0
+  projectilePrefab: {fileID: 6111494187698877684, guid: 509a80fdac48b2d4cbe98b30ae26bfa7, type: 3}
+  projectileSpeedOverride: 0
   specialEffect: {fileID: 0}
   appliesPoison: 0
   poisonApplyChance: 0.25

--- a/Assets/Resources/Combat/Ranged/Ammunition/Mithril Arrow (p).asset
+++ b/Assets/Resources/Combat/Ranged/Ammunition/Mithril Arrow (p).asset
@@ -19,6 +19,8 @@ MonoBehaviour:
   accuracyMultiplier: 1
   damageMultiplier: 1
   rangeBonusTiles: 0
+  projectilePrefab: {fileID: 6111494187698877684, guid: 59fcf1ab29e945d4d90be0fb651d6259, type: 3}
+  projectileSpeedOverride: 0
   specialEffect: {fileID: 0}
   appliesPoison: 1
   poisonApplyChance: 0.25

--- a/Assets/Resources/Combat/Ranged/Ammunition/Mithril Arrow.asset
+++ b/Assets/Resources/Combat/Ranged/Ammunition/Mithril Arrow.asset
@@ -19,6 +19,8 @@ MonoBehaviour:
   accuracyMultiplier: 1
   damageMultiplier: 1
   rangeBonusTiles: 0
+  projectilePrefab: {fileID: 6111494187698877684, guid: dfd651891223b9c428bc7a91932e0ace, type: 3}
+  projectileSpeedOverride: 0
   specialEffect: {fileID: 0}
   appliesPoison: 0
   poisonApplyChance: 0.25

--- a/Assets/Resources/Combat/Ranged/Ammunition/Orichalcum Arrow (p).asset
+++ b/Assets/Resources/Combat/Ranged/Ammunition/Orichalcum Arrow (p).asset
@@ -19,6 +19,8 @@ MonoBehaviour:
   accuracyMultiplier: 1
   damageMultiplier: 1
   rangeBonusTiles: 0
+  projectilePrefab: {fileID: 6111494187698877684, guid: 9547536c546c062488efbc953701f18b, type: 3}
+  projectileSpeedOverride: 0
   specialEffect: {fileID: 0}
   appliesPoison: 1
   poisonApplyChance: 0.25

--- a/Assets/Resources/Combat/Ranged/Ammunition/Orichalcum Arrow.asset
+++ b/Assets/Resources/Combat/Ranged/Ammunition/Orichalcum Arrow.asset
@@ -19,6 +19,8 @@ MonoBehaviour:
   accuracyMultiplier: 1
   damageMultiplier: 1
   rangeBonusTiles: 0
+  projectilePrefab: {fileID: 6111494187698877684, guid: ffada92f2d71f2949b2f518e67ef5391, type: 3}
+  projectileSpeedOverride: 0
   specialEffect: {fileID: 0}
   appliesPoison: 0
   poisonApplyChance: 0.25

--- a/Assets/Resources/Combat/Ranged/Ammunition/Rune Arrow (p).asset
+++ b/Assets/Resources/Combat/Ranged/Ammunition/Rune Arrow (p).asset
@@ -19,6 +19,8 @@ MonoBehaviour:
   accuracyMultiplier: 1
   damageMultiplier: 1
   rangeBonusTiles: 0
+  projectilePrefab: {fileID: 6111494187698877684, guid: c523917a8580dfd4fa49d34327005609, type: 3}
+  projectileSpeedOverride: 0
   specialEffect: {fileID: 0}
   appliesPoison: 1
   poisonApplyChance: 0.25

--- a/Assets/Resources/Combat/Ranged/Ammunition/Rune Arrow.asset
+++ b/Assets/Resources/Combat/Ranged/Ammunition/Rune Arrow.asset
@@ -19,6 +19,8 @@ MonoBehaviour:
   accuracyMultiplier: 1
   damageMultiplier: 1
   rangeBonusTiles: 0
+  projectilePrefab: {fileID: 6111494187698877684, guid: 1c3ab66455793e445b48f4e4c0a23239, type: 3}
+  projectileSpeedOverride: 0
   specialEffect: {fileID: 0}
   appliesPoison: 0
   poisonApplyChance: 0.25

--- a/Assets/Resources/Combat/Ranged/Ammunition/Steel Arrow (p).asset
+++ b/Assets/Resources/Combat/Ranged/Ammunition/Steel Arrow (p).asset
@@ -19,6 +19,8 @@ MonoBehaviour:
   accuracyMultiplier: 1
   damageMultiplier: 1
   rangeBonusTiles: 0
+  projectilePrefab: {fileID: 6111494187698877684, guid: f5cc20e4ec3caa44488dc87d7a322d65, type: 3}
+  projectileSpeedOverride: 0
   specialEffect: {fileID: 0}
   appliesPoison: 1
   poisonApplyChance: 0.25

--- a/Assets/Resources/Combat/Ranged/Ammunition/Steel Arrow.asset
+++ b/Assets/Resources/Combat/Ranged/Ammunition/Steel Arrow.asset
@@ -19,6 +19,8 @@ MonoBehaviour:
   accuracyMultiplier: 1
   damageMultiplier: 1
   rangeBonusTiles: 0
+  projectilePrefab: {fileID: 6111494187698877684, guid: 1fb7a6a76afdbf94c97dd5a3c75bf196, type: 3}
+  projectileSpeedOverride: 0
   specialEffect: {fileID: 0}
   appliesPoison: 0
   poisonApplyChance: 0.25

--- a/Assets/Scripts/Combat/Ranged/AmmunitionData.cs
+++ b/Assets/Scripts/Combat/Ranged/AmmunitionData.cs
@@ -27,6 +27,12 @@ namespace Combat.Ranged
         [Tooltip("Extra tiles added to the weapon's range when this ammo is loaded.")]
         public float rangeBonusTiles;
 
+        [Header("Projectiles")]
+        [Tooltip("Projectile prefab spawned when this ammunition is fired. Overrides the weapon default when assigned.")]
+        public GameObject projectilePrefab;
+        [Tooltip("Optional projectile speed override expressed in units per second. Set to 0 to use the weapon's speed.")]
+        [Min(0f)] public float projectileSpeedOverride;
+
         [Header("Effects")]
         [Tooltip("Optional special effect triggered when the projectile lands.")]
         public RangedSpecialEffect specialEffect;
@@ -59,6 +65,7 @@ namespace Combat.Ranged
         {
             accuracyMultiplier = Mathf.Max(0f, accuracyMultiplier);
             damageMultiplier = Mathf.Max(0f, damageMultiplier);
+            projectileSpeedOverride = Mathf.Max(0f, projectileSpeedOverride);
             if (ammoItem != null && string.IsNullOrWhiteSpace(ammoIdOverride))
                 ammoIdOverride = ammoItem.id;
         }

--- a/Assets/Scripts/Combat/Ranged/RangedCombatController.cs
+++ b/Assets/Scripts/Combat/Ranged/RangedCombatController.cs
@@ -335,7 +335,11 @@ namespace Combat.Ranged
         {
             context = EnsureContextWeapon(context);
             RangedWeaponData weaponReference = context.weapon;
-            var prefab = weaponReference != null ? weaponReference.projectilePrefab : null;
+            GameObject prefab = null;
+            if (context.ammunition != null && context.ammunition.projectilePrefab != null)
+                prefab = context.ammunition.projectilePrefab;
+            else if (weaponReference != null)
+                prefab = weaponReference.projectilePrefab;
             if (prefab == null)
             {
                 ShotFired?.Invoke(context);
@@ -375,6 +379,8 @@ namespace Combat.Ranged
                 SoundManager.Instance?.PlaySfxByFileName(context.weapon.releaseSoundId);
 
             float projectileSpeed = weaponReference != null ? weaponReference.projectileSpeed : 10f;
+            if (context.ammunition != null && context.ammunition.projectileSpeedOverride > 0f)
+                projectileSpeed = context.ammunition.projectileSpeedOverride;
             projectile.Initialise(this, context.target, context, projectileSpeed);
         }
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,6 +1,15 @@
 # Session Log
 This file is auto-updated by CI on every push. Times shown are Europe/London.
 
+<!-- commit:d52806ffe4069db246f37e26044e6d935a12ce2b -->
+## 2025-10-05T17:45:17+01:00 — Allow ammunition to override projectile visuals
+
+- Author: aicovergod <lewisshuffle136@gmail.com>
+- Changed files (18): Assets/Resources/Combat/Ranged/Ammunition/Adamant Arrow (p).asset, Assets/Resources/Combat/Ranged/Ammunition/Adamant Arrow.asset, Assets/Resources/Combat/Ranged/Ammunition/Black Arrow (p).asset, Assets/Resources/Combat/Ranged/Ammunition/Black Arrow.asset, Assets/Resources/Combat/Ranged/Ammunition/Bronze Arrow (p).asset, Assets/Resources/Combat/Ranged/Ammunition/Bronze Arrow.asset, Assets/Resources/Combat/Ranged/Ammunition/Iron Arrow (p).asset, Assets/Resources/Combat/Ranged/Ammunition/Iron Arrow.asset, Assets/Resources/Combat/Ranged/Ammunition/Mithril Arrow (p).asset, Assets/Resources/Combat/Ranged/Ammunition/Mithril Arrow.asset, Assets/Resources/Combat/Ranged/Ammunition/Orichalcum Arrow (p).asset, Assets/Resources/Combat/Ranged/Ammunition/Orichalcum Arrow.asset, Assets/Resources/Combat/Ranged/Ammunition/Rune Arrow (p).asset, Assets/Resources/Combat/Ranged/Ammunition/Rune Arrow.asset, Assets/Resources/Combat/Ranged/Ammunition/Steel Arrow (p).asset, Assets/Resources/Combat/Ranged/Ammunition/Steel Arrow.asset, Assets/Scripts/Combat/Ranged/AmmunitionData.cs, Assets/Scripts/Combat/Ranged/RangedCombatController.cs
+- Diff: 46 ++ / 1 --
+- Notes:
+  —
+---
 <!-- commit:5ce211b75af78384c6d8348ea125bcb33953363b -->
 ## 2025-10-05T17:40:09+01:00 — Merge pull request #1011 from aicovergod/codex/add-ammo-restrictions-to-ranged-weapons
 


### PR DESCRIPTION
## Summary
- allow ammunition definitions to provide bespoke projectile prefabs and optional speed overrides
- update ranged combat controller to respect ammo-prefab overrides while defaulting to the weapon projectile when needed
- assign the correct projectile prefab to each arrow ammunition asset so their visuals match the ammo type

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e29f8179bc832e827cf08a9f28e87c