### PR TITLE
Adjust ranged style bonuses

### DIFF
--- a/Assets/Scripts/Combat/CombatController.cs
+++ b/Assets/Scripts/Combat/CombatController.cs
@@ -525,6 +525,7 @@ namespace Combat
                 DamageType.Ranged => CombatMath.GetEffectiveRanged(attacker.RangedLevel, attacker.Style),
                 _ => CombatMath.GetEffectiveAttack(attacker.AttackLevel, attacker.Style)
             };
+            // Longrange now contributes a +3 defensive boost here instead of modifying equipment stats.
             int defEff = CombatMath.GetEffectiveDefence(defender.DefenceLevel, defender.Style);
             // Mirror OSRS combat by selecting the correct offensive bonus based on the damage type.
             // Melee continues to rely on the weapon's attack rating, magic uses spell accuracy, and

--- a/Assets/Scripts/Combat/CombatMath.cs
+++ b/Assets/Scripts/Combat/CombatMath.cs
@@ -42,11 +42,30 @@ namespace Combat
         }
 
         /// <summary>
-        /// Mirrors the OSRS ranged effective level calculation. Accurate adds +3, defensive styles grant
-        /// +1 and rapid-style shots (represented by <see cref="CombatStyle.Aggressive"/>) provide no
-        /// bonus. A constant 8 is applied to keep low level accuracy consistent with melee and magic.
+        /// Mirrors the OSRS ranged effective level calculation. Defensive styles grant +1 and rapid-style
+        /// shots (represented by <see cref="CombatStyle.Aggressive"/>) provide no bonus. A constant 8 is
+        /// applied to keep low level accuracy consistent with melee and magic. Accurate no longer adds a
+        /// hidden +3 here so it can exclusively influence ranged strength rolls.
         /// </summary>
         public static int GetEffectiveRanged(int level, CombatStyle style)
+        {
+            int bonus = style switch
+            {
+                CombatStyle.Defensive => 1,
+                CombatStyle.Controlled => 1,
+                CombatStyle.Longrange => 1,
+                _ => 0
+            };
+            return level + bonus + 8;
+        }
+
+        /// <summary>
+        /// Effective strength when rolling ranged max hits. Accurate grants +3, defensive and controlled
+        /// styles grant +1, while Longrange maintains its +1 damage bonus even though the style now focuses
+        /// on defence within <see cref="GetEffectiveDefence"/>. A constant 8 is applied for parity with the
+        /// wider OSRS formulas.
+        /// </summary>
+        public static int GetEffectiveRangedStrength(int level, CombatStyle style)
         {
             int bonus = style switch
             {
@@ -59,21 +78,13 @@ namespace Combat
             return level + bonus + 8;
         }
 
-        /// <summary>
-        /// Effective strength when rolling ranged max hits. OSRS uses the same bonuses as accuracy,
-        /// so the helper simply mirrors <see cref="GetEffectiveRanged"/> while keeping the intent clear.
-        /// </summary>
-        public static int GetEffectiveRangedStrength(int level, CombatStyle style)
-        {
-            return GetEffectiveRanged(level, style);
-        }
-
         public static int GetEffectiveDefence(int level, CombatStyle style)
         {
             int bonus = style switch
             {
                 CombatStyle.Defensive => 3,
                 CombatStyle.Controlled => 1,
+                CombatStyle.Longrange => 3,
                 _ => 0
             };
             // Defence also needs the constant 8 for parity with OSRS calculations.

--- a/Assets/Scripts/Combat/Ranged/RangedCombatController.cs
+++ b/Assets/Scripts/Combat/Ranged/RangedCombatController.cs
@@ -232,6 +232,8 @@ namespace Combat.Ranged
             var defender = combatController.GetDefenderStats(target, attacker);
             attacker.DamageType = DamageType.Ranged;
 
+            // Accurate should only increase ranged strength now, so this call intentionally omits the
+            // previous +3 accuracy boost when Accurate is selected.
             int effectiveAttack = CombatMath.GetEffectiveRanged(attacker.RangedLevel, attacker.Style);
             int attackBonus = Mathf.RoundToInt(attacker.Equip.range * accuracyMultiplier);
             int attackRoll = CombatMath.GetAttackRoll(effectiveAttack, attackBonus);
@@ -242,6 +244,8 @@ namespace Combat.Ranged
             float chanceToHit = CombatMath.ChanceToHit(attackRoll, defenceRoll);
             bool hit = UnityEngine.Random.value < chanceToHit;
 
+            // Ranged strength retains the Accurate +3 bonus, ensuring the style still rewards damage
+            // rolls without influencing the hit chance traced above.
             int effectiveStrength = CombatMath.GetEffectiveRangedStrength(attacker.RangedLevel, attacker.Style);
             int strengthBonus = Mathf.Max(0, attacker.Equip.rangeStrength);
             int maxHit = CombatMath.GetMaxHit(effectiveStrength, strengthBonus);

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1,6 +1,15 @@
 # Session Log
 This file is auto-updated by CI on every push. Times shown are Europe/London.
 
+<!-- commit:8df70ff20bfbf982eb33334f4adb144648fc5576 -->
+## 2025-10-08T16:41:20+01:00 — Adjust ranged style bonuses
+
+- Author: aicovergod <lewisshuffle136@gmail.com>
+- Changed files (3): Assets/Scripts/Combat/CombatController.cs, Assets/Scripts/Combat/CombatMath.cs, Assets/Scripts/Combat/Ranged/RangedCombatController.cs
+- Diff: 23 ++ / 7 --
+- Notes:
+  —
+---
 <!-- commit:b4641b85c130936922f6d6cb2e40fb9f7f2e20f8 -->
 ## 2025-10-08T16:21:22+01:00 — Update attack styles for ranged weapons
 


### PR DESCRIPTION
## Summary
- update combat math so Accurate no longer boosts ranged accuracy while retaining its +3 strength bonus
- give ranged strength its own style switch and extend Longrange to provide +3 effective defence
- document the effective stat traces in ranged and core combat controllers so behaviour is clear

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6856225c4832e9291694f6dbb97a4