### PR TITLE
Fix stacking when equipping identical stackable items

### DIFF
--- a/Assets/Scripts/Inventory/Equipment.cs
+++ b/Assets/Scripts/Inventory/Equipment.cs
@@ -394,6 +394,51 @@ namespace Inventory
             }
 
             var current = equipped[index];
+
+            // Merge stackable equipment when the same item is already equipped instead of swapping it back
+            // into the inventory. This mirrors OSRS behaviour where throwing weapons, arrows, and similar
+            // stackables add to the equipped stack when re-equipped from the inventory.
+            if (current.item != null && entry.item != null && current.item == entry.item && current.item.stackable)
+            {
+                int maxStack = current.item.MaxStack;
+                int availableSpace = Mathf.Max(0, maxStack - current.count);
+                if (availableSpace <= 0)
+                {
+                    // The equipped stack is already capped. Notify the player and abort so the original
+                    // inventory slot restoration logic can place the stack back where it came from.
+                    FloatingText.Show("You cannot equip any more of that.", anchor.position);
+                    return false;
+                }
+
+                int transferAmount = Mathf.Min(entry.count, availableSpace);
+                if (transferAmount <= 0)
+                {
+                    FloatingText.Show("You cannot equip any more of that.", anchor.position);
+                    return false;
+                }
+
+                int overflow = entry.count - transferAmount;
+                if (overflow > 0)
+                {
+                    // Return the overflow to the inventory. If the bag is full we abort so nothing is lost
+                    // and the calling inventory logic restores the original stack.
+                    if (inventory == null || !inventory.AddItem(entry.item, overflow))
+                    {
+                        FloatingText.Show("Your inventory is full", anchor.position);
+                        return false;
+                    }
+                }
+
+                current.count += transferAmount;
+                equipped[index] = current;
+                UpdateSlotVisual(slot);
+                UpdateBonuses();
+                Save();
+                OnEquipmentChanged?.Invoke(slot);
+                ItemUseResolver.NotifyItemUsed(gameObject, entry.item, ItemUseType.Equipped);
+                return true;
+            }
+
             if (current.item != null)
             {
                 if (inventory != null && !inventory.AddItem(current.item, current.count))

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,6 +1,15 @@
 # Session Log
 This file is auto-updated by CI on every push. Times shown are Europe/London.
 
+<!-- commit:bc5001c8581d274d319d1eca86fd7d848a6f4c62 -->
+## 2025-10-08T15:31:04+01:00 — Fix stacking when equipping identical stackable items
+
+- Author: aicovergod <lewisshuffle136@gmail.com>
+- Changed files (1): Assets/Scripts/Inventory/Equipment.cs
+- Diff: 45 ++ / 0 --
+- Notes:
+  —
+---
 <!-- commit:7123eb7dfa732e9592dbfb2ba01a8744b8c65c90 -->
 ## 2025-10-08T12:30:39+01:00 — Merge pull request #1036 from aicovergod/codex/fix-item-deletion-on-shop-sell
 


### PR DESCRIPTION
## Summary
- merge stackable items into the existing equipped stack instead of swapping back to inventory
- return overflow to the inventory and surface feedback when equipment stacks are full

## Testing
- not run (Unity editor required)

------
https://chatgpt.com/codex/tasks/task_e_68e674a957c8832ea573e40e58568323