### PR TITLE
Ensure ranged projectiles persist for a frame at impact

### DIFF
--- a/Assets/Scripts/Combat/Ranged/RangedProjectile.cs
+++ b/Assets/Scripts/Combat/Ranged/RangedProjectile.cs
@@ -40,21 +40,17 @@ namespace Combat.Ranged
             while (lifetime < maxLifetime)
             {
                 Vector3 destination = ResolveDestination();
-                Vector3 toTarget = destination - transform.position;
-                float sqrDistance = toTarget.sqrMagnitude;
                 float step = speed * Time.deltaTime;
-                float sqrStep = step * step;
+                Vector3 newPosition = Vector3.MoveTowards(transform.position, destination, step);
+                bool reachedDestination = newPosition == destination || speed <= 0.001f;
 
-                if (sqrDistance <= sqrStep || speed <= 0.001f)
-                {
-                    transform.position = destination;
-                    break;
-                }
-
-                transform.position += toTarget.normalized * step;
+                transform.position = newPosition;
                 context.targetPosition = destination;
                 lifetime += Time.deltaTime;
                 yield return null;
+
+                if (reachedDestination)
+                    break;
             }
 
             travelRoutine = null;

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,6 +1,15 @@
 # Session Log
 This file is auto-updated by CI on every push. Times shown are Europe/London.
 
+<!-- commit:06c1e0c1352e7672c5001ae0e36487e1d713fabb -->
+## 2025-10-05T19:09:04+01:00 — Ensure ranged projectiles persist for a frame at impact
+
+- Author: aicovergod <lewisshuffle136@gmail.com>
+- Changed files (1): Assets/Scripts/Combat/Ranged/RangedProjectile.cs
+- Diff: 6 ++ / 10 --
+- Notes:
+  —
+---
 <!-- commit:9055b92d4ff6d22f190b8510c44cb37b1c3fc76e -->
 ## 2025-10-05T18:45:54+01:00 — uwu
 


### PR DESCRIPTION
## Summary
- clamp projectile travel with Vector3.MoveTowards so the context is updated even on very short hops
- ensure the ranged projectile coroutine always yields before breaking so the projectile remains visible for at least one frame

## Testing
- Not run (Unity editor not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e2b2aea090832eb5140e36bc7c7cb7