### PR TITLE
Cache quest UI reference in inventory

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -136,6 +136,9 @@ namespace Inventory
         private Equipment equipment;
         private FiremakingSkill firemakingSkill;
 
+        // Cached quest UI reference to avoid per-frame lookups.
+        private QuestUI questUi;
+
         // UI
         private GameObject uiRoot; // Canvas root
         private static GameObject sharedUIRoot;
@@ -306,11 +309,16 @@ namespace Inventory
         {
             EnsureInitialized();
             SaveManager.Register(this);
+            QuestUI.QuestUIOpened += OnQuestUiOpened;
+            QuestUI.QuestUIClosed += OnQuestUiClosed;
+            questUi = QuestUI.Instance;
         }
 
         private void OnDisable()
         {
             SaveManager.Unregister(this);
+            QuestUI.QuestUIOpened -= OnQuestUiOpened;
+            QuestUI.QuestUIClosed -= OnQuestUiClosed;
         }
 
         /// <summary>
@@ -1603,8 +1611,9 @@ namespace Inventory
             if (playerMover == null)
                 return;
 
-            var quest = Object.FindObjectOfType<QuestUI>();
-            if (quest != null && quest.IsOpen)
+            EnsureQuestUiReference();
+
+            if (questUi != null && questUi.IsOpen)
             {
                 if (uiRoot != null && uiRoot.activeSelf)
                     CloseUI();
@@ -1636,6 +1645,40 @@ namespace Inventory
                     CloseUI();
                 }
             }
+        }
+
+        /// <summary>
+        /// Ensures the cached quest UI reference stays valid without per-frame allocations.
+        /// </summary>
+        private void EnsureQuestUiReference()
+        {
+            if (questUi == null)
+                questUi = QuestUI.Instance;
+        }
+
+        /// <summary>
+        /// Handles quest UI open events so the inventory can immediately react.
+        /// </summary>
+        private void OnQuestUiOpened(QuestUI quest)
+        {
+            questUi = quest ?? QuestUI.Instance;
+
+            if (questUi != null && questUi.IsOpen && uiRoot != null && uiRoot.activeSelf)
+                CloseUI();
+        }
+
+        /// <summary>
+        /// Keeps the cached quest UI reference in sync when the quest window closes or is destroyed.
+        /// </summary>
+        private void OnQuestUiClosed(QuestUI quest)
+        {
+            if (quest == null)
+            {
+                questUi = null;
+                return;
+            }
+
+            questUi = quest;
         }
 
         /// <summary>

--- a/Assets/Scripts/Quests/QuestUI.cs
+++ b/Assets/Scripts/Quests/QuestUI.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.UI;
@@ -27,6 +28,21 @@ namespace Quests
 
         private static QuestUI instance;
 
+        /// <summary>
+        /// Raised whenever the quest UI finishes opening.
+        /// </summary>
+        public static event Action<QuestUI> QuestUIOpened;
+
+        /// <summary>
+        /// Raised whenever the quest UI finishes closing.
+        /// </summary>
+        public static event Action<QuestUI> QuestUIClosed;
+
+        /// <summary>
+        /// Cached singleton-style access for systems that need to query quest visibility.
+        /// </summary>
+        public static QuestUI Instance => instance;
+
         public bool IsOpen => canvas != null && canvas.enabled;
 
         protected override void Awake()
@@ -55,7 +71,11 @@ namespace Quests
         private void OnDestroy()
         {
             if (instance == this)
+            {
+                if (canvas != null && canvas.enabled)
+                    QuestUIClosed?.Invoke(this);
                 instance = null;
+            }
         }
 
         private void Start()
@@ -74,6 +94,7 @@ namespace Quests
 
         public void Open()
         {
+            bool wasOpen = IsOpen;
             UIManager.Instance.OpenWindow(this);
             var inv = FindObjectOfType<Inventory.Inventory>();
             if (inv != null && inv.IsOpen)
@@ -87,14 +108,22 @@ namespace Quests
                 playerMover = FindObjectOfType<PlayerMover>();
             if (playerMover != null)
                 playerMover.enabled = false;
+
+            if (!wasOpen)
+                QuestUIOpened?.Invoke(this);
         }
 
         public void Close()
         {
+            if (!IsOpen)
+                return;
+
             canvas.enabled = false;
             Clear();
             if (playerMover != null)
                 playerMover.enabled = true;
+
+            QuestUIClosed?.Invoke(this);
         }
 
         private void Update()


### PR DESCRIPTION
## Summary
- add QuestUI open/close events and expose the current instance for consumers
- cache the quest UI reference inside Inventory and react to visibility events instead of performing per-frame lookups

## Testing
- not run (Unity editor not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e3a5ab14c0832eb4dabeb97d81f3b7