### PR TITLE
Stop ranged combat when ammo is depleted

### DIFF
--- a/Assets/Scripts/Combat/Ranged/RangedCombatController.cs
+++ b/Assets/Scripts/Combat/Ranged/RangedCombatController.cs
@@ -642,6 +642,7 @@ namespace Combat.Ranged
                 equipmentComponent.OverrideAmmoLabel(ammoEmptyLabel, ammoDepletedColor);
 
             ShowAmmoWarning("You have run out of ammo!", true);
+            combatController?.CancelCombat();
         }
 
         private bool HasRequiredAmmo(RangedWeaponData weapon, AmmunitionData ammo)


### PR DESCRIPTION
## Summary
- call `CancelCombat` when ammo runs out so ranged attacks stop immediately and targets clear

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e390dae954832e9787b3de9be21e06