### PR TITLE
Handle ranged weapon keywords in combat controller

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -120,6 +121,16 @@ namespace Combat
 
         [Header("Line of Sight")]
         private static readonly string[] DefaultObstructionLayers = { "Obstacles", "Obstacle", "Physical Objects" };
+
+        private static readonly string[] RangedWeaponNameKeywords =
+        {
+            "crossbow",
+            "dart",
+            "javelin",
+            "throwing knife",
+            "shortbow",
+            "longbow"
+        };
 
         [SerializeField, Tooltip("Layers considered solid when checking whether swings or spells have a clear path to the target.")]
         private LayerMask obstructionMask;
@@ -358,6 +369,9 @@ namespace Combat
                     if (weapon.combat.Magic > 0)
                         return DamageType.Magic;
 
+                    if (WeaponNameIndicatesRanged(weapon))
+                        return DamageType.Ranged;
+
                     if (weapon.combat.Range > 0 || weapon.combat.RangeStrength > 0)
                         return DamageType.Ranged;
                 }
@@ -376,11 +390,33 @@ namespace Combat
             {
                 if (weapon.combat.Magic > 0)
                     return DamageType.Magic;
+
+                if (WeaponNameIndicatesRanged(weapon))
+                    return DamageType.Ranged;
                 if (weapon.combat.Range > 0 || weapon.combat.RangeStrength > 0)
                     return DamageType.Ranged;
             }
 
             return DamageType.Melee;
+        }
+
+        /// <summary>
+        /// Inspect the equipped weapon's display name to catch ranged weapons that lack
+        /// explicit ranged stat blocks. The lookup is case-insensitive so variations in
+        /// item naming (Longbow vs. longbow) still flag the weapon as ranged.
+        /// </summary>
+        private bool WeaponNameIndicatesRanged(Inventory.ItemData weapon)
+        {
+            if (weapon == null || string.IsNullOrWhiteSpace(weapon.itemName))
+                return false;
+
+            foreach (string keyword in RangedWeaponNameKeywords)
+            {
+                if (weapon.itemName.IndexOf(keyword, StringComparison.OrdinalIgnoreCase) >= 0)
+                    return true;
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,6 +1,15 @@
 # Session Log
 This file is auto-updated by CI on every push. Times shown are Europe/London.
 
+<!-- commit:f4423877bce7caa1d40e95f5e0e5bdf1c87f85b6 -->
+## 2025-10-05T18:36:52+01:00 — Adjust ranged damage detection for thrown weapons
+
+- Author: aicovergod <lewisshuffle136@gmail.com>
+- Changed files (1): Assets/Scripts/Combat/CombatController.cs
+- Diff: 36 ++ / 0 --
+- Notes:
+  —
+---
 <!-- commit:a429eb81485c56035137b82208f621eb1b3d0ccd -->
 ## 2025-10-05T18:26:09+01:00 — Merge pull request #1013 from aicovergod/codex/update-determineactivedamagetype-logic
 


### PR DESCRIPTION
## Summary
- add a helper that recognises ranged weapon keywords from the equipped weapon name
- force ranged damage type when melee profiles equip keyword-matched weapons while preserving existing magic overrides

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2ab2067b4832e83f0fedf874adeb4