### PR TITLE
Ensure ranged projectiles dispatch impact before disable

### DIFF
--- a/Assets/Scripts/Combat/Ranged/RangedProjectile.cs
+++ b/Assets/Scripts/Combat/Ranged/RangedProjectile.cs
@@ -18,6 +18,7 @@ namespace Combat.Ranged
         private RangedAttackContext context;
         private float speed;
         private Coroutine travelRoutine;
+        private bool impactDispatched;
 
         /// <summary>
         /// Initialises the projectile for travel towards <paramref name="target"/>.
@@ -37,6 +38,7 @@ namespace Combat.Ranged
         private IEnumerator TravelRoutine()
         {
             float lifetime = 0f;
+            impactDispatched = false;
             while (lifetime < maxLifetime)
             {
                 Vector3 destination = ResolveDestination();
@@ -47,14 +49,23 @@ namespace Combat.Ranged
                 transform.position = newPosition;
                 context.targetPosition = destination;
                 lifetime += Time.deltaTime;
-                yield return null;
-
                 if (reachedDestination)
+                {
+                    owner?.HandleProjectileImpact(context, this);
+                    impactDispatched = true;
+                    yield return null;
                     break;
+                }
+
+                yield return null;
             }
 
             travelRoutine = null;
-            owner?.HandleProjectileImpact(context, this);
+            if (!impactDispatched)
+            {
+                owner?.HandleProjectileImpact(context, this);
+                impactDispatched = true;
+            }
         }
 
         private Vector3 ResolveDestination()
@@ -74,6 +85,11 @@ namespace Combat.Ranged
             {
                 StopCoroutine(travelRoutine);
                 travelRoutine = null;
+                if (!impactDispatched)
+                {
+                    owner?.HandleProjectileImpact(context, this);
+                    impactDispatched = true;
+                }
             }
         }
     }

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,6 +1,15 @@
 # Session Log
 This file is auto-updated by CI on every push. Times shown are Europe/London.
 
+<!-- commit:eaca487ef630b4c6dbd3e22cf2ebcb7d4bf33de1 -->
+## 2025-10-07T19:25:22+01:00 — Ensure projectile impact dispatch survives disable
+
+- Author: aicovergod <lewisshuffle136@gmail.com>
+- Changed files (1): Assets/Scripts/Combat/Ranged/RangedProjectile.cs
+- Diff: 19 ++ / 3 --
+- Notes:
+  —
+---
 <!-- commit:06c1e0c1352e7672c5001ae0e36487e1d713fabb -->
 ## 2025-10-05T19:09:04+01:00 — Ensure ranged projectiles persist for a frame at impact
 


### PR DESCRIPTION
## Summary
- dispatch projectile impacts before yielding so external disables cannot suppress the hit callback
- track impact dispatch state so coroutine completion and OnDisable only notify once
- fall back to notifying on OnDisable when the coroutine is interrupted mid-flight

## Testing
- Not run (Unity editor not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e55a8a79b0832e85d9e8f255c49535