### PR TITLE
Fix quest UI close button to trigger Close workflow

### DIFF
--- a/Assets/Scripts/Quests/QuestUI.cs
+++ b/Assets/Scripts/Quests/QuestUI.cs
@@ -219,7 +219,9 @@ namespace Quests
             var closeText = CreateText("X", closeRect, Vector2.zero, Vector2.one, Vector2.zero);
             closeText.alignment = TextAnchor.MiddleCenter;
             closeBtnGO.GetComponent<Image>().color = Color.clear;
-            closeBtnGO.GetComponent<Button>().onClick.AddListener(() => canvas.enabled = false);
+            // Route the close button through the standard Close path so player movement and
+            // QuestUIClosed subscribers are restored/notified just like other exit flows.
+            closeBtnGO.GetComponent<Button>().onClick.AddListener(Close);
         }
 
         private Text CreateText(string name, RectTransform parent, Vector2 anchorMin, Vector2 anchorMax, Vector2 offset)

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,6 +1,15 @@
 # Session Log
 This file is auto-updated by CI on every push. Times shown are Europe/London.
 
+<!-- commit:0e72088b0bc681ac534c013aa4fbb1a475ab981e -->
+## 2025-10-08T11:48:14+01:00 — Fix quest UI close button to use Close method
+
+- Author: aicovergod <lewisshuffle136@gmail.com>
+- Changed files (1): Assets/Scripts/Quests/QuestUI.cs
+- Diff: 3 ++ / 1 --
+- Notes:
+  —
+---
 <!-- commit:cf33410e54e9e98c98ea56af78c4e4c9de8cfbd9 -->
 ## 2025-10-08T11:04:09+01:00 — Merge pull request #1033 from aicovergod/codex/update-questui-to-manage-listeners-properly
 


### PR DESCRIPTION
## Summary
- route the Quest UI close button through the existing Close() path so player movement resumes and listeners are notified

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e63f432e3c832e9ef76666303386bc