### PR TITLE
Align ranged projectiles with their travel direction

### DIFF
--- a/Assets/Scripts/Combat/Ranged/RangedProjectile.cs
+++ b/Assets/Scripts/Combat/Ranged/RangedProjectile.cs
@@ -41,6 +41,15 @@ namespace Combat.Ranged
             {
                 Vector3 destination = ResolveDestination();
                 float step = speed * Time.deltaTime;
+
+                // Align the projectile so the sprite always faces the direction of travel, matching
+                // the behaviour used by spell projectiles. This keeps arrow sprites (authored to
+                // point upward) visually pointing along their flight path regardless of target
+                // movement.
+                Vector3 toDestination = destination - transform.position;
+                if (toDestination.sqrMagnitude > 0.0001f)
+                    transform.up = toDestination;
+
                 Vector3 newPosition = Vector3.MoveTowards(transform.position, destination, step);
                 bool reachedDestination = newPosition == destination || speed <= 0.001f;
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,6 +1,15 @@
 # Session Log
 This file is auto-updated by CI on every push. Times shown are Europe/London.
 
+<!-- commit:2d94c98f646ba86ff1b4b27edcf036878fc487a6 -->
+## 2025-10-05T19:17:03+01:00 — Align ranged projectile orientation with travel direction
+
+- Author: aicovergod <lewisshuffle136@gmail.com>
+- Changed files (1): Assets/Scripts/Combat/Ranged/RangedProjectile.cs
+- Diff: 9 ++ / 0 --
+- Notes:
+  —
+---
 <!-- commit:40c7f1f10287a4066e4b7e25600b62c8c0b0cf42 -->
 ## 2025-10-05T19:10:13+01:00 — Merge pull request #1016 from aicovergod/codex/modify-rangedprojectile-travelroutine
 


### PR DESCRIPTION
## Summary
- rotate ranged projectiles toward their destination each frame so arrow sprites always face their travel direction
- keep ranged visuals consistent with spell projectiles even when targets move mid-flight

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2b54a50f8832eb6a0cefeeb0e6eb8