### PR TITLE
Adjust damage type detection to respect equipped weapon

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -339,14 +339,39 @@ namespace Combat
             else if (loadout != null)
                 stats = loadout.GetCombatantStats();
 
+            // Cache the currently equipped weapon once so multiple checks all reference
+            // the same item data. This avoids recomputing lookups when we need to cross
+            // validate the combat profile with the actual equipment.
+            var weapon = GetEquippedWeapon();
+
             if (stats != null)
-                return stats.DamageType;
+            {
+                var reportedType = stats.DamageType;
+
+                if (reportedType == DamageType.Melee && weapon != null)
+                {
+                    // Some merged combat profiles default to melee even when the player
+                    // equips a ranged or magic weapon (for example when using pet merge
+                    // loadouts). In those cases we trust the weapon's combat stats over
+                    // the profile so movement and range checks line up with the equipped
+                    // item.
+                    if (weapon.combat.Magic > 0)
+                        return DamageType.Magic;
+
+                    if (weapon.combat.Range > 0 || weapon.combat.RangeStrength > 0)
+                        return DamageType.Ranged;
+                }
+
+                // Pet merge profiles that explicitly flag ranged or magic combat types
+                // should retain their declared damage category, so only melee defaults
+                // are adjusted above.
+                return reportedType;
+            }
 
             var activeSpell = MagicUI.ActiveSpell;
             if (activeSpell != null)
                 return DamageType.Magic;
 
-            var weapon = GetEquippedWeapon();
             if (weapon != null)
             {
                 if (weapon.combat.Magic > 0)

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,6 +1,15 @@
 # Session Log
 This file is auto-updated by CI on every push. Times shown are Europe/London.
 
+<!-- commit:e0656a606936ed81d1273f842b90bcbed13247e1 -->
+## 2025-10-05T18:25:46+01:00 — Adjust damage type detection to respect equipped weapon
+
+- Author: aicovergod <lewisshuffle136@gmail.com>
+- Changed files (1): Assets/Scripts/Combat/CombatController.cs
+- Diff: 27 ++ / 2 --
+- Notes:
+  —
+---
 <!-- commit:65d3ad33095222a1beff14e867904ce7f1548838 -->
 ## 2025-10-05T17:46:50+01:00 — Merge pull request #1012 from aicovergod/codex/add-projectile-prefab-and-speed-override
 


### PR DESCRIPTION
## Summary
- ensure CombatController cross-checks the equipped weapon when resolving the active damage type
- override melee profiles to ranged or magic when the weapon's combat stats indicate non-melee behaviour while keeping explicit ranged/magic profiles intact

## Testing
- not run (requires Unity editor)

------
https://chatgpt.com/codex/tasks/task_e_68e2a8d430d4832e9afc317755f482ce