### PR TITLE
Update attack styles for ranged weapons

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -932,6 +932,7 @@ namespace Combat
                 {
                     case CombatStyle.Defensive:
                     case CombatStyle.Controlled:
+                    case CombatStyle.Longrange:
                         float split = total * 0.5f;
                         skills?.AddXP(SkillType.Ranged, split);
                         skills?.AddXP(SkillType.Defence, split);

--- a/Assets/Scripts/Combat/CombatEnums.cs
+++ b/Assets/Scripts/Combat/CombatEnums.cs
@@ -37,6 +37,8 @@ namespace Combat
         Accurate,
         Aggressive,
         Defensive,
-        Controlled
+        Controlled,
+        Rapid,
+        Longrange
     }
 }

--- a/Assets/Scripts/Combat/CombatMath.cs
+++ b/Assets/Scripts/Combat/CombatMath.cs
@@ -53,6 +53,7 @@ namespace Combat
                 CombatStyle.Accurate => 3,
                 CombatStyle.Defensive => 1,
                 CombatStyle.Controlled => 1,
+                CombatStyle.Longrange => 1,
                 _ => 0
             };
             return level + bonus + 8;

--- a/Assets/Scripts/Combat/CombatantStats.cs
+++ b/Assets/Scripts/Combat/CombatantStats.cs
@@ -22,6 +22,24 @@ namespace Combat
         /// </summary>
         public static CombatantStats ForPlayer(SkillManager skills, EquipmentAggregator equip, CombatStyle style, DamageType type)
         {
+            var combinedStats = equip != null ? equip.GetCombinedStats() : default;
+
+            if (type == DamageType.Ranged)
+            {
+                // When the player is using ranged weapons the selected combat style
+                // grants hidden equipment-style bonuses that should not appear in the
+                // equipment window. Adjust the aggregated stats here so every combat
+                // calculation automatically respects the invisible boosts.
+                if (style == CombatStyle.Accurate)
+                    combinedStats.rangeStrength += 3;
+                else if (style == CombatStyle.Longrange)
+                {
+                    combinedStats.meleeDef += 3;
+                    combinedStats.rangeDef += 3;
+                    combinedStats.magicDef += 3;
+                }
+            }
+
             return new CombatantStats
             {
                 AttackLevel = skills != null ? skills.GetLevel(SkillType.Attack) : 1,
@@ -29,7 +47,7 @@ namespace Combat
                 DefenceLevel = skills != null ? skills.GetLevel(SkillType.Defence) : 1,
                 RangedLevel = skills != null ? skills.GetLevel(SkillType.Ranged) : 1,
                 MagicLevel = skills != null ? skills.GetLevel(SkillType.Magic) : 1,
-                Equip = equip != null ? equip.GetCombinedStats() : default,
+                Equip = combinedStats,
                 Style = style,
                 DamageType = type
             };

--- a/Assets/Scripts/Player/PlayerCombatLoadout.cs
+++ b/Assets/Scripts/Player/PlayerCombatLoadout.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using UnityEngine;
 using Combat;
 using EquipmentSystem;
@@ -18,6 +20,29 @@ namespace Player
         [SerializeField] private DamageType damageType = DamageType.Melee;
         private const string SaveKey = "PlayerCombatStyle";
 
+        private static readonly CombatStyle[] MeleeStyles =
+        {
+            CombatStyle.Accurate,
+            CombatStyle.Aggressive,
+            CombatStyle.Defensive,
+            CombatStyle.Controlled
+        };
+
+        private static readonly CombatStyle[] RangedStyles =
+        {
+            CombatStyle.Accurate,
+            CombatStyle.Rapid,
+            CombatStyle.Longrange
+        };
+
+        private static readonly CombatStyle[] MagicStyles = { CombatStyle.Accurate };
+
+        /// <summary>Raised whenever the combat style changes.</summary>
+        public event Action<CombatStyle> StyleChanged;
+
+        /// <summary>Raised whenever the active damage type changes.</summary>
+        public event Action<DamageType> DamageTypeChanged;
+
         private EquipmentAggregator equipmentAggregator;
         private Equipment equipment;
         private SkillManager skills;
@@ -28,10 +53,10 @@ namespace Player
             get => style;
             set
             {
-                if (style == value)
-                    return;
-                style = value;
-                Save();
+                var available = GetAvailableStylesInternal();
+                if (Array.IndexOf(available, value) < 0 && available.Length > 0)
+                    value = available[0];
+                SetStyleInternal(value, true);
             }
         }
 
@@ -61,10 +86,18 @@ namespace Player
                 CycleStyle();
         }
 
-        /// <summary>Cycle combat style in order Accurate → Aggressive → Defensive → Controlled.</summary>
+        /// <summary>Cycle combat style in the order defined for the current weapon.</summary>
         public void CycleStyle()
         {
-            Style = (CombatStyle)(((int)style + 1) % 4);
+            var styles = GetAvailableStylesInternal();
+            if (styles.Length == 0)
+                return;
+            int index = Array.IndexOf(styles, style);
+            if (index < 0)
+                index = 0;
+            else
+                index = (index + 1) % styles.Length;
+            Style = styles[index];
         }
 
         /// <summary>Get a snapshot of combat stats for the player.</summary>
@@ -76,7 +109,7 @@ namespace Player
         /// <summary>Set the current damage type.</summary>
         public void SetDamageType(DamageType type)
         {
-            damageType = type;
+            UpdateDamageType(type);
         }
 
         public void Save()
@@ -87,6 +120,58 @@ namespace Player
         public void Load()
         {
             style = SaveManager.Load<CombatStyle>(SaveKey);
+            EnsureStyleValidForCurrentWeapon(false);
+        }
+
+        /// <summary>Return the combat styles available for the current damage type.</summary>
+        public IReadOnlyList<CombatStyle> GetAvailableStyles()
+        {
+            return GetAvailableStylesInternal();
+        }
+
+        /// <summary>Check whether the provided style is valid for the current weapon category.</summary>
+        public bool IsStyleAvailable(CombatStyle candidate)
+        {
+            return Array.IndexOf(GetAvailableStylesInternal(), candidate) >= 0;
+        }
+
+        private CombatStyle[] GetAvailableStylesInternal()
+        {
+            return damageType switch
+            {
+                DamageType.Ranged => RangedStyles,
+                DamageType.Magic => MagicStyles,
+                _ => MeleeStyles
+            };
+        }
+
+        private void SetStyleInternal(CombatStyle newStyle, bool shouldSave)
+        {
+            if (style == newStyle)
+                return;
+            style = newStyle;
+            if (shouldSave)
+                Save();
+            StyleChanged?.Invoke(style);
+        }
+
+        private void EnsureStyleValidForCurrentWeapon(bool persist = true)
+        {
+            var styles = GetAvailableStylesInternal();
+            if (styles.Length == 0)
+                return;
+            if (Array.IndexOf(styles, style) >= 0)
+                return;
+            SetStyleInternal(styles[0], persist);
+        }
+
+        private void UpdateDamageType(DamageType newType)
+        {
+            if (damageType == newType)
+                return;
+            damageType = newType;
+            EnsureStyleValidForCurrentWeapon();
+            DamageTypeChanged?.Invoke(damageType);
         }
 
         private void HandleEquipmentChanged(EquipmentSlot slot)
@@ -111,27 +196,26 @@ namespace Player
                 Destroy(poisonApplier);
             }
 
+            DamageType newType = DamageType.Melee;
             if (weapon != null)
             {
                 if (weapon.combat.Magic > 0)
-                {
-                    damageType = DamageType.Magic;
-                    if (MagicUI.ActiveSpell == null)
-                        MagicUI.RestoreLastSpell();
-                }
+                    newType = DamageType.Magic;
                 else if (weapon.combat.Range > 0 || weapon.combat.RangeStrength > 0)
-                    damageType = DamageType.Ranged;
-                else
-                {
-                    damageType = DamageType.Melee;
-                    MagicUI.ClearActiveSpell();
-                }
+                    newType = DamageType.Ranged;
             }
-            else
+
+            if (newType == DamageType.Magic)
             {
-                damageType = DamageType.Melee;
+                if (MagicUI.ActiveSpell == null)
+                    MagicUI.RestoreLastSpell();
+            }
+            else if (newType == DamageType.Melee)
+            {
                 MagicUI.ClearActiveSpell();
             }
+
+            UpdateDamageType(newType);
         }
     }
 }

--- a/Assets/Scripts/UI/AttackStyleUI.cs
+++ b/Assets/Scripts/UI/AttackStyleUI.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 using Combat;
@@ -15,10 +16,26 @@ namespace UI
 
         private GameObject uiRoot;
         private PlayerCombatLoadout loadout;
-        private Button accurateButton;
-        private Button aggressiveButton;
-        private Button defensiveButton;
-        private Button controlledButton;
+        private Transform buttonContainer;
+        private readonly Dictionary<CombatStyle, Button> styleButtons = new();
+
+        private static readonly CombatStyle[] DefaultMeleeStyles =
+        {
+            CombatStyle.Accurate,
+            CombatStyle.Aggressive,
+            CombatStyle.Defensive,
+            CombatStyle.Controlled
+        };
+
+        private static readonly Dictionary<CombatStyle, string> StyleSpriteMap = new()
+        {
+            { CombatStyle.Accurate, "Accurate" },
+            { CombatStyle.Aggressive, "Aggressive" },
+            { CombatStyle.Defensive, "Defensive" },
+            { CombatStyle.Controlled, "Controlled" },
+            { CombatStyle.Rapid, "Rapid" },
+            { CombatStyle.Longrange, "Longrange" }
+        };
 
         /// <summary>Whether the interface is currently visible.</summary>
         public bool IsOpen => uiRoot != null && uiRoot.activeSelf;
@@ -43,8 +60,13 @@ namespace UI
 
             loadout = FindObjectOfType<PlayerCombatLoadout>();
             CreateUI();
+            EnsureLoadoutBound();
             if (uiRoot != null)
+            {
                 uiRoot.SetActive(false);
+                RefreshStyleButtons();
+                UpdateSelection();
+            }
             if (UIManager.Instance != null)
                 UIManager.Instance.RegisterWindow(this);
         }
@@ -54,6 +76,11 @@ namespace UI
             if (!PersistentSceneSingleton<AttackStyleUI>.HandleOnDestroy(this))
                 return;
 
+            if (loadout != null)
+            {
+                loadout.StyleChanged -= HandleLoadoutStyleChanged;
+                loadout.DamageTypeChanged -= HandleLoadoutDamageTypeChanged;
+            }
             if (UIManager.Instance != null)
                 UIManager.Instance.UnregisterWindow(this);
         }
@@ -85,17 +112,17 @@ namespace UI
             layout.childForceExpandHeight = false;
             layout.childForceExpandWidth = false;
 
-            accurateButton = CreateStyleButton(panel.transform, "Accurate", CombatStyle.Accurate);
-            aggressiveButton = CreateStyleButton(panel.transform, "Aggressive", CombatStyle.Aggressive);
-            defensiveButton = CreateStyleButton(panel.transform, "Defensive", CombatStyle.Defensive);
-            controlledButton = CreateStyleButton(panel.transform, "Controlled", CombatStyle.Controlled);
-
-            UpdateSelection();
+            buttonContainer = panel.transform;
         }
 
-        private Button CreateStyleButton(Transform parent, string spriteName, CombatStyle style)
+        private Button CreateStyleButton(Transform parent, CombatStyle style)
         {
+            if (!StyleSpriteMap.TryGetValue(style, out string spriteName))
+                return null;
+
             var sprite = Resources.Load<Sprite>("Interfaces/AttackStyle/" + spriteName);
+            if (sprite == null)
+                Debug.LogWarning($"AttackStyleUI: Missing sprite for style {style} ({spriteName}).");
             var go = new GameObject(spriteName, typeof(Image), typeof(Button));
             go.transform.SetParent(parent, false);
             var img = go.GetComponent<Image>();
@@ -105,8 +132,67 @@ namespace UI
             rect.sizeDelta = new Vector2(30f, 30f);
             rect.localScale = new Vector3(2f, 1f, 1f);
             var btn = go.GetComponent<Button>();
-            btn.onClick.AddListener(() => SetStyle(style));
             return btn;
+        }
+
+        /// <summary>Rebuild the style buttons using the current loadout configuration.</summary>
+        private void RefreshStyleButtons()
+        {
+            if (buttonContainer == null)
+                return;
+
+            EnsureLoadoutBound();
+
+            var toDestroy = new List<GameObject>();
+            foreach (Transform child in buttonContainer)
+                toDestroy.Add(child.gameObject);
+            foreach (var child in toDestroy)
+                Destroy(child);
+
+            styleButtons.Clear();
+
+            foreach (var style in GetAvailableStyles())
+            {
+                var button = CreateStyleButton(buttonContainer, style);
+                if (button == null)
+                    continue;
+                var capturedStyle = style;
+                button.onClick.AddListener(() => SetStyle(capturedStyle));
+                styleButtons[capturedStyle] = button;
+            }
+
+            if (buttonContainer is RectTransform rectTransform)
+                LayoutRebuilder.ForceRebuildLayoutImmediate(rectTransform);
+        }
+
+        /// <summary>Retrieve the attack styles that should be exposed in the UI.</summary>
+        private IReadOnlyList<CombatStyle> GetAvailableStyles()
+        {
+            return loadout != null ? loadout.GetAvailableStyles() : DefaultMeleeStyles;
+        }
+
+        /// <summary>Find and subscribe to the player's combat loadout component if needed.</summary>
+        private bool EnsureLoadoutBound()
+        {
+            if (loadout != null)
+                return false;
+            loadout = FindObjectOfType<PlayerCombatLoadout>();
+            if (loadout == null)
+                return false;
+            loadout.StyleChanged += HandleLoadoutStyleChanged;
+            loadout.DamageTypeChanged += HandleLoadoutDamageTypeChanged;
+            return true;
+        }
+
+        private void HandleLoadoutStyleChanged(CombatStyle _)
+        {
+            UpdateSelection();
+        }
+
+        private void HandleLoadoutDamageTypeChanged(DamageType _)
+        {
+            RefreshStyleButtons();
+            UpdateSelection();
         }
 
         /// <summary>Toggle the visibility of the UI.</summary>
@@ -125,6 +211,7 @@ namespace UI
             if (uiRoot != null)
             {
                 uiRoot.SetActive(true);
+                RefreshStyleButtons();
                 UpdateSelection();
             }
         }
@@ -138,23 +225,22 @@ namespace UI
 
         private void SetStyle(CombatStyle style)
         {
-            if (loadout == null)
-                loadout = FindObjectOfType<PlayerCombatLoadout>();
-            if (loadout != null)
-                loadout.Style = style;
+            EnsureLoadoutBound();
+            if (loadout == null || !loadout.IsStyleAvailable(style))
+                return;
+            loadout.Style = style;
             UpdateSelection();
         }
 
         private void UpdateSelection()
         {
-            if (loadout == null)
-                loadout = FindObjectOfType<PlayerCombatLoadout>();
+            bool boundNow = EnsureLoadoutBound();
+            if (boundNow)
+                RefreshStyleButtons();
             if (loadout == null)
                 return;
-            Highlight(accurateButton, loadout.Style == CombatStyle.Accurate);
-            Highlight(aggressiveButton, loadout.Style == CombatStyle.Aggressive);
-            Highlight(defensiveButton, loadout.Style == CombatStyle.Defensive);
-            Highlight(controlledButton, loadout.Style == CombatStyle.Controlled);
+            foreach (var pair in styleButtons)
+                Highlight(pair.Value, loadout.Style == pair.Key);
         }
 
         private void Highlight(Button btn, bool selected)

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,6 +1,15 @@
 # Session Log
 This file is auto-updated by CI on every push. Times shown are Europe/London.
 
+<!-- commit:b4641b85c130936922f6d6cb2e40fb9f7f2e20f8 -->
+## 2025-10-08T16:21:22+01:00 — Update attack styles for ranged weapons
+
+- Author: aicovergod <lewisshuffle136@gmail.com>
+- Changed files (6): Assets/Scripts/Combat/CombatController.cs, Assets/Scripts/Combat/CombatEnums.cs, Assets/Scripts/Combat/CombatMath.cs, Assets/Scripts/Combat/CombatantStats.cs, Assets/Scripts/Player/PlayerCombatLoadout.cs, Assets/Scripts/UI/AttackStyleUI.cs
+- Diff: 236 ++ / 44 --
+- Notes:
+  —
+---
 <!-- commit:386f28dc04f6e9d5ce6b814c27b3a7f3f5bf3352 -->
 ## 2025-10-08T16:05:34+01:00 — Merge branch 'main' of https://github.com/aicovergod/My-project
 


### PR DESCRIPTION
## Summary
- add Rapid and Longrange combat styles with appropriate ranged bonuses
- rebuild the attack style UI dynamically so ranged weapons show Accurate, Rapid, and Longrange
- extend the player combat loadout to expose style/damage type changes for the UI and enforce valid selections

## Testing
- dotnet test *(fails: no project or solution found in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e67dde0e50832e91027f149b1d4dc5